### PR TITLE
fix(audit-erp): corregir errores críticos de DB, temas, iconos y RRHH

### DIFF
--- a/pos_spj_v13.4/core/db/connection.py
+++ b/pos_spj_v13.4/core/db/connection.py
@@ -92,10 +92,10 @@ def _new_connection(path: str) -> sqlite3.Connection:
 # OBTENER CONEXIÓN
 # ─────────────────────────────────────────────────────────────
 
-def get_connection(path: Optional[str] = None) -> sqlite3.Connection:
+def get_connection(path: Optional[str] = None) -> "DatabaseWrapper":
     """
-    Devuelve la conexión thread-local.
-    Crea una nueva si no existe.
+    Devuelve la conexión thread-local envuelta en DatabaseWrapper.
+    Crea una nueva si no existe o si está muerta.
     """
 
     db_path = path or _DB_PATH
@@ -103,25 +103,31 @@ def get_connection(path: Optional[str] = None) -> sqlite3.Connection:
     conn = getattr(_tls, "conn", None)
 
     if conn is not None:
+        # Unwrap si ya es DatabaseWrapper para hacer el ping
+        raw = conn._conn if isinstance(conn, DatabaseWrapper) else conn
         try:
-            conn.execute("SELECT 1")
-            return conn
+            raw.execute("SELECT 1")
+            # Asegurar que siempre retornamos DatabaseWrapper
+            if isinstance(conn, DatabaseWrapper):
+                return conn
+            wrapped = DatabaseWrapper(conn)
+            _tls.conn = wrapped
+            return wrapped
         except Exception:
             logger.warning(
                 "Conexión muerta en hilo %s — reconectando",
                 threading.current_thread().name
             )
             try:
-                conn.close()
+                raw.close()
             except Exception:
                 pass
-
             _tls.conn = None
 
-    conn = _new_connection(db_path)
-    _tls.conn = conn
-
-    return conn
+    raw_conn = _new_connection(db_path)
+    wrapped = DatabaseWrapper(raw_conn)
+    _tls.conn = wrapped
+    return wrapped
 
 
 # ─────────────────────────────────────────────────────────────
@@ -216,6 +222,97 @@ def transaction(conn: sqlite3.Connection):
 
 
 # ─────────────────────────────────────────────────────────────
+# DATABASE WRAPPER — añade fetchall / fetchone / transaction
+# a sqlite3.Connection para compatibilidad con repositorios.
+# ─────────────────────────────────────────────────────────────
+
+class DatabaseWrapper:
+    """
+    Envuelve sqlite3.Connection y expone la API extendida que usan
+    los repositorios del ERP (fetchall, fetchone, transaction).
+
+    Se usa automáticamente en get_connection() para que TODO el
+    código que obtiene una conexión reciba esta interfaz unificada.
+    """
+
+    __slots__ = ("_conn",)
+
+    def __init__(self, conn: sqlite3.Connection):
+        object.__setattr__(self, "_conn", conn)
+
+    # ── API extendida ─────────────────────────────────────────
+
+    def fetchall(self, sql: str, params=()) -> list:
+        """Ejecuta sql y retorna todas las filas."""
+        return self._conn.execute(sql, params).fetchall()
+
+    def fetchone(self, sql: str, params=()) -> Optional[sqlite3.Row]:
+        """Ejecuta sql y retorna la primera fila o None."""
+        return self._conn.execute(sql, params).fetchone()
+
+    def transaction(self, name: str = ""):
+        """Context manager de transacción con SAVEPOINT."""
+        return transaction(self._conn)
+
+    # ── Delegación total a sqlite3.Connection ────────────────
+
+    def execute(self, sql: str, params=()):
+        return self._conn.execute(sql, params)
+
+    def executemany(self, sql: str, params):
+        return self._conn.executemany(sql, params)
+
+    def executescript(self, sql: str):
+        return self._conn.executescript(sql)
+
+    def commit(self):
+        return self._conn.commit()
+
+    def rollback(self):
+        return self._conn.rollback()
+
+    def close(self):
+        return self._conn.close()
+
+    def cursor(self):
+        return self._conn.cursor()
+
+    @property
+    def row_factory(self):
+        return self._conn.row_factory
+
+    @row_factory.setter
+    def row_factory(self, value):
+        self._conn.row_factory = value
+
+    @property
+    def in_transaction(self):
+        return self._conn.in_transaction
+
+    def __getattr__(self, name: str):
+        return getattr(self._conn, name)
+
+    def __setattr__(self, name: str, value):
+        if name == "_conn":
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._conn, name, value)
+
+    def __enter__(self):
+        return self._conn.__enter__()
+
+    def __exit__(self, *args):
+        return self._conn.__exit__(*args)
+
+
+def wrap(conn) -> "DatabaseWrapper":
+    """Envuelve una conexión si todavía no es DatabaseWrapper."""
+    if isinstance(conn, DatabaseWrapper):
+        return conn
+    return DatabaseWrapper(conn)
+
+
+# ─────────────────────────────────────────────────────────────
 # SHIMS DE COMPATIBILIDAD
 # ─────────────────────────────────────────────────────────────
 
@@ -266,7 +363,7 @@ class Database:
 
 
 # Alias legacy
-def get_db(path: str = None) -> sqlite3.Connection:
+def get_db(path: str = None) -> "DatabaseWrapper":
     return get_connection(path)
 
 
@@ -282,6 +379,8 @@ __all__ = [
     "close_thread_connection",
     "execute_with_retry",
     "transaction",
+    "DatabaseWrapper",
+    "wrap",
     "Connection",
     "Database",
     "get_db",

--- a/pos_spj_v13.4/core/forecast/demand_forecast_engine.py
+++ b/pos_spj_v13.4/core/forecast/demand_forecast_engine.py
@@ -46,7 +46,8 @@ class DemandForecastEngine:
     """
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
 
     # ── Config ─────────────────────────────────────────────────────────────────
 

--- a/pos_spj_v13.4/core/forecast/replenishment_engine.py
+++ b/pos_spj_v13.4/core/forecast/replenishment_engine.py
@@ -47,7 +47,8 @@ class ReplenishmentEngine:
     """
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
         self._forecast_eng = DemandForecastEngine(db)
 
     # ── Helpers ─────────────────────────────────────────────────────────────────

--- a/pos_spj_v13.4/core/production/production_engine.py
+++ b/pos_spj_v13.4/core/production/production_engine.py
@@ -126,7 +126,8 @@ class ProductionEngine:
     """
 
     def __init__(self, db, branch_id: int):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
         self.branch_id = branch_id
 
     def _now(self) -> str:

--- a/pos_spj_v13.4/core/services/enterprise/demand_forecasting.py
+++ b/pos_spj_v13.4/core/services/enterprise/demand_forecasting.py
@@ -77,7 +77,8 @@ DIAS = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado", "Doming
 class DemandForecastingEngine:
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
         self._bus = None
         try:
             from core.events.event_bus import get_bus

--- a/pos_spj_v13.4/core/services/enterprise/finance_service.py
+++ b/pos_spj_v13.4/core/services/enterprise/finance_service.py
@@ -61,11 +61,10 @@ class FinanceService:
 
     def __init__(self, db):
         """
-        db: objeto con métodos fetchone(sql,params), fetchall(sql,params),
-            execute(sql,params), conn (sqlite3.Connection).
-        Compatible con el helper DB del sistema SPJ.
+        db: sqlite3.Connection o DatabaseWrapper — se envuelve automáticamente.
         """
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
 
     # ═════════════════════════════════════════════════════════════════════════
     # DASHBOARD KPIs

--- a/pos_spj_v13.4/core/services/enterprise/report_engine.py
+++ b/pos_spj_v13.4/core/services/enterprise/report_engine.py
@@ -19,7 +19,8 @@ logger = logging.getLogger("spj.enterprise.reports")
 class ReportEngine:
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
 
     def _now(self) -> str:
         return datetime.utcnow().isoformat()

--- a/pos_spj_v13.4/core/services/enterprise/report_engine_v2.py
+++ b/pos_spj_v13.4/core/services/enterprise/report_engine_v2.py
@@ -28,7 +28,8 @@ logger = logging.getLogger("spj.report_engine_v2")
 class ReportEngineV2:
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
         self._forecast = DemandForecastingEngine(db)
 
     def _now(self) -> str:

--- a/pos_spj_v13.4/core/services/integrity_engine.py
+++ b/pos_spj_v13.4/core/services/integrity_engine.py
@@ -10,7 +10,8 @@ DEFAULT_MAX_DEPTH = 50
 class IntegrityEngine:
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
 
     def _now(self):
         return datetime.utcnow().isoformat()

--- a/pos_spj_v13.4/core/services/recipe_engine.py
+++ b/pos_spj_v13.4/core/services/recipe_engine.py
@@ -70,7 +70,8 @@ class ProduccionResultDTO:
 class RecipeEngine:
 
     def __init__(self, db, branch_id: int):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
         self.branch_id = branch_id
 
     def ejecutar_produccion(

--- a/pos_spj_v13.4/core/services/sales_reversal_service.py
+++ b/pos_spj_v13.4/core/services/sales_reversal_service.py
@@ -128,10 +128,11 @@ class SalesReversalService:
 
     def __init__(self, db, branch_id: int):
         """
-        db        — instancia de core.database.Database
+        db        — sqlite3.Connection o DatabaseWrapper
         branch_id — sucursal activa
         """
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
         self.branch_id = branch_id
 
     # ── Helpers internos ─────────────────────────────────────────────────────

--- a/pos_spj_v13.4/main.py
+++ b/pos_spj_v13.4/main.py
@@ -112,6 +112,14 @@ def inicializar_sistema():
     app.setApplicationName(__app_name__)
     app.setApplicationVersion(__version__)
 
+    # ── Aplicar tema guardado ANTES de mostrar cualquier ventana ─────────────
+    try:
+        from ui.themes.theme_engine import load_saved_theme
+        load_saved_theme(None)   # None → aplica solo a QApplication
+        logger.info("✅ Tema aplicado al arranque")
+    except Exception as _te:
+        logger.warning("Tema no aplicado al arranque: %s", _te)
+
     if not _instancia_unica(app):
         QMessageBox.information(None, "Ya está ejecutándose",
             "SPJ POS ya está abierto en esta computadora.")

--- a/pos_spj_v13.4/modulos/activos.py
+++ b/pos_spj_v13.4/modulos/activos.py
@@ -300,6 +300,14 @@ def calcular_depreciacion_mensual(db, sucursal_id: int = 1) -> list:
     logger = logging.getLogger("spj.activos.depreciacion")
     resultados = []
     try:
+        # Asegurar que la columna valor_residual existe (puede faltar en DBs antiguas)
+        try:
+            db.execute("ALTER TABLE activos ADD COLUMN valor_residual REAL DEFAULT 0")
+            try: db.commit()
+            except Exception: pass
+        except Exception:
+            pass  # La columna ya existe o la tabla no existe aún
+
         activos = db.execute("""
             SELECT id, nombre, valor_actual, depreciacion_anual, vida_util_anios,
                    COALESCE(valor_residual, 0) as valor_residual

--- a/pos_spj_v13.4/modulos/base.py
+++ b/pos_spj_v13.4/modulos/base.py
@@ -55,26 +55,29 @@ class ModuloBase(QWidget):
         
         # Si no existe el archivo, usar iconos del sistema como fallback
         iconos_sistema = {
-            "search.png": QStyle.SP_FileDialogContentsView,
-            "filter.png": QStyle.SP_FileDialogDetailedView,
-            "add.png": QStyle.SP_FileDialogNewFolder,
-            "edit.png": QStyle.SP_FileDialogContentsView,
-            "delete.png": QStyle.SP_TrashIcon,
-            "payment.png": QStyle.SP_DialogApplyButton,
-            "refresh.png": QStyle.SP_BrowserReload,
-            "list.png": QStyle.SP_FileDialogListView,
+            "search.png":   QStyle.SP_FileDialogContentsView,
+            "filter.png":   QStyle.SP_FileDialogDetailedView,
+            "add.png":      QStyle.SP_FileDialogNewFolder,
+            "edit.png":     QStyle.SP_FileDialogContentsView,
+            "delete.png":   QStyle.SP_TrashIcon,
+            "history.png":  QStyle.SP_FileDialogDetailedView,
+            "card.png":     QStyle.SP_FileDialogInfoView,
+            "payment.png":  QStyle.SP_DialogApplyButton,
+            "refresh.png":  QStyle.SP_BrowserReload,
+            "list.png":     QStyle.SP_FileDialogListView,
             "transfer.png": QStyle.SP_FileDialogBack,
-            "save.png": QStyle.SP_DialogSaveButton,
-            "cancel.png": QStyle.SP_DialogCancelButton,
-            "print.png": QStyle.SP_ComputerIcon,
-            "config.png": QStyle.SP_ComputerIcon
+            "save.png":     QStyle.SP_DialogSaveButton,
+            "cancel.png":   QStyle.SP_DialogCancelButton,
+            "print.png":    QStyle.SP_ComputerIcon,
+            "config.png":   QStyle.SP_ComputerIcon,
+            "security.png": QStyle.SP_MessageBoxWarning,
         }
-        
+
         if nombre_icono in iconos_sistema:
             return self.style().standardIcon(iconos_sistema[nombre_icono])
-        
-        # Icono por defecto si no se encuentra ninguno
-        logger.warning(f"Advertencia: Icono '{nombre_icono}' no encontrado, usando icono por defecto")
+
+        # Icono vacío sin ruido en el log
+        logger.debug("Icono '%s' no encontrado, usando QIcon vacío", nombre_icono)
         return QIcon()
 
     def mostrar_mensaje(self, titulo: str, mensaje: str, 

--- a/pos_spj_v13.4/modulos/rrhh.py
+++ b/pos_spj_v13.4/modulos/rrhh.py
@@ -251,6 +251,10 @@ class ModuloRRHH(QWidget):
         self.tab_roles_turno = QWidget()
         self.tabs_rrhh.addTab(self.tab_roles_turno, "🗓️ Turnos de Trabajo")
 
+        # ── Tab Reglas Laborales (HRRuleEngine) ──────────────────────────
+        self.tab_reglas = QWidget()
+        self.tabs_rrhh.addTab(self.tab_reglas, "⚖️ Reglas Laborales")
+
         self.tabs_rrhh.currentChanged.connect(self._on_rrhh_tab_change)
         lay.addWidget(self.tabs_rrhh)
 
@@ -261,6 +265,7 @@ class ModuloRRHH(QWidget):
         self.setup_tab_evaluaciones()
         self.setup_tab_puestos()
         self._setup_tab_turnos_completo()
+        self.setup_tab_reglas_laborales()
         return dashboard
 
     def setup_tab_roles_turno(self):
@@ -1272,3 +1277,268 @@ class ModuloRRHH(QWidget):
         except Exception as e:
         # [spj-dedup removed local QMessageBox import]
             QMessageBox.critical(self, "Error", str(e))
+
+    # =========================================================
+    # TAB: REGLAS LABORALES (HRRuleEngine)
+    # =========================================================
+
+    def setup_tab_reglas_laborales(self):
+        """
+        UI para configurar y auditar las reglas laborales del HRRuleEngine.
+        Muestra: días consecutivos, descansos, cobertura mínima, horas extra.
+        """
+        from PyQt5.QtWidgets import (
+            QVBoxLayout, QHBoxLayout, QGroupBox, QFormLayout,
+            QSpinBox, QLabel, QPushButton, QTextEdit, QScrollArea,
+            QWidget, QFrame, QSizePolicy
+        )
+        from PyQt5.QtCore import Qt
+
+        lay = QVBoxLayout(self.tab_reglas)
+        lay.setContentsMargins(12, 12, 12, 12)
+        lay.setSpacing(10)
+
+        # ── Encabezado ────────────────────────────────────────────────────────
+        lbl_titulo = QLabel("⚖️ Reglas Laborales — NOM-035 / LFT México")
+        lbl_titulo.setStyleSheet(
+            "font-size:16px;font-weight:bold;color:#2c3e50;padding:4px 0;"
+        )
+        lay.addWidget(lbl_titulo)
+
+        lbl_desc = QLabel(
+            "Configura los parámetros de jornada y ejecuta auditorías "
+            "automáticas para detectar violaciones laborales en tiempo real."
+        )
+        lbl_desc.setWordWrap(True)
+        lbl_desc.setStyleSheet("color:#555;font-size:11px;margin-bottom:6px;")
+        lay.addWidget(lbl_desc)
+
+        # ── Parámetros configurables ──────────────────────────────────────────
+        grp_params = QGroupBox("Parámetros de jornada (Art. LFT)")
+        grp_params.setStyleSheet(
+            "QGroupBox{font-weight:bold;border:1px solid #bdc3c7;"
+            "border-radius:6px;margin-top:6px;padding-top:8px;}"
+            "QGroupBox::title{subcontrol-origin:margin;left:8px;}"
+        )
+        form = QFormLayout(grp_params)
+        form.setLabelAlignment(Qt.AlignRight)
+        form.setSpacing(8)
+
+        self._spin_max_dias = QSpinBox()
+        self._spin_max_dias.setRange(1, 7)
+        self._spin_max_dias.setValue(6)
+        self._spin_max_dias.setSuffix(" días")
+        self._spin_max_dias.setToolTip("Art. 69 LFT: máximo días consecutivos sin descanso")
+        form.addRow("Máx. días consecutivos:", self._spin_max_dias)
+
+        self._spin_horas_sem = QSpinBox()
+        self._spin_horas_sem.setRange(1, 72)
+        self._spin_horas_sem.setValue(48)
+        self._spin_horas_sem.setSuffix(" hrs/semana")
+        self._spin_horas_sem.setToolTip("Art. 61 LFT: jornada semanal máxima diurna")
+        form.addRow("Límite semanal de horas:", self._spin_horas_sem)
+
+        self._spin_cobertura = QSpinBox()
+        self._spin_cobertura.setRange(1, 20)
+        self._spin_cobertura.setValue(1)
+        self._spin_cobertura.setSuffix(" empleado(s)")
+        self._spin_cobertura.setToolTip("Empleados mínimos activos por turno/sucursal")
+        form.addRow("Cobertura mínima por turno:", self._spin_cobertura)
+
+        self._spin_periodo_pago = QSpinBox()
+        self._spin_periodo_pago.setRange(1, 30)
+        self._spin_periodo_pago.setValue(7)
+        self._spin_periodo_pago.setSuffix(" días")
+        self._spin_periodo_pago.setToolTip("Frecuencia de pago: 7=semanal, 14=quincenal, 30=mensual")
+        form.addRow("Periodo de nómina:", self._spin_periodo_pago)
+
+        lay.addWidget(grp_params)
+
+        # ── Botones de acción ─────────────────────────────────────────────────
+        row_btns = QHBoxLayout()
+
+        btn_guardar = QPushButton("💾 Guardar parámetros")
+        btn_guardar.setStyleSheet(
+            "background:#27ae60;color:white;font-weight:bold;"
+            "padding:8px 20px;border-radius:4px;"
+        )
+        btn_guardar.clicked.connect(self._guardar_reglas_laborales)
+
+        btn_auditar = QPushButton("🔍 Ejecutar auditoría ahora")
+        btn_auditar.setStyleSheet(
+            "background:#2980b9;color:white;font-weight:bold;"
+            "padding:8px 20px;border-radius:4px;"
+        )
+        btn_auditar.clicked.connect(self._ejecutar_auditoria_hr)
+
+        btn_nomina = QPushButton("💰 Verificar nóminas vencidas")
+        btn_nomina.setStyleSheet(
+            "background:#8e44ad;color:white;font-weight:bold;"
+            "padding:8px 20px;border-radius:4px;"
+        )
+        btn_nomina.clicked.connect(self._verificar_nomina_hr)
+
+        row_btns.addWidget(btn_guardar)
+        row_btns.addWidget(btn_auditar)
+        row_btns.addWidget(btn_nomina)
+        row_btns.addStretch()
+        lay.addLayout(row_btns)
+
+        # ── Panel de resultados ───────────────────────────────────────────────
+        grp_resultado = QGroupBox("Resultado de auditoría")
+        grp_resultado.setStyleSheet(
+            "QGroupBox{font-weight:bold;border:1px solid #bdc3c7;"
+            "border-radius:6px;margin-top:6px;padding-top:8px;}"
+            "QGroupBox::title{subcontrol-origin:margin;left:8px;}"
+        )
+        lay_res = QVBoxLayout(grp_resultado)
+
+        self._txt_resultado_hr = QTextEdit()
+        self._txt_resultado_hr.setReadOnly(True)
+        self._txt_resultado_hr.setMinimumHeight(200)
+        self._txt_resultado_hr.setStyleSheet(
+            "font-family:Consolas,monospace;font-size:12px;"
+            "background:#f8f9fa;border:none;"
+        )
+        self._txt_resultado_hr.setPlaceholderText(
+            "Presiona 'Ejecutar auditoría' para ver violaciones laborales, "
+            "descansos sugeridos y estado de cobertura..."
+        )
+        lay_res.addWidget(self._txt_resultado_hr)
+        lay.addWidget(grp_resultado)
+
+        # Cargar parámetros guardados al abrir
+        self._cargar_reglas_laborales()
+
+    def _cargar_reglas_laborales(self):
+        """Carga parámetros desde la BD (tabla configuraciones)."""
+        try:
+            db = self.container.db
+            def _cfg(k, d):
+                r = db.execute(
+                    "SELECT valor FROM configuraciones WHERE clave=?", (k,)
+                ).fetchone()
+                return r[0] if r else d
+            self._spin_max_dias.setValue(int(_cfg("hr_max_dias_consecutivos", 6)))
+            self._spin_horas_sem.setValue(int(_cfg("hr_max_horas_semana", 48)))
+            self._spin_cobertura.setValue(int(_cfg("hr_cobertura_minima", 1)))
+            self._spin_periodo_pago.setValue(int(_cfg("hr_periodo_pago_dias", 7)))
+        except Exception:
+            pass
+
+    def _guardar_reglas_laborales(self):
+        """Persiste los parámetros en la tabla configuraciones."""
+        try:
+            db = self.container.db
+            params = {
+                "hr_max_dias_consecutivos": self._spin_max_dias.value(),
+                "hr_max_horas_semana":      self._spin_horas_sem.value(),
+                "hr_cobertura_minima":      self._spin_cobertura.value(),
+                "hr_periodo_pago_dias":     self._spin_periodo_pago.value(),
+            }
+            for clave, valor in params.items():
+                db.execute(
+                    "INSERT OR REPLACE INTO configuraciones "
+                    "(clave, valor, descripcion) VALUES (?,?,?)",
+                    (clave, str(valor), "Regla laboral LFT")
+                )
+            try:
+                db.commit()
+            except Exception:
+                pass
+            QMessageBox.information(
+                self, "✅ Guardado",
+                "Parámetros de reglas laborales actualizados correctamente."
+            )
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"No se pudo guardar: {e}")
+
+    def _ejecutar_auditoria_hr(self):
+        """Llama a HRRuleEngine.auditar_sucursal() y muestra el resultado."""
+        try:
+            engine = getattr(self.container, "hr_rule_engine", None)
+            if engine is None:
+                from core.services.hr_rule_engine import HRRuleEngine
+                engine = HRRuleEngine(
+                    self.container.db,
+                    getattr(self.container, "module_config", None)
+                )
+            resultado = engine.auditar_sucursal(self.sucursal_id)
+            self._mostrar_resultado_auditoria(resultado)
+        except Exception as e:
+            self._txt_resultado_hr.setPlainText(f"❌ Error al auditar: {e}")
+
+    def _verificar_nomina_hr(self):
+        """Verifica nóminas vencidas o próximas a vencer."""
+        try:
+            engine = getattr(self.container, "hr_rule_engine", None)
+            if engine is None:
+                from core.services.hr_rule_engine import HRRuleEngine
+                engine = HRRuleEngine(
+                    self.container.db,
+                    getattr(self.container, "module_config", None)
+                )
+            alertas = engine.auditar_nomina_pendiente()
+            if not alertas:
+                self._txt_resultado_hr.setPlainText(
+                    "✅ Nóminas al día — ningún empleado con pago vencido."
+                )
+                return
+            lineas = ["⚠️ NÓMINAS PENDIENTES / VENCIDAS\n" + "─" * 50]
+            for a in alertas:
+                lineas.append(
+                    f"• {a.get('nombre','?')} — "
+                    f"Último pago: {a.get('ultimo_pago','N/A')} "
+                    f"({a.get('dias_vencido', '?')} días)"
+                )
+            self._txt_resultado_hr.setPlainText("\n".join(lineas))
+        except Exception as e:
+            self._txt_resultado_hr.setPlainText(f"❌ Error al verificar nómina: {e}")
+
+    def _mostrar_resultado_auditoria(self, resultado: dict):
+        """Formatea y muestra el resultado de auditoría en el QTextEdit."""
+        lineas = []
+        lineas.append("═" * 55)
+        lineas.append(f"  AUDITORÍA LABORAL — Sucursal {resultado.get('sucursal_id', '?')}")
+        lineas.append(f"  Fecha: {resultado.get('fecha', 'N/A')}")
+        lineas.append("═" * 55)
+        lineas.append(
+            f"  Empleados total : {resultado.get('empleados_total', 0)}"
+        )
+        lineas.append(
+            f"  Activos hoy     : {resultado.get('activos_hoy', 0)}"
+        )
+        cob = resultado.get("cobertura_ok", True)
+        lineas.append(
+            f"  Cobertura mín.  : {'✅ OK' if cob else '❌ INSUFICIENTE'}"
+        )
+        lineas.append("")
+
+        overwork = resultado.get("overwork", [])
+        if overwork:
+            lineas.append(f"⚠️  SOBRETIEMPO DETECTADO ({len(overwork)} empleado(s)):")
+            for ov in overwork:
+                lineas.append(
+                    f"   • {ov.get('nombre','?')} — "
+                    f"{ov.get('dias_consecutivos', 0)} días consecutivos "
+                    f"(máx. permitido: 6)"
+                )
+        else:
+            lineas.append("✅ Ningún empleado excede días consecutivos.")
+
+        lineas.append("")
+        descansos = resultado.get("descansos_sugeridos", [])
+        if descansos:
+            lineas.append(f"🗓️  DESCANSOS SUGERIDOS ({len(descansos)}):")
+            for d in descansos:
+                lineas.append(
+                    f"   • {d.get('nombre','?')} — "
+                    f"descanso sugerido: {d.get('fecha_descanso', 'N/A')}"
+                )
+        else:
+            lineas.append("✅ No se requieren descansos adicionales.")
+
+        lineas.append("")
+        lineas.append("─" * 55)
+        lineas.append("Auditoría completada. Revisa el log del sistema para más detalles.")
+        self._txt_resultado_hr.setPlainText("\n".join(lineas))

--- a/pos_spj_v13.4/modulos/spj_styles.py
+++ b/pos_spj_v13.4/modulos/spj_styles.py
@@ -188,21 +188,27 @@ def apply_theme_dialogs(dialog) -> None:
 
 def apply_global_theme(db_conn=None) -> None:
     """
-    v13.30: Solo Light/Dark. Lee 'tema' de BD → aplica QSS.
+    v13.4: Lee 'tema' de BD y aplica QSS a QApplication.
+    Primero intenta ThemeService; si falla, usa theme_engine.
     No modifica tamaño de iconos ni botones — solo colores.
     """
     from PyQt5.QtWidgets import QApplication
+    _log = __import__("logging").getLogger("spj.styles")
+
     tema = "Light"
     if db_conn:
         try:
             row = db_conn.execute(
                 "SELECT valor FROM configuraciones WHERE clave='tema'"
             ).fetchone()
-            if row and row[0] and 'dark' in str(row[0]).lower():
-                tema = "Dark"
+            if row and row[0]:
+                tema = str(row[0])
+                if 'dark' in tema.lower():
+                    tema = "Dark"
         except Exception:
             pass
 
+    # Intento 1: ThemeService (puede generar QSS richer)
     try:
         from core.services.theme_service import ThemeService
         ts = ThemeService(db_conn)
@@ -210,8 +216,15 @@ def apply_global_theme(db_conn=None) -> None:
                             font_size="12", icon_size="24")
         qss = ts.generate_qss()
         app = QApplication.instance()
-        if app:
+        if app and qss:
             app.setStyleSheet(qss)
+            return
     except Exception as e:
-        import logging
-        logging.getLogger("spj.styles").debug("apply_global_theme: %s", e)
+        _log.debug("ThemeService no disponible, usando theme_engine: %s", e)
+
+    # Intento 2: theme_engine (fuente de verdad config.TEMAS)
+    try:
+        from ui.themes.theme_engine import load_saved_theme
+        load_saved_theme(None)
+    except Exception as e:
+        _log.debug("apply_global_theme: %s", e)

--- a/pos_spj_v13.4/repositories/caja.py
+++ b/pos_spj_v13.4/repositories/caja.py
@@ -36,7 +36,8 @@ class CajaMontoInvalidoError(CajaError):
 class CajaRepository:
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
 
     def _now(self) -> str:
         return datetime.utcnow().isoformat()

--- a/pos_spj_v13.4/repositories/recetas.py
+++ b/pos_spj_v13.4/repositories/recetas.py
@@ -41,49 +41,12 @@ class RecetaDuplicadaError(RecetaError):
     pass
 
 
-class _SQLiteTransaction:
-    """Context manager for SQLite transactions."""
-    def __init__(self, conn):
-        self.conn = conn
-
-    def __enter__(self):
-        self.conn.execute("BEGIN")
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is None:
-            self.conn.commit()
-        else:
-            self.conn.rollback()
-
-
-class SQLiteConnectionWrapper:
-    """Wrapper for sqlite3.Connection that adds a transaction method."""
-    def __init__(self, conn: sqlite3.Connection):
-        self._conn = conn
-
-    def transaction(self, name=None):
-        """Return a transaction context manager."""
-        return _SQLiteTransaction(self._conn)
-
-    def execute(self, sql, parameters=None):
-        """Delegate execute to the underlying connection."""
-        if parameters is None:
-            return self._conn.execute(sql)
-        return self._conn.execute(sql, parameters)
-
-    def __getattr__(self, name):
-        """Delegate any other attribute to the underlying connection."""
-        return getattr(self._conn, name)
-
-
 class RecetaRepository:
 
     def __init__(self, db):
-        # Wrap db if it doesn't have a transaction method
-        if not hasattr(db, 'transaction'):
-            db = SQLiteConnectionWrapper(db)
-        self.db = db
+        # Usar DatabaseWrapper para garantizar fetchall/fetchone/transaction
+        from core.db.connection import wrap
+        self.db = wrap(db)
 
         # Detect all columns in product_recipes
         self._product_columns = self._get_table_columns('product_recipes')

--- a/pos_spj_v13.4/repositories/tarjetas.py
+++ b/pos_spj_v13.4/repositories/tarjetas.py
@@ -31,7 +31,8 @@ class TarjetaYaAsignadaError(TarjetaError):
 class TarjetaRepository:
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
 
     def _now(self) -> str:
         return datetime.utcnow().isoformat()

--- a/pos_spj_v13.4/repositories/transferencias.py
+++ b/pos_spj_v13.4/repositories/transferencias.py
@@ -42,7 +42,8 @@ class TransferOverReceptionError(TransferError):
 class TransferRepository:
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
 
     def _now(self) -> str:
         return datetime.utcnow().isoformat()

--- a/pos_spj_v13.4/repositories/ventas.py
+++ b/pos_spj_v13.4/repositories/ventas.py
@@ -34,7 +34,8 @@ class VentaDuplicadaError(VentaError):
 class VentaRepository:
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
 
     def _now(self) -> str:
         return datetime.utcnow().isoformat()

--- a/pos_spj_v13.4/sync/sync_monitor.py
+++ b/pos_spj_v13.4/sync/sync_monitor.py
@@ -22,7 +22,8 @@ class SyncMonitor:
     """
 
     def __init__(self, db):
-        self.db = db
+        from core.db.connection import wrap
+        self.db = wrap(db)
 
     def _now(self) -> str:
         return datetime.utcnow().isoformat()

--- a/pos_spj_v13.4/ui/themes/theme_engine.py
+++ b/pos_spj_v13.4/ui/themes/theme_engine.py
@@ -1,8 +1,8 @@
 
-# ui/themes/theme_engine.py — SPJ POS v6.1
-# Motor de temas enterprise — extrae QSS de config.py y añade los 5 temas requeridos.
-# Los temas existentes (Oscuro Moderno, Claro Elegante, etc.) son preservados.
-# Los nuevos temas del spec se mapean a los existentes para compatibilidad.
+# ui/themes/theme_engine.py — SPJ POS v13.4
+# ThemeManager global — aplica QSS a QApplication + widget activo.
+# Los temas se cargan desde config.TEMAS (fuente única de verdad).
+# La persistencia usa la tabla configuraciones (clave='tema').
 from __future__ import annotations
 import logging
 from typing import Optional
@@ -45,7 +45,6 @@ def get_available_themes() -> list:
 def get_qss(theme_name: str) -> str:
     """Retorna el QSS para el tema dado. Acepta nombres spec o nombres legacy."""
     temas = _get_temas()
-    # Resolver alias
     real_name = _THEME_ALIASES.get(theme_name, theme_name)
     qss = temas.get(real_name, "")
     if not qss:
@@ -55,16 +54,36 @@ def get_qss(theme_name: str) -> str:
 
 
 def apply_theme(widget, theme_name: str) -> bool:
-    """Aplica un tema a un QWidget (usualmente la QApplication o QMainWindow)."""
+    """
+    Aplica un tema GLOBALMENTE: primero a QApplication (todos los widgets),
+    después al widget específico si es distinto de la app.
+
+    Siempre persiste el tema en BD para que sobreviva reinicios.
+    """
     global _current_theme
     qss = get_qss(theme_name)
     if not qss:
         return False
     try:
-        widget.setStyleSheet(qss)
+        # 1. Aplicar a QApplication para que TODOS los widgets hereden el tema
+        try:
+            from PyQt5.QtWidgets import QApplication
+            app = QApplication.instance()
+            if app is not None:
+                app.setStyleSheet(qss)
+        except Exception:
+            pass
+
+        # 2. Aplicar también al widget específico (refuerzo)
+        if widget is not None:
+            try:
+                widget.setStyleSheet(qss)
+            except Exception:
+                pass
+
         _current_theme = theme_name
         _persist_theme(theme_name)
-        logger.info("Tema aplicado: %s", theme_name)
+        logger.info("Tema aplicado globalmente: %s", theme_name)
         return True
     except Exception as e:
         logger.error("Error aplicando tema '%s': %s", theme_name, e)
@@ -75,8 +94,11 @@ def get_current_theme() -> str:
     return _current_theme
 
 
-def load_saved_theme(widget) -> str:
-    """Carga el tema guardado en BD y lo aplica."""
+def load_saved_theme(widget=None) -> str:
+    """
+    Carga el tema guardado en BD y lo aplica globalmente.
+    Si no hay widget, aplica solo a QApplication.
+    """
     try:
         from core.db.connection import get_connection
         conn = get_connection()
@@ -104,7 +126,10 @@ def _persist_theme(theme_name: str) -> None:
 
 
 class ThemeEngine:
-    """Clase de compatibilidad con GestorTemas existente en config.py."""
+    """
+    Clase de compatibilidad con GestorTemas existente en config.py.
+    Delega en las funciones de módulo para garantizar consistencia global.
+    """
     def __init__(self, conexion=None):
         self.conexion = conexion
 
@@ -120,5 +145,9 @@ class ThemeEngine:
     def obtener_tema_actual(self) -> str:
         return get_current_theme()
 
-    def cargar_tema_guardado(self, widget) -> Optional[str]:
+    def cargar_tema_guardado(self, widget=None) -> Optional[str]:
         return load_saved_theme(widget)
+
+
+# Alias de conveniencia — ThemeManager es el punto de entrada preferido
+ThemeManager = ThemeEngine


### PR DESCRIPTION
ERRORES CORREGIDOS:

1. core/db/connection.py — DatabaseWrapper global
   - Nueva clase DatabaseWrapper con fetchall(sql,params), fetchone(sql,params), transaction(name) como context manager usando SAVEPOINT
   - get_connection() ahora devuelve DatabaseWrapper (thread-local)
   - Función helper wrap(conn) para garantizar interface unificada
   - Resuelve: 'sqlite3.Connection has no attribute fetchall/fetchone/transaction'

2. repositories/ y core/services/ — wrapping automático
   - VentaRepository, CajaRepository, TarjetaRepository, TransferRepository, RecetaRepository, SyncMonitor, ReportEngine, FinanceService, DemandForecastingEngine, ReportEngineV2, SalesReversalService, RecipeEngine, IntegrityEngine, ProductionEngine, DemandForecastEngine, ReplenishmentEngine: cada __init__ hace wrap(db) al recibir conexión
   - Retrocompatible: DatabaseWrapper delega todo a sqlite3.Connection vía __getattr__

3. modulos/activos.py — columna valor_residual faltante
   - ALTER TABLE IF NOT EXISTS para agregar valor_residual en BD antiguas
   - Elimina el error repetido 'no such column: valor_residual'

4. modulos/base.py — iconos faltantes (security.png, history.png, card.png)
   - Agrega security.png, history.png, card.png al mapa iconos_sistema
   - Cambia logger.warning a logger.debug para iconos sin mapeo
   - Elimina el ruido 'Icono security.png no encontrado' del log

5. modulos/rrhh.py — Tab Reglas Laborales (HRRuleEngine)
   - Nuevo tab '⚖️ Reglas Laborales' en el módulo RRHH
   - UI para configurar: max días consecutivos, límite horas/semana, cobertura mínima, periodo de nómina (art. LFT México)
   - Botones: Guardar parámetros, Ejecutar auditoría, Verificar nóminas
   - Persiste configuración en tabla 'configuraciones'
   - Integra con HRRuleEngine.auditar_sucursal() y auditar_nomina_pendiente()

6. ui/themes/theme_engine.py — ThemeManager global
   - apply_theme() ahora aplica QSS a QApplication PRIMERO (todos los widgets) y después al widget específico como refuerzo
   - load_saved_theme() acepta widget=None (solo QApplication)
   - Alias ThemeManager = ThemeEngine para API moderna
   - main.py carga el tema guardado ANTES de mostrar cualquier ventana

7. modulos/spj_styles.py — apply_global_theme robustecida
   - Fallback a theme_engine si ThemeService no está disponible
   - Lee nombre completo del tema (no solo dark/light)

https://claude.ai/code/session_01T3j7TExfxpwYjs6CefiCPh