### PR TITLE
feat(erp): evolución POS → ERP — 8 fases aditivas sin romper funciona…

### DIFF
--- a/pos_spj_v13.4/core/app_container.py
+++ b/pos_spj_v13.4/core/app_container.py
@@ -415,6 +415,32 @@ class AppContainer:
             sucursal_id=self.sucursal_id
         )
 
+        # ── ERP FASE 3: AccountingEngine ─────────────────────────────────────
+        try:
+            from core.services.finance.accounting_engine import AccountingEngine
+            self.accounting_engine = AccountingEngine(self.finance_service)
+            self.accounting_engine.wire()
+        except Exception as _ae:
+            self.accounting_engine = None
+            logger.debug("AccountingEngine: %s", _ae)
+
+        # ── ERP FASE 4: UnifiedThirdPartyService ─────────────────────────────
+        try:
+            from core.services.finance.third_party_service import UnifiedThirdPartyService
+            self.third_party_service = UnifiedThirdPartyService(self.finance_service)
+        except Exception as _tp:
+            self.third_party_service = None
+            logger.debug("ThirdPartyService: %s", _tp)
+
+        # ── ERP FASE 5: AnalyticsEngine ──────────────────────────────────────
+        try:
+            from core.services.analytics.analytics_engine import AnalyticsEngine
+            self.analytics_engine = AnalyticsEngine(self.db)
+            self.analytics_engine.wire()
+        except Exception as _anae:
+            self.analytics_engine = None
+            logger.debug("AnalyticsEngine: %s", _anae)
+
         # Wire kitchen printer and comisiones to sales_service
         try:
             self.sales_service._hw_svc = self.hardware_service

--- a/pos_spj_v13.4/core/events/domain_events.py
+++ b/pos_spj_v13.4/core/events/domain_events.py
@@ -1,0 +1,31 @@
+# core/events/domain_events.py — SPJ ERP v13.4
+"""
+Constantes canónicas de eventos de dominio para el plano ERP.
+
+Reglas:
+  - Aliases a eventos existentes usan el mismo string que event_bus.py
+    (mismo canal EventBus, sin duplicar registros).
+  - Eventos NUEVOS usan lowercase para distinguirlos de los legacy UPPERCASE.
+  - Dependencia unidireccional: este módulo importa de event_bus, nunca al revés.
+"""
+from core.events.event_bus import (
+    VENTA_COMPLETADA      as SALE_CREATED,       # "VENTA_COMPLETADA"
+    COMPRA_REGISTRADA     as PURCHASE_CREATED,   # "COMPRA_REGISTRADA"
+    PRODUCCION_COMPLETADA as PRODUCTION_EXECUTED, # "PRODUCCION_COMPLETADA"
+    AJUSTE_INVENTARIO     as STOCK_UPDATED,       # "AJUSTE_INVENTARIO"
+)
+
+# Nuevos eventos ERP (lowercase — no existen en event_bus.py)
+INVENTORY_MOVEMENT  = "inventory_movement"   # emitido por UnifiedInventoryService.process_movement()
+PAYMENT_RECEIVED    = "payment_received"     # emitido por UnifiedThirdPartyService.apply_payment()
+EXPENSE_REGISTERED  = "expense_registered"   # emitido al registrar gasto/CXP
+
+__all__ = [
+    "SALE_CREATED",
+    "PURCHASE_CREATED",
+    "PRODUCTION_EXECUTED",
+    "STOCK_UPDATED",
+    "INVENTORY_MOVEMENT",
+    "PAYMENT_RECEIVED",
+    "EXPENSE_REGISTERED",
+]

--- a/pos_spj_v13.4/core/services/analytics/__init__.py
+++ b/pos_spj_v13.4/core/services/analytics/__init__.py
@@ -1,0 +1,1 @@
+# core/services/analytics/__init__.py

--- a/pos_spj_v13.4/core/services/analytics/analytics_engine.py
+++ b/pos_spj_v13.4/core/services/analytics/analytics_engine.py
@@ -1,0 +1,106 @@
+# core/services/analytics/analytics_engine.py — SPJ ERP
+"""
+AnalyticsEngine — Motor de Inteligencia de Negocios Reactivo.
+
+Prioridad 5 = BI/analytics (la más baja per convenio).
+Reacciona a eventos y agrega datos en tablas bi_*.
+Non-fatal: nunca cancela la operación que originó el evento.
+"""
+from __future__ import annotations
+import json
+import logging
+from datetime import datetime
+
+logger = logging.getLogger("spj.analytics_engine")
+
+_PRIORITY = 5
+
+
+class AnalyticsEngine:
+    """Suscriptor de eventos que alimenta las tablas BI de agregación."""
+
+    def __init__(self, db_conn):
+        self._db = db_conn
+        self._subscribed = False
+
+    def wire(self) -> None:
+        """Registra handlers en el EventBus. Idempotente."""
+        if self._subscribed:
+            return
+        from core.events.event_bus import get_bus
+        from core.events.domain_events import SALE_CREATED, PRODUCTION_EXECUTED
+
+        bus = get_bus()
+        bus.subscribe(SALE_CREATED, self.update_sales,
+                      priority=_PRIORITY, label="analytics.sales")
+        bus.subscribe(PRODUCTION_EXECUTED, self.update_yield,
+                      priority=_PRIORITY, label="analytics.yield")
+        self._subscribed = True
+        logger.info("AnalyticsEngine wired (prio=%d)", _PRIORITY)
+
+    def update_sales(self, data: dict) -> None:
+        """SALE_CREATED → UPSERT en bi_sales_daily."""
+        try:
+            fecha = (data.get("fecha") or datetime.now().strftime("%Y-%m-%d"))[:10]
+            sucursal_id = int(data.get("sucursal_id", 1))
+            total = float(data.get("total", 0))
+            if total <= 0:
+                return
+
+            self._db.execute("""
+                INSERT INTO bi_sales_daily
+                    (fecha, sucursal_id, total_ventas, num_transacciones, promedio_ticket)
+                VALUES (?, ?, ?, 1, ?)
+                ON CONFLICT(fecha, sucursal_id) DO UPDATE SET
+                    total_ventas      = total_ventas + excluded.total_ventas,
+                    num_transacciones = num_transacciones + 1,
+                    promedio_ticket   = (total_ventas + excluded.total_ventas)
+                                        / (num_transacciones + 1)
+            """, (fecha, sucursal_id, total, total))
+            try:
+                self._db.commit()
+            except Exception:
+                pass
+        except Exception as e:
+            logger.warning("update_sales non-fatal: %s", e)
+
+    def update_yield(self, data: dict) -> None:
+        """PRODUCTION_EXECUTED → INSERT en bi_transformations."""
+        try:
+            fecha = (data.get("fecha") or datetime.now().strftime("%Y-%m-%d"))[:10]
+            sucursal_id = int(data.get("sucursal_id", 1))
+            # Soporta payload plano y anidado via DomainEvent.to_dict()
+            nested = (data.get("data") or {})
+            rendimiento = float(
+                data.get("rendimiento_pct")
+                or nested.get("rendimiento_pct")
+                or data.get("yield_pct")
+                or 0
+            )
+            categoria = (
+                data.get("categoria")
+                or nested.get("categoria")
+                or data.get("tipo", "")
+            )
+            inputs_json  = json.dumps(
+                data.get("inputs") or nested.get("inputs") or data.get("insumos", []),
+                ensure_ascii=False,
+            )
+            outputs_json = json.dumps(
+                data.get("outputs") or nested.get("outputs") or data.get("productos", []),
+                ensure_ascii=False,
+            )
+
+            self._db.execute("""
+                INSERT INTO bi_transformations
+                    (fecha, sucursal_id, categoria, inputs_json,
+                     outputs_json, rendimiento_pct)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, (fecha, sucursal_id, categoria, inputs_json,
+                  outputs_json, rendimiento))
+            try:
+                self._db.commit()
+            except Exception:
+                pass
+        except Exception as e:
+            logger.warning("update_yield non-fatal: %s", e)

--- a/pos_spj_v13.4/core/services/finance/__init__.py
+++ b/pos_spj_v13.4/core/services/finance/__init__.py
@@ -1,0 +1,1 @@
+# core/services/finance/__init__.py

--- a/pos_spj_v13.4/core/services/finance/accounting_engine.py
+++ b/pos_spj_v13.4/core/services/finance/accounting_engine.py
@@ -1,0 +1,96 @@
+# core/services/finance/accounting_engine.py — SPJ ERP
+"""
+AccountingEngine — Motor de Contabilidad de Doble Entrada.
+
+Reacciona a eventos de dominio y crea asientos contables en financial_event_log.
+Prioridad 48 (< 50 de _wire_venta_financiero existente) para orden determinístico.
+
+NO controla el flujo — solo reacciona.
+Si falla, NO cancela la operación original.
+
+Cuentas SAT:
+  Ventas:   1100 (caja/clientes) DEBE  /  4100 (ventas) HABER
+  Compras:  5100 (costo mercancía) DEBE  /  2100 (cuentas por pagar) HABER
+"""
+from __future__ import annotations
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.services.enterprise.finance_service import FinanceService
+
+logger = logging.getLogger("spj.accounting_engine")
+
+_PRIORITY = 48
+
+
+class AccountingEngine:
+    """Suscriptor del EventBus que genera asientos de doble entrada."""
+
+    def __init__(self, finance_service: "FinanceService"):
+        self._fs = finance_service
+        self._subscribed = False
+
+    def wire(self) -> None:
+        """Registra los handlers en el EventBus. Idempotente."""
+        if self._subscribed:
+            return
+        from core.events.event_bus import get_bus
+        from core.events.domain_events import SALE_CREATED, PURCHASE_CREATED
+
+        bus = get_bus()
+        bus.subscribe(SALE_CREATED, self.handle_sale,
+                      priority=_PRIORITY, label="accounting.sale")
+        bus.subscribe(PURCHASE_CREATED, self.handle_purchase,
+                      priority=_PRIORITY, label="accounting.purchase")
+        self._subscribed = True
+        logger.info("AccountingEngine wired (prio=%d)", _PRIORITY)
+
+    def handle_sale(self, data: dict) -> None:
+        """SALE_CREATED → Débito caja (1100) / Crédito ventas (4100)."""
+        try:
+            total = float(data.get("total", 0))
+            if total <= 0:
+                return
+            self._fs.registrar_asiento(
+                debe="1100",
+                haber="4100",
+                concepto=f"Venta #{data.get('folio', data.get('venta_id', ''))}",
+                monto=total,
+                modulo="ventas",
+                referencia_id=data.get("venta_id"),
+                usuario_id=data.get("usuario_id"),
+                sucursal_id=int(data.get("sucursal_id", 1)),
+                evento="SALE_CREATED",
+                metadata={
+                    "folio": data.get("folio"),
+                    "cliente_id": data.get("cliente_id"),
+                    "metodo_pago": data.get("metodo_pago", data.get("forma_pago")),
+                },
+            )
+        except Exception as e:
+            logger.warning("handle_sale non-fatal: %s", e)
+
+    def handle_purchase(self, data: dict) -> None:
+        """PURCHASE_CREATED → Débito costo (5100) / Crédito CXP (2100)."""
+        try:
+            total = float(data.get("total", data.get("monto", 0)))
+            if total <= 0:
+                return
+            self._fs.registrar_asiento(
+                debe="5100",
+                haber="2100",
+                concepto=f"Compra #{data.get('compra_id', '')} proveedor {data.get('proveedor_id', '')}",
+                monto=total,
+                modulo="compras",
+                referencia_id=data.get("compra_id"),
+                usuario_id=data.get("usuario_id"),
+                sucursal_id=int(data.get("sucursal_id", 1)),
+                evento="PURCHASE_CREATED",
+                metadata={
+                    "proveedor_id": data.get("proveedor_id"),
+                    "items_count": len(data.get("items", [])),
+                },
+            )
+        except Exception as e:
+            logger.warning("handle_purchase non-fatal: %s", e)

--- a/pos_spj_v13.4/core/services/finance/third_party_service.py
+++ b/pos_spj_v13.4/core/services/finance/third_party_service.py
@@ -1,0 +1,106 @@
+# core/services/finance/third_party_service.py — SPJ ERP
+"""
+UnifiedThirdPartyService — Gestión unificada de terceros (Proveedores/Clientes).
+
+Wrapper sobre FinanceService AP/AR. No reemplaza módulos existentes.
+Sin SQL propio — delega completamente a FinanceService.
+"""
+from __future__ import annotations
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.services.enterprise.finance_service import FinanceService
+
+logger = logging.getLogger("spj.third_party_service")
+
+
+class UnifiedThirdPartyService:
+    """Punto único de consulta y pago para terceros (AP y AR)."""
+
+    def __init__(self, finance_service: "FinanceService"):
+        self._fs = finance_service
+
+    def get_balance(self, third_party_id: int, tipo: str = "proveedor") -> dict:
+        """
+        Retorna saldo pendiente para un tercero.
+        tipo='proveedor' → CXP (accounts_payable)
+        tipo='cliente'   → CXC (accounts_receivable)
+        """
+        try:
+            if tipo == "proveedor":
+                rows = self._fs.cuentas_por_pagar()
+                filtered = [r for r in rows
+                            if int(r.get("supplier_id") or r.get("proveedor_id") or 0) == third_party_id]
+                saldo = sum(float(r.get("balance", r.get("saldo", 0))) for r in filtered)
+                return {
+                    "third_party_id": third_party_id,
+                    "tipo": tipo,
+                    "saldo_pendiente": round(saldo, 2),
+                    "facturas": len(filtered),
+                }
+            else:
+                rows = self._fs.cuentas_por_cobrar()
+                filtered = [r for r in rows
+                            if int(r.get("cliente_id") or 0) == third_party_id]
+                saldo = sum(float(r.get("balance", r.get("saldo", 0))) for r in filtered)
+                return {
+                    "third_party_id": third_party_id,
+                    "tipo": tipo,
+                    "saldo_pendiente": round(saldo, 2),
+                    "facturas": len(filtered),
+                }
+        except Exception as e:
+            logger.warning("get_balance non-fatal: %s", e)
+            return {"third_party_id": third_party_id, "tipo": tipo,
+                    "saldo_pendiente": 0.0, "error": str(e)}
+
+    def apply_payment(self, data: dict) -> dict:
+        """
+        Aplica un pago a CXP o CXC.
+        data keys:
+          account_id   — int (fila AP o AR)
+          monto        — float
+          tipo         — 'cxp' | 'cxc'
+          metodo_pago  — str (default 'efectivo')
+          usuario      — str (default 'Sistema')
+          notas        — str (opcional)
+        """
+        try:
+            account_id = int(data["account_id"])
+            monto      = float(data["monto"])
+            tipo       = data.get("tipo", "cxp")
+            metodo     = data.get("metodo_pago", "efectivo")
+            usuario    = data.get("usuario", "Sistema")
+            notas      = data.get("notas")
+
+            if tipo == "cxp":
+                result = self._fs.abonar_cxp(
+                    ap_id=account_id, monto=monto,
+                    metodo_pago=metodo, usuario=usuario, notas=notas,
+                ) or {}
+            else:
+                result = self._fs.cobrar_cxc(
+                    ar_id=account_id, monto=monto,
+                    metodo_pago=metodo, usuario=usuario, notas=notas,
+                ) or {}
+
+            try:
+                from core.events.event_bus import get_bus
+                from core.events.domain_events import PAYMENT_RECEIVED
+                get_bus().publish(PAYMENT_RECEIVED, {
+                    "account_id": account_id,
+                    "tipo": tipo,
+                    "monto": monto,
+                    "metodo_pago": metodo,
+                    "nuevo_balance": result.get("nuevo_balance", 0),
+                    "nuevo_status": result.get("nuevo_status", ""),
+                })
+            except Exception as _e:
+                logger.debug("apply_payment event non-fatal: %s", _e)
+
+            return {"ok": True, **result}
+
+        except Exception as e:
+            logger.warning("apply_payment failed: %s", e)
+            return {"ok": False, "error": str(e)}

--- a/pos_spj_v13.4/core/services/inventory/unified_inventory_service.py
+++ b/pos_spj_v13.4/core/services/inventory/unified_inventory_service.py
@@ -97,3 +97,34 @@ class UnifiedInventoryService:
                 c.execute("UPDATE productos SET existencia=? WHERE id=?", (stock_nuevo, producto_id))
     def validate_stock(self, producto_id, quantity, sucursal_id=None):
         return self.get_stock(producto_id)>=quantity
+
+    def process_movement(self, product_id, quantity, movement_type,
+                         reference=None, metadata=None):
+        """
+        Wrapper público sobre register_movement().
+        Registra el movimiento y emite el evento 'inventory_movement' al EventBus.
+        Non-fatal: el evento nunca cancela la operación de inventario.
+        """
+        if metadata is None:
+            metadata = {}
+        mid = self.register_movement(
+            producto_id=product_id,
+            movement_type=movement_type,
+            quantity=quantity,
+            reference=reference,
+            notas=metadata.get("notas"),
+        )
+        try:
+            from core.events.event_bus import get_bus
+            get_bus().publish("inventory_movement", {
+                "movement_id": mid,
+                "product_id": product_id,
+                "quantity": quantity,
+                "movement_type": movement_type,
+                "reference": reference,
+                "sucursal_id": self.sucursal_id,
+                "metadata": metadata,
+            })
+        except Exception as _e:
+            logger.warning("process_movement event non-fatal: %s", _e)
+        return mid

--- a/pos_spj_v13.4/core/services/inventory_engine.py
+++ b/pos_spj_v13.4/core/services/inventory_engine.py
@@ -6,6 +6,12 @@ El motor real está en core/services/inventory/unified_inventory_service.py.
 NOTA: Este archivo reemplaza el shim corrupto que tenía 30+ líneas
 redundantes de 'InventoryEngine = InventoryEngine' (merge artifact).
 """
+import logging as _log
+_log.getLogger("spj.inventory_engine").warning(
+    "DEPRECATED: inventory_engine shim. "
+    "Import directly from core.services.inventory.unified_inventory_service."
+)
+
 from core.services.inventory.unified_inventory_service import (
     UnifiedInventoryService as InventoryEngine,
     UnifiedInventoryService,

--- a/pos_spj_v13.4/core/services/inventory_service.py
+++ b/pos_spj_v13.4/core/services/inventory_service.py
@@ -15,6 +15,10 @@ class InventoryService:
     def __init__(self, db_conn, inventory_repo):
         self.db = db_conn
         self.repo = inventory_repo
+        logger.warning(
+            "DEPRECATED: InventoryService is deprecated. "
+            "Use core.services.inventory.unified_inventory_service.UnifiedInventoryService instead."
+        )
         
     # ¡BAM! Un muro de seguridad de una sola línea
     @require_permission('adjust_inventory')

--- a/pos_spj_v13.4/migrations/engine.py
+++ b/pos_spj_v13.4/migrations/engine.py
@@ -54,6 +54,10 @@ MIGRATIONS = [
     ("058",  "migrations.standalone.058_scan_event_log"),    # v13.4: auditoría de escaneos Fase 2
     ("059",  "migrations.standalone.059_plan_cuentas"),      # v13.4: plan de cuentas SAT NIF Fase 3
     ("060",  "migrations.standalone.060_depreciacion_acumulada"),  # v13.4: depreciación acumulada Fase 3
+    # ERP evolution — additive, non-breaking
+    ("061",  "migrations.standalone.061_fix_finanzas_schema"),   # ERP FASE 1: columnas finanzas hotfix
+    ("062",  "migrations.standalone.062_bi_analytics_tables"),   # ERP FASE 5: tablas BI analytics
+    ("063",  "migrations.standalone.063_audit_log_table"),       # ERP FASE 7: audit_log (inglés)
 ]
 
 def _ensure_tracking_table(conn):

--- a/pos_spj_v13.4/migrations/fix_finanzas_schema.sql
+++ b/pos_spj_v13.4/migrations/fix_finanzas_schema.sql
@@ -1,0 +1,13 @@
+-- migrations/fix_finanzas_schema.sql — SPJ POS v13.4 ERP Hotfix
+-- Columnas faltantes en tablas de finanzas.
+-- SQLite 3.35+: ADD COLUMN IF NOT EXISTS
+-- Para SQLite < 3.35, usar la migración Python 061_fix_finanzas_schema.py
+
+ALTER TABLE financial_event_log ADD COLUMN IF NOT EXISTS concepto TEXT;
+
+ALTER TABLE accounts_payable ADD COLUMN IF NOT EXISTS folio TEXT;
+ALTER TABLE accounts_payable ADD COLUMN IF NOT EXISTS concepto TEXT;
+ALTER TABLE accounts_payable ADD COLUMN IF NOT EXISTS ref_type TEXT DEFAULT 'manual';
+
+ALTER TABLE accounts_receivable ADD COLUMN IF NOT EXISTS folio TEXT;
+ALTER TABLE accounts_receivable ADD COLUMN IF NOT EXISTS venta_id INTEGER;

--- a/pos_spj_v13.4/migrations/standalone/061_fix_finanzas_schema.py
+++ b/pos_spj_v13.4/migrations/standalone/061_fix_finanzas_schema.py
@@ -1,0 +1,40 @@
+# migrations/standalone/061_fix_finanzas_schema.py — SPJ ERP
+"""
+FASE 1 Hotfix — columnas faltantes en tablas de finanzas.
+Usa PRAGMA table_info() para compatibilidad con SQLite < 3.35.
+Non-fatal: errores individuales se loguean sin abortar la migración.
+"""
+import logging
+
+logger = logging.getLogger("spj.migrations.061")
+
+
+def run(conn):
+    def _col_exists(table, col):
+        try:
+            rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+            return any(r[1] == col for r in rows)
+        except Exception:
+            return False
+
+    def _add_col(table, col, defn):
+        if not _col_exists(table, col):
+            try:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {defn}")
+                logger.info("061: added %s.%s", table, col)
+            except Exception as e:
+                logger.warning("061: could not add %s.%s: %s", table, col, e)
+
+    _add_col("financial_event_log", "concepto", "TEXT")
+
+    _add_col("accounts_payable", "folio",    "TEXT")
+    _add_col("accounts_payable", "concepto", "TEXT")
+    _add_col("accounts_payable", "ref_type", "TEXT DEFAULT 'manual'")
+
+    _add_col("accounts_receivable", "folio",    "TEXT")
+    _add_col("accounts_receivable", "venta_id", "INTEGER")
+
+    try:
+        conn.commit()
+    except Exception:
+        pass

--- a/pos_spj_v13.4/migrations/standalone/062_bi_analytics_tables.py
+++ b/pos_spj_v13.4/migrations/standalone/062_bi_analytics_tables.py
@@ -1,0 +1,80 @@
+# migrations/standalone/062_bi_analytics_tables.py — SPJ ERP
+"""
+FASE 5 — Tablas BI para AnalyticsEngine.
+Idempotente: todas usan CREATE TABLE IF NOT EXISTS.
+"""
+
+
+def run(conn):
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS bi_sales_daily (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            fecha               TEXT    NOT NULL,
+            sucursal_id         INTEGER NOT NULL DEFAULT 1,
+            total_ventas        REAL    NOT NULL DEFAULT 0,
+            num_transacciones   INTEGER NOT NULL DEFAULT 0,
+            promedio_ticket     REAL    NOT NULL DEFAULT 0,
+            created_at          TEXT    NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(fecha, sucursal_id)
+        )
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_bi_sd_fecha_suc
+            ON bi_sales_daily(fecha, sucursal_id)
+    """)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS bi_product_profit (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            fecha       TEXT    NOT NULL,
+            producto_id INTEGER NOT NULL,
+            ingresos    REAL    NOT NULL DEFAULT 0,
+            costo       REAL    NOT NULL DEFAULT 0,
+            margen      REAL    NOT NULL DEFAULT 0,
+            created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(fecha, producto_id)
+        )
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_bi_pp_fecha
+            ON bi_product_profit(fecha, producto_id)
+    """)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS bi_transformations (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            fecha           TEXT    NOT NULL,
+            sucursal_id     INTEGER NOT NULL DEFAULT 1,
+            categoria       TEXT    NOT NULL DEFAULT '',
+            inputs_json     TEXT    NOT NULL DEFAULT '[]',
+            outputs_json    TEXT    NOT NULL DEFAULT '[]',
+            rendimiento_pct REAL    NOT NULL DEFAULT 0,
+            created_at      TEXT    NOT NULL DEFAULT (datetime('now'))
+        )
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_bi_tr_fecha_suc
+            ON bi_transformations(fecha, sucursal_id)
+    """)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS bi_branch_ranking (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            fecha       TEXT    NOT NULL,
+            sucursal_id INTEGER NOT NULL,
+            rank_ventas INTEGER NOT NULL DEFAULT 0,
+            rank_margen INTEGER NOT NULL DEFAULT 0,
+            score       REAL    NOT NULL DEFAULT 0,
+            created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(fecha, sucursal_id)
+        )
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_bi_br_fecha
+            ON bi_branch_ranking(fecha, sucursal_id)
+    """)
+
+    try:
+        conn.commit()
+    except Exception:
+        pass

--- a/pos_spj_v13.4/migrations/standalone/063_audit_log_table.py
+++ b/pos_spj_v13.4/migrations/standalone/063_audit_log_table.py
@@ -1,0 +1,40 @@
+# migrations/standalone/063_audit_log_table.py — SPJ ERP
+"""
+FASE 7 — Tabla audit_log (columnas en inglés, spec ERP).
+Coexiste con audit_logs (columnas en español, legacy POS) — no se toca ni elimina.
+"""
+
+
+def run(conn):
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS audit_log (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id       INTEGER,
+            action        TEXT    NOT NULL,
+            entity        TEXT    NOT NULL,
+            entity_id     INTEGER,
+            timestamp     TEXT    NOT NULL DEFAULT (datetime('now')),
+            sucursal_id   INTEGER NOT NULL DEFAULT 1,
+            metadata_json TEXT    DEFAULT '{}'
+        )
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_audit_log_user
+            ON audit_log(user_id)
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_audit_log_entity
+            ON audit_log(entity, entity_id)
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp
+            ON audit_log(timestamp)
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_audit_log_sucursal
+            ON audit_log(sucursal_id)
+    """)
+    try:
+        conn.commit()
+    except Exception:
+        pass

--- a/pos_spj_v13.4/modulos/produccion.py
+++ b/pos_spj_v13.4/modulos/produccion.py
@@ -87,16 +87,9 @@ class _DBWrapperProd:
     from contextlib import contextmanager
     @contextmanager
     def transaction(self, name=""):
-        import uuid as _u
-        sp = f"sp_{_u.uuid4().hex[:8]}"
-        self.conn.execute(f"SAVEPOINT {sp}")
-        try:
+        from core.db.connection import transaction as _canonical_tx
+        with _canonical_tx(self.conn):
             yield self
-            self.conn.execute(f"RELEASE SAVEPOINT {sp}")
-        except Exception:
-            try: self.conn.execute(f"ROLLBACK TO SAVEPOINT {sp}")
-            except Exception: pass
-            raise
 
 
 class ModuloProduccion(ModuloBase):

--- a/pos_spj_v13.4/modulos/recepcion_qr_widget.py
+++ b/pos_spj_v13.4/modulos/recepcion_qr_widget.py
@@ -700,10 +700,8 @@ class RecepcionQRWidget(QWidget):
         monto_pagado = float(datos_extra.get("monto_pagado", 0))
         monto_total  = float(datos_extra.get("monto_total", 0))
 
-        import uuid as _u2
-        _sp_qr = f"qr_{_u2.uuid4().hex[:8]}"
-        self.conexion.execute(f"SAVEPOINT {_sp_qr}")
-        try:
+        from core.db.connection import transaction as _tx_qr
+        with _tx_qr(self.conexion):
             # 1. Recepción cabecera
             cur = self.conexion.execute("""
                 INSERT INTO recepciones
@@ -783,35 +781,28 @@ class RecepcionQRWidget(QWidget):
                 """, (self.sucursal_id, uuid_qr))
             except Exception: pass
 
-            self.conexion.execute(f"RELEASE SAVEPOINT {_sp_qr}")
-
-            # Actualizar inventario via ApplicationService
-            _app = getattr(self.container, 'app_service', None) if self.container else None
-            for item in items:
-                try:
-                    pid = item.get("product_id", item.get("producto_id", 0))
-                    qty = float(item.get("cantidad", 0))
-                    costo = float(item.get("costo_unitario", 0))
-                    if _app and pid and qty > 0:
-                        _app.registrar_compra(
-                            producto_id=pid, cantidad=qty,
-                            costo_unitario=costo,
-                            usuario=getattr(self, 'usuario', ''),
-                            sucursal_id=self.sucursal_id)
-                    elif pid and qty > 0:
-                        self.conexion.execute(
-                            "UPDATE productos SET existencia = existencia + ?, "
-                            "precio_compra = CASE WHEN ? > 0 THEN ? ELSE precio_compra END "
-                            "WHERE id = ?",
-                            (qty, costo, costo, pid))
-                except Exception as _ue:
-                    import logging as _lg
-                    _lg.getLogger(__name__).error("QR existencia update: %s", _ue)
-
-        except Exception:
-            try: self.conexion.execute(f"ROLLBACK TO SAVEPOINT {_sp_qr}")
-            except Exception: pass
-            raise
+        # Actualizar inventario via ApplicationService (post-commit)
+        _app = getattr(self.container, 'app_service', None) if self.container else None
+        for item in items:
+            try:
+                pid = item.get("product_id", item.get("producto_id", 0))
+                qty = float(item.get("cantidad", 0))
+                costo = float(item.get("costo_unitario", 0))
+                if _app and pid and qty > 0:
+                    _app.registrar_compra(
+                        producto_id=pid, cantidad=qty,
+                        costo_unitario=costo,
+                        usuario=getattr(self, 'usuario', ''),
+                        sucursal_id=self.sucursal_id)
+                elif pid and qty > 0:
+                    self.conexion.execute(
+                        "UPDATE productos SET existencia = existencia + ?, "
+                        "precio_compra = CASE WHEN ? > 0 THEN ? ELSE precio_compra END "
+                        "WHERE id = ?",
+                        (qty, costo, costo, pid))
+            except Exception as _ue:
+                import logging as _lg
+                _lg.getLogger(__name__).error("QR existencia update: %s", _ue)
 
     def _guardar_asignacion(self) -> None:
         """Guarda la asignación de productos + pago al contenedor."""


### PR DESCRIPTION
…lidad

FASE 0 — Inventario normalizado
- UnifiedInventoryService.process_movement(): wrapper público sobre register_movement() que emite evento 'inventory_movement' al EventBus

FASE 1 — Hotfix SAVEPOINTs y schema
- modulos/produccion.py: _DBWrapperProd.transaction() delega a core.db.connection.transaction() (canónico) en vez de SAVEPOINT raw
- modulos/recepcion_qr_widget.py: bloque SAVEPOINT reemplazado por with transaction(self.conexion): — lógica interna sin cambios
- migrations/standalone/061_fix_finanzas_schema.py: columnas defensivas en financial_event_log, accounts_payable, accounts_receivable
- migrations/fix_finanzas_schema.sql: versión SQL documental

FASE 2 — Domain Events
- core/events/domain_events.py: constantes canónicas ERP (SALE_CREATED, PURCHASE_CREATED, PRODUCTION_EXECUTED, STOCK_UPDATED, INVENTORY_MOVEMENT, PAYMENT_RECEIVED, EXPENSE_REGISTERED)

FASE 3 — AccountingEngine reactivo
- core/services/finance/accounting_engine.py: suscriptor prio=48 SALE_CREATED → asiento 1100/4100, PURCHASE_CREATED → 5100/2100 via FinanceService.registrar_asiento() existente. Non-fatal.

FASE 4 — UnifiedThirdPartyService
- core/services/finance/third_party_service.py: wrapper AP/AR get_balance(), apply_payment() → delega a FinanceService

FASE 5 — AnalyticsEngine + tablas BI
- core/services/analytics/analytics_engine.py: suscriptor prio=5 SALE_CREATED → bi_sales_daily (UPSERT acumulativo) PRODUCTION_EXECUTED → bi_transformations
- migrations/standalone/062_bi_analytics_tables.py: crea bi_sales_daily, bi_product_profit, bi_transformations, bi_branch_ranking

FASE 6 — Deprecación controlada
- inventory_service.py: warning DEPRECATED en __init__
- inventory_engine.py: warning DEPRECATED a nivel módulo

FASE 7 — Audit log ERP
- migrations/standalone/063_audit_log_table.py: tabla audit_log (columnas en inglés) coexiste con audit_logs legacy

Wiring: AppContainer instancia y conecta AccountingEngine, UnifiedThirdPartyService y AnalyticsEngine con try/except non-fatal. migrations/engine.py: registradas migraciones 061, 062, 063.

Tests de humo: PASADOS. Sintaxis global: SIN errores.

https://claude.ai/code/session_019YqsgJ9RMiALnU6ezs8Vty