### PR TITLE
fix(v13.4): DB bootstrap fail-fast + wiring + missing service methods

### DIFF
--- a/pos_spj_v13.4/core/db/connection.py
+++ b/pos_spj_v13.4/core/db/connection.py
@@ -313,6 +313,33 @@ def wrap(conn) -> "DatabaseWrapper":
 
 
 # ─────────────────────────────────────────────────────────────
+# v13.4: VALIDACIÓN FAIL-FAST
+# ─────────────────────────────────────────────────────────────
+
+TABLAS_REQUERIDAS = [
+    "usuarios", "productos", "clientes",
+    "ventas", "configuraciones", "inventario",
+]
+
+
+def verificar_tablas(conn) -> None:
+    """Levanta RuntimeError si alguna tabla crítica falta en la DB.
+
+    Se llama desde main.py justo después de ejecutar las migraciones
+    para garantizar un arranque fail-fast antes de inicializar la UI.
+    """
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )
+    existentes = {r[0] for r in cur.fetchall()}
+    faltantes = [t for t in TABLAS_REQUERIDAS if t not in existentes]
+    if faltantes:
+        raise RuntimeError(
+            f"DB incompleta — tablas faltantes: {faltantes}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────
 # SHIMS DE COMPATIBILIDAD
 # ─────────────────────────────────────────────────────────────
 

--- a/pos_spj_v13.4/core/events/wiring.py
+++ b/pos_spj_v13.4/core/events/wiring.py
@@ -52,6 +52,10 @@ def wire_all(container: "AppContainer") -> None:
     _wire_merma_financiero(bus, container)
     _wire_purchase_inventario(bus, container)
 
+    # v13.4: asiento ingreso en venta + ajuste stock en merma
+    _wire_venta_financiero(bus, container)
+    _wire_merma_inventario(bus, container)
+
     logger.info("EventBus wiring completado — %d eventos activos",
                 len(bus.registered_events()))
 
@@ -589,3 +593,69 @@ def _wire_purchase_inventario(bus, container) -> None:
 
     bus.subscribe(PURCHASE_CREATED, _on_compra_inventario,
                   priority=80, label="compra_ledger")
+
+
+# ── v13.4: VENTA_COMPLETADA → asiento ingreso ────────────────────────────────
+
+def _wire_venta_financiero(bus, container) -> None:
+    """
+    VENTA_COMPLETADA → asiento contable de ingreso doble entrada.
+    Debita caja_ventas, acredita ventas_contado.
+    Solo activo si finance_service.registrar_ingreso está disponible.
+    """
+    from core.events.event_bus import VENTA_COMPLETADA
+
+    def _on_venta_ingreso(data: dict) -> None:
+        try:
+            fs = getattr(container, "finance_service", None)
+            if not fs or not hasattr(fs, "registrar_ingreso"):
+                return
+            total = float(data.get("total", 0))
+            if total <= 0:
+                return
+            fs.registrar_ingreso(
+                concepto=f"Venta #{data.get('folio', data.get('venta_id', ''))}",
+                monto=total,
+                referencia_id=data.get("venta_id"),
+                usuario_id=data.get("usuario_id"),
+                sucursal_id=data.get("sucursal_id", 1),
+                metadata={"folio": data.get("folio"),
+                          "cliente_id": data.get("cliente_id")},
+            )
+        except Exception as e:
+            logger.debug("on_venta_ingreso: %s", e)
+
+    bus.subscribe(VENTA_COMPLETADA, _on_venta_ingreso,
+                  priority=50, label="venta_ledger")
+
+
+# ── v13.4: MERMA_CREATED → ajuste stock físico ───────────────────────────────
+
+def _wire_merma_inventario(bus, container) -> None:
+    """
+    MERMA_CREATED → descuenta la cantidad merma del stock físico.
+    Complementa _wire_merma_financiero (que solo registra el asiento).
+    Solo activo si inventory_service.ajustar_merma está disponible.
+    """
+    from core.events.event_bus import MERMA_CREATED
+
+    def _on_merma_inventario(data: dict) -> None:
+        try:
+            inv = getattr(container, "inventory_service", None)
+            if not inv or not hasattr(inv, "ajustar_merma"):
+                return
+            cantidad = float(data.get("cantidad", 0))
+            if cantidad <= 0:
+                return
+            inv.ajustar_merma(
+                producto_id=data.get("producto_id"),
+                cantidad=cantidad,
+                branch_id=data.get("sucursal_id", 1),
+                referencia_id=str(data.get("merma_id", "MERMA")),
+                usuario=data.get("usuario", "sistema"),
+            )
+        except Exception as e:
+            logger.debug("on_merma_inventario: %s", e)
+
+    bus.subscribe(MERMA_CREATED, _on_merma_inventario,
+                  priority=80, label="merma_stock")

--- a/pos_spj_v13.4/core/services/enterprise/finance_service.py
+++ b/pos_spj_v13.4/core/services/enterprise/finance_service.py
@@ -1274,3 +1274,47 @@ class FinanceService:
             return round(utilidad / total_venta, 4)
         except Exception:
             return -1.0
+
+    # ── v13.4: convenience wrappers around registrar_asiento ─────────────────
+
+    def registrar_ingreso(self, concepto: str, monto: float, **kwargs) -> int:
+        """Registra un ingreso: caja_ventas (debe) ↔ ventas_contado (haber)."""
+        return self.registrar_asiento(
+            debe=kwargs.get("debe", "caja_ventas"),
+            haber=kwargs.get("haber", "ventas_contado"),
+            concepto=concepto, monto=monto,
+            modulo=kwargs.get("modulo", "ventas"),
+            referencia_id=kwargs.get("referencia_id"),
+            usuario_id=kwargs.get("usuario_id"),
+            sucursal_id=kwargs.get("sucursal_id", 1),
+            evento=kwargs.get("evento", "VENTA_COMPLETADA"),
+            metadata=kwargs.get("metadata"),
+        )
+
+    def registrar_egreso(self, concepto: str, monto: float, **kwargs) -> int:
+        """Registra un egreso: inventario_almacen (debe) ↔ cuentas_por_pagar (haber)."""
+        return self.registrar_asiento(
+            debe=kwargs.get("debe", "inventario_almacen"),
+            haber=kwargs.get("haber", "cuentas_por_pagar"),
+            concepto=concepto, monto=monto,
+            modulo=kwargs.get("modulo", "compras"),
+            referencia_id=kwargs.get("referencia_id"),
+            usuario_id=kwargs.get("usuario_id"),
+            sucursal_id=kwargs.get("sucursal_id", 1),
+            evento=kwargs.get("evento", "COMPRA_REGISTRADA"),
+            metadata=kwargs.get("metadata"),
+        )
+
+    def registrar_perdida(self, concepto: str, monto: float, **kwargs) -> int:
+        """Registra una pérdida/merma: mermas_y_deterioro (debe) ↔ inventario_almacen (haber)."""
+        return self.registrar_asiento(
+            debe=kwargs.get("debe", "mermas_y_deterioro"),
+            haber=kwargs.get("haber", "inventario_almacen"),
+            concepto=concepto, monto=monto,
+            modulo=kwargs.get("modulo", "merma"),
+            referencia_id=kwargs.get("referencia_id"),
+            usuario_id=kwargs.get("usuario_id"),
+            sucursal_id=kwargs.get("sucursal_id", 1),
+            evento=kwargs.get("evento", "MERMA_REGISTRADA"),
+            metadata=kwargs.get("metadata"),
+        )

--- a/pos_spj_v13.4/core/services/forecast_engine.py
+++ b/pos_spj_v13.4/core/services/forecast_engine.py
@@ -53,6 +53,10 @@ class ForecastEngine:
             "demanda_mes": round(fc * 30, 3),
         }
 
+    def generar_forecast_diario(self) -> list:
+        """Alias de run() requerido por SchedulerService."""
+        return self.run()
+
     def _get_productos_activos(self) -> list:
         try:
             rows = self.conn.execute(

--- a/pos_spj_v13.4/core/services/inventory_service.py
+++ b/pos_spj_v13.4/core/services/inventory_service.py
@@ -119,6 +119,43 @@ class InventoryService:
         """
         return self.repo.get_current_stock(product_id, branch_id)
 
+    # ── v13.4: aliases en español para EventBus wiring ────────────────────────
+
+    def descontar_stock(self, producto_id: int, cantidad: float,
+                        branch_id: int = 1, referencia_id: str = "EVT",
+                        usuario: str = "sistema", **kwargs) -> None:
+        """Alias de deduct_stock() para uso desde EventBus."""
+        self.deduct_stock(
+            product_id=producto_id, branch_id=branch_id, qty=cantidad,
+            reference_type="SALE_EVENT", reference_id=str(referencia_id),
+            operation_id=kwargs.get("operation_id", str(producto_id)),
+            user=usuario, notes=kwargs.get("notes", ""),
+        )
+
+    def incrementar_stock(self, producto_id: int, cantidad: float,
+                          unit_cost: float = 0.0, branch_id: int = 1,
+                          referencia_id: str = "EVT",
+                          usuario: str = "sistema", **kwargs) -> None:
+        """Alias de add_stock() para uso desde EventBus."""
+        self.add_stock(
+            product_id=producto_id, branch_id=branch_id, qty=cantidad,
+            unit_cost=unit_cost,
+            reference_type="PURCHASE_EVENT", reference_id=str(referencia_id),
+            operation_id=kwargs.get("operation_id", str(producto_id)),
+            user=usuario, notes=kwargs.get("notes", ""),
+        )
+
+    def ajustar_merma(self, producto_id: int, cantidad: float,
+                      branch_id: int = 1, referencia_id: str = "MERMA",
+                      usuario: str = "sistema", **kwargs) -> None:
+        """Descuenta merma del inventario. Alias para EventBus."""
+        self.deduct_stock(
+            product_id=producto_id, branch_id=branch_id, qty=cantidad,
+            reference_type="WASTE", reference_id=str(referencia_id),
+            operation_id=kwargs.get("operation_id", str(producto_id)),
+            user=usuario, notes=kwargs.get("notes", "merma"),
+        )
+
     def conciliate_stock(self, product_id: int, branch_id: int):
         """
         🚨 BOTÓN DE PÁNICO / AUDITORÍA 🚨

--- a/pos_spj_v13.4/main.py
+++ b/pos_spj_v13.4/main.py
@@ -130,9 +130,20 @@ def inicializar_sistema():
 
     try:
         import sqlite3
+        from core.db.connection import verificar_tablas
         conn = sqlite3.connect(DB_PATH)
-        migrator.up(conn); conn.close()
+        migrator.up(conn)
+        verificar_tablas(conn)
+        conn.close()
         logger.info("✅ Migraciones OK")
+    except RuntimeError as e:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        logger.critical("DB incompleta post-migraciones: %s", e)
+        QMessageBox.critical(None, "Error Fatal — DB incompleta", str(e))
+        sys.exit(1)
     except Exception as e:
         logger.warning("Migraciones (continuando): %s", e)
 

--- a/pos_spj_v13.4/migrations/MIGRATION_LOG.md
+++ b/pos_spj_v13.4/migrations/MIGRATION_LOG.md
@@ -104,3 +104,36 @@ documentarse aquí antes del commit.
 - **Archivo**: `054_sync_improvements_orphan.py`
 - **Motivo**: Resolución del conflicto 048. Columnas del huérfano
   `048_sync_improvements.py` aplicadas de forma idempotente via ALTER TABLE.
+
+---
+
+## v13.4 wiring + bootstrap fix — 2026-04-08
+
+### Cambios en servicios (solo aditivos)
+
+- **`core/db/connection.py`**: Agregada función `verificar_tablas(conn)` que
+  levanta `RuntimeError` si alguna de las tablas críticas
+  (`usuarios`, `productos`, `clientes`, `ventas`, `configuraciones`, `inventario`)
+  no existe. Usada por `main.py` como check fail-fast post-migraciones.
+
+- **`main.py`**: `inicializar_sistema()` ahora llama `verificar_tablas()` justo
+  después de `migrator.up()`. Si las tablas faltan se muestra un diálogo y se
+  aborta el arranque en lugar de continuar con DB vacía.
+
+- **`core/services/forecast_engine.py`**: Agregado `generar_forecast_diario()`
+  como alias de `run()`. Resuelve el crash del `SchedulerService` que llamaba
+  este método inexistente.
+
+- **`core/services/inventory_service.py`**: Agregados alias en español
+  `descontar_stock()`, `incrementar_stock()`, `ajustar_merma()` que delegan en
+  `deduct_stock()` / `add_stock()` respectivamente.
+
+- **`core/services/enterprise/finance_service.py`**: Agregados
+  `registrar_ingreso()`, `registrar_egreso()`, `registrar_perdida()` como
+  wrappers de `registrar_asiento()` con cuentas contables predeterminadas.
+
+- **`core/events/wiring.py`**: Agregadas dos nuevas funciones de wiring:
+  - `_wire_venta_financiero`: `VENTA_COMPLETADA` → `finance_service.registrar_ingreso`
+    (prioridad 50) para generar asiento contable en cada venta.
+  - `_wire_merma_inventario`: `MERMA_CREATED` → `inventory_service.ajustar_merma`
+    (prioridad 80) para descontar stock físico ante mermas vía evento.

--- a/pos_spj_v13.4/tests/test_bootstrap_wiring.py
+++ b/pos_spj_v13.4/tests/test_bootstrap_wiring.py
@@ -1,0 +1,259 @@
+# tests/test_bootstrap_wiring.py — v13.4
+"""
+Tests para:
+  1. verificar_tablas() en core/db/connection.py
+  2. ForecastEngine.generar_forecast_diario()
+  3. InventoryService aliases en español
+  4. FinanceService.registrar_ingreso / registrar_egreso / registrar_perdida
+"""
+from __future__ import annotations
+
+import sqlite3
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ─────────────────────────────────────────────────────────────
+# 1. verificar_tablas
+# ─────────────────────────────────────────────────────────────
+
+def test_verificar_tablas_raises_when_missing():
+    """DB vacía debe levantar RuntimeError con las tablas faltantes."""
+    from core.db.connection import verificar_tablas
+    conn = sqlite3.connect(":memory:")
+    with pytest.raises(RuntimeError) as exc_info:
+        verificar_tablas(conn)
+    conn.close()
+    assert "tablas faltantes" in str(exc_info.value)
+    assert "usuarios" in str(exc_info.value)
+
+
+def test_verificar_tablas_passes_with_all_required_tables():
+    """DB con todas las tablas requeridas no debe levantar error."""
+    from core.db.connection import verificar_tablas, TABLAS_REQUERIDAS
+    conn = sqlite3.connect(":memory:")
+    for tabla in TABLAS_REQUERIDAS:
+        conn.execute(f"CREATE TABLE {tabla} (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    # No debe lanzar excepción
+    verificar_tablas(conn)
+    conn.close()
+
+
+def test_verificar_tablas_partial_raises():
+    """DB con algunas tablas debe listar solo las faltantes."""
+    from core.db.connection import verificar_tablas
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE usuarios (id INTEGER PRIMARY KEY)")
+    conn.execute("CREATE TABLE productos (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    with pytest.raises(RuntimeError) as exc_info:
+        verificar_tablas(conn)
+    conn.close()
+    msg = str(exc_info.value)
+    # usuarios y productos existen → no deben aparecer como faltantes
+    assert "usuarios" not in msg
+    assert "productos" not in msg
+    # clientes falta → debe aparecer
+    assert "clientes" in msg
+
+
+# ─────────────────────────────────────────────────────────────
+# 2. ForecastEngine.generar_forecast_diario
+# ─────────────────────────────────────────────────────────────
+
+def test_forecast_engine_generar_forecast_diario_returns_list():
+    """generar_forecast_diario() debe delegar a run() y retornar lista."""
+    from core.services.forecast_engine import ForecastEngine
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    # Tablas mínimas que run() necesita para no fallar
+    conn.execute(
+        "CREATE TABLE productos "
+        "(id INTEGER PRIMARY KEY, nombre TEXT, stock_minimo REAL, activo INTEGER, oculto INTEGER)"
+    )
+    conn.commit()
+
+    eng = ForecastEngine(conn, sucursal_id=1)
+    result = eng.generar_forecast_diario()
+    conn.close()
+
+    assert isinstance(result, list)
+
+
+def test_forecast_engine_generar_forecast_diario_delegates_to_run():
+    """generar_forecast_diario() debe ser idéntico a run()."""
+    from core.services.forecast_engine import ForecastEngine
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE productos "
+        "(id INTEGER PRIMARY KEY, nombre TEXT, stock_minimo REAL, activo INTEGER, oculto INTEGER)"
+    )
+    conn.commit()
+
+    eng = ForecastEngine(conn, sucursal_id=1)
+    assert eng.generar_forecast_diario() == eng.run()
+    conn.close()
+
+
+# ─────────────────────────────────────────────────────────────
+# 3. InventoryService Spanish aliases
+# ─────────────────────────────────────────────────────────────
+
+def _make_inventory_service():
+    """Crea un InventoryService con repo mock."""
+    from core.services.inventory_service import InventoryService
+
+    mock_repo = MagicMock()
+    mock_repo.get_current_stock.return_value = 100.0
+    mock_repo.get_average_cost.return_value = 10.0
+    mock_service = InventoryService(db_conn=MagicMock(), inventory_repo=mock_repo)
+    return mock_service, mock_repo
+
+
+def test_inventory_descontar_stock_exists_and_callable():
+    svc, _ = _make_inventory_service()
+    assert callable(getattr(svc, "descontar_stock", None))
+
+
+def test_inventory_incrementar_stock_exists_and_callable():
+    svc, _ = _make_inventory_service()
+    assert callable(getattr(svc, "incrementar_stock", None))
+
+
+def test_inventory_ajustar_merma_exists_and_callable():
+    svc, _ = _make_inventory_service()
+    assert callable(getattr(svc, "ajustar_merma", None))
+
+
+def test_inventory_descontar_stock_calls_deduct():
+    svc, repo = _make_inventory_service()
+    svc.descontar_stock(producto_id=1, cantidad=5.0, branch_id=1)
+    repo.insert_movement.assert_called_once()
+    call_kwargs = repo.insert_movement.call_args
+    assert call_kwargs.kwargs.get("movement_type") == "OUT"
+
+
+def test_inventory_incrementar_stock_calls_add():
+    svc, repo = _make_inventory_service()
+    repo.get_current_stock.return_value = 0.0
+    svc.incrementar_stock(producto_id=2, cantidad=10.0, unit_cost=5.0, branch_id=1)
+    repo.insert_movement.assert_called_once()
+    call_kwargs = repo.insert_movement.call_args
+    assert call_kwargs.kwargs.get("movement_type") == "IN"
+
+
+def test_inventory_ajustar_merma_uses_waste_reference():
+    svc, repo = _make_inventory_service()
+    svc.ajustar_merma(producto_id=3, cantidad=2.0, branch_id=1)
+    repo.insert_movement.assert_called_once()
+    call_kwargs = repo.insert_movement.call_args
+    assert call_kwargs.kwargs.get("reference_type") == "WASTE"
+
+
+# ─────────────────────────────────────────────────────────────
+# 4. FinanceService registrar_ingreso / egreso / perdida
+# ─────────────────────────────────────────────────────────────
+
+def _make_finance_service():
+    """Crea FinanceService con DB in-memory que tiene financial_event_log."""
+    from core.services.enterprise.finance_service import FinanceService
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE financial_event_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            evento TEXT,
+            modulo TEXT,
+            referencia_id INTEGER,
+            monto REAL,
+            cuenta_debe TEXT,
+            cuenta_haber TEXT,
+            usuario_id INTEGER,
+            sucursal_id INTEGER,
+            metadata TEXT,
+            timestamp DATETIME DEFAULT (datetime('now'))
+        )
+    """)
+    conn.commit()
+
+    # FinanceService.__init__ puede requerir varios parámetros — usamos mock
+    svc = object.__new__(FinanceService)
+    svc.db = conn
+    return svc, conn
+
+
+def test_finance_registrar_ingreso_exists():
+    svc, conn = _make_finance_service()
+    assert callable(getattr(svc, "registrar_ingreso", None))
+    conn.close()
+
+
+def test_finance_registrar_egreso_exists():
+    svc, conn = _make_finance_service()
+    assert callable(getattr(svc, "registrar_egreso", None))
+    conn.close()
+
+
+def test_finance_registrar_perdida_exists():
+    svc, conn = _make_finance_service()
+    assert callable(getattr(svc, "registrar_perdida", None))
+    conn.close()
+
+
+def test_finance_registrar_ingreso_inserts_row():
+    svc, conn = _make_finance_service()
+    row_id = svc.registrar_ingreso("Test ingreso", 100.0)
+    assert row_id > 0
+    row = conn.execute(
+        "SELECT * FROM financial_event_log WHERE id=?", (row_id,)
+    ).fetchone()
+    assert row is not None
+    assert row["cuenta_debe"] == "caja_ventas"
+    assert row["cuenta_haber"] == "ventas_contado"
+    assert float(row["monto"]) == 100.0
+    conn.close()
+
+
+def test_finance_registrar_egreso_inserts_row():
+    svc, conn = _make_finance_service()
+    row_id = svc.registrar_egreso("Test egreso", 200.0)
+    assert row_id > 0
+    row = conn.execute(
+        "SELECT * FROM financial_event_log WHERE id=?", (row_id,)
+    ).fetchone()
+    assert row["cuenta_debe"] == "inventario_almacen"
+    assert row["cuenta_haber"] == "cuentas_por_pagar"
+    conn.close()
+
+
+def test_finance_registrar_perdida_inserts_row():
+    svc, conn = _make_finance_service()
+    row_id = svc.registrar_perdida("Merma pollo", 50.0)
+    assert row_id > 0
+    row = conn.execute(
+        "SELECT * FROM financial_event_log WHERE id=?", (row_id,)
+    ).fetchone()
+    assert row["cuenta_debe"] == "mermas_y_deterioro"
+    assert row["cuenta_haber"] == "inventario_almacen"
+    conn.close()
+
+
+def test_finance_registrar_perdida_custom_cuentas():
+    """Se pueden sobreescribir las cuentas via kwargs."""
+    svc, conn = _make_finance_service()
+    row_id = svc.registrar_perdida(
+        "Robo bodega", 300.0,
+        debe="perdidas_extraordinarias",
+        haber="caja",
+    )
+    row = conn.execute(
+        "SELECT * FROM financial_event_log WHERE id=?", (row_id,)
+    ).fetchone()
+    assert row["cuenta_debe"] == "perdidas_extraordinarias"
+    assert row["cuenta_haber"] == "caja"
+    conn.close()


### PR DESCRIPTION
Critical fixes (additive only — no existing logic modified):

- core/db/connection.py: add verificar_tablas() — raises RuntimeError if any of [usuarios, productos, clientes, ventas, configuraciones, inventario] are missing after migrations run.

- main.py: call verificar_tablas() after migrator.up(); aborts with dialog instead of continuing with empty DB.

- core/services/forecast_engine.py: add generar_forecast_diario() alias of run() — fixes SchedulerService crash (method was called but missing).

- core/services/inventory_service.py: add Spanish-named aliases descontar_stock(), incrementar_stock(), ajustar_merma() delegating to existing deduct_stock() / add_stock() for EventBus wiring.

- core/services/enterprise/finance_service.py: add registrar_ingreso(), registrar_egreso(), registrar_perdida() as wrappers of registrar_asiento() with double-entry default accounts.

- core/events/wiring.py: add _wire_venta_financiero (VENTA_COMPLETADA → finance ledger at priority 50) and _wire_merma_inventario (MERMA_CREATED → inventory stock deduction at priority 80).

- migrations/MIGRATION_LOG.md: document all v13.4 wiring decisions.

- tests/test_bootstrap_wiring.py: 18 new tests covering all additions (verificar_tablas, ForecastEngine alias, InventoryService aliases, FinanceService registrar_ingreso/egreso/perdida).

https://claude.ai/code/session_01LLEXs1mLrLT47oXQd9Td6S