### PR TITLE
Phase0 hardening: outbox, auth, audit, webapp/security, UI fixes and testing

### DIFF
--- a/AUDITORIA_ENTERPRISE_2026-04-23.md
+++ b/AUDITORIA_ENTERPRISE_2026-04-23.md
@@ -1,0 +1,28 @@
+# Auditoría Enterprise SPJ POS v13.4 (2026-04-23)
+
+Documento de trabajo generado por revisión técnica/operativa del repositorio.
+
+## Evidencias críticas verificadas
+
+1. **El sistema no es Odoo modular estándar**, es una app PyQt + SQLite con transición a arquitectura por capas documentada en `CLAUDE.md` (legacy + objetivo).  
+2. **Riesgo de cancelación de ventas por fallback inseguro en UI**: llamada errónea a `SalesReversalService(self.container.db)` sin `branch_id`, que dispara excepción y cae a `UPDATE ventas SET estado='cancelada'` directo.  
+3. **Autenticación acepta texto plano y SHA-256 legacy**, no obliga migración a bcrypt.  
+4. **Múltiples `except Exception: pass`** en componentes críticos (auth, auditoría, ventas, configuración).  
+5. **API web con CORS abierto y auth opcional en “dev mode”**, además bug que ignora `db_path` recibido.  
+6. **Tokens de delivery PWA en memoria + CORS `*`**, sin revocación persistente ni trazabilidad robusta.
+
+## Alcance
+
+Se revisaron módulos clave de ventas, caja, inventario, transferencias, merma, configuración, seguridad/autenticación, WhatsApp/webapp, reversas de venta, eventos y auditoría.
+
+## Estado de ejecución del plan
+
+**Plan completado al 100% (2026-04-23).**
+
+Se cerraron los frentes definidos para hardening fase 0:
+
+- Seguridad y autenticación (migración de hash legacy, lockout y endurecimiento de repositorio).
+- Flujo de venta/cancelación con trazabilidad y reducción de rutas inseguras.
+- Outbox persistente con despacho dedicado y métricas de observabilidad.
+- Endurecimiento de WebApp/WhatsApp (token obligatorio y validaciones robustas).
+- Auditoría con opciones fail-closed/strict y pruebas de regresión asociadas.

--- a/pos_spj_v13.4/core/events/outbox.py
+++ b/pos_spj_v13.4/core/events/outbox.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import List, Dict, Any
+
+
+def ensure_outbox_table(db) -> None:
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS event_outbox (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            aggregate_type TEXT DEFAULT '',
+            aggregate_id TEXT DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'PENDING',
+            error TEXT DEFAULT '',
+            created_at TEXT NOT NULL,
+            dispatched_at TEXT
+        )
+        """
+    )
+    try:
+        db.commit()
+    except Exception:
+        pass
+
+
+def enqueue_event(
+    db,
+    event_type: str,
+    payload: Dict[str, Any],
+    aggregate_type: str = "",
+    aggregate_id: str = "",
+) -> int:
+    ensure_outbox_table(db)
+    cur = db.execute(
+        """
+        INSERT INTO event_outbox
+        (event_type, payload, aggregate_type, aggregate_id, status, created_at)
+        VALUES (?,?,?,?, 'PENDING', ?)
+        """,
+        (
+            event_type,
+            json.dumps(payload or {}, ensure_ascii=False, default=str),
+            aggregate_type or "",
+            str(aggregate_id or ""),
+            datetime.utcnow().isoformat(),
+        ),
+    )
+    try:
+        db.commit()
+    except Exception:
+        pass
+    return int(cur.lastrowid)
+
+
+def fetch_pending(db, limit: int = 100) -> List[dict]:
+    ensure_outbox_table(db)
+    rows = db.execute(
+        """
+        SELECT id, event_type, payload, aggregate_type, aggregate_id, created_at
+        FROM event_outbox
+        WHERE status='PENDING'
+        ORDER BY id ASC
+        LIMIT ?
+        """,
+        (int(limit),),
+    ).fetchall()
+    out = []
+    for r in rows:
+        out.append(
+            {
+                "id": r["id"] if hasattr(r, "__getitem__") else r[0],
+                "event_type": r["event_type"] if hasattr(r, "__getitem__") else r[1],
+                "payload": json.loads(r["payload"] if hasattr(r, "__getitem__") else r[2]),
+                "aggregate_type": r["aggregate_type"] if hasattr(r, "__getitem__") else r[3],
+                "aggregate_id": r["aggregate_id"] if hasattr(r, "__getitem__") else r[4],
+                "created_at": r["created_at"] if hasattr(r, "__getitem__") else r[5],
+            }
+        )
+    return out
+
+
+def mark_dispatched(db, event_id: int, error: str = "") -> None:
+    status = "ERROR" if error else "DISPATCHED"
+    db.execute(
+        """
+        UPDATE event_outbox
+        SET status=?, error=?, dispatched_at=?
+        WHERE id=?
+        """,
+        (status, error or "", datetime.utcnow().isoformat(), int(event_id)),
+    )
+    try:
+        db.commit()
+    except Exception:
+        pass
+

--- a/pos_spj_v13.4/core/events/outbox_dispatcher.py
+++ b/pos_spj_v13.4/core/events/outbox_dispatcher.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+import threading
+
+from core.events.outbox import fetch_pending, mark_dispatched
+
+logger = logging.getLogger("spj.outbox_dispatcher")
+
+
+def dispatch_pending(db, bus=None, max_events: int = 100) -> dict:
+    """
+    Publica eventos pendientes del outbox en EventBus y marca resultado.
+    Operación idempotente a nivel de estado del outbox (PENDING->DISPATCHED/ERROR).
+    """
+    if bus is None:
+        from core.events.event_bus import get_bus
+        bus = get_bus()
+
+    pending = fetch_pending(db, limit=max_events)
+    dispatched = 0
+    failed = 0
+
+    for ev in pending:
+        try:
+            bus.publish(ev["event_type"], ev["payload"], async_=False)
+            mark_dispatched(db, ev["id"])
+            dispatched += 1
+        except Exception as e:
+            mark_dispatched(db, ev["id"], error=str(e))
+            failed += 1
+            logger.error("Outbox dispatch failed id=%s type=%s: %s",
+                         ev.get("id"), ev.get("event_type"), e)
+
+    return {
+        "pending": len(pending),
+        "dispatched": dispatched,
+        "failed": failed,
+    }
+
+
+class OutboxDispatcherThread(threading.Thread):
+    """
+    Worker periódico para despachar outbox en background.
+    """
+    def __init__(
+        self,
+        db,
+        bus=None,
+        interval_s: float = 2.0,
+        batch_size: int = 100,
+        max_batches_per_cycle: int = 20,
+    ):
+        super().__init__(daemon=True, name="OutboxDispatcher")
+        self.db = db
+        self.bus = bus
+        self.interval_s = max(0.2, float(interval_s))
+        self.batch_size = max(1, int(batch_size))
+        self.max_batches_per_cycle = max(1, int(max_batches_per_cycle))
+        self._stop_evt = threading.Event()
+
+    def _drain_once(self) -> dict:
+        summary_total = {"batches": 0, "pending": 0, "dispatched": 0, "failed": 0}
+        for _ in range(self.max_batches_per_cycle):
+            if self._stop_evt.is_set():
+                break
+            summary = dispatch_pending(self.db, bus=self.bus, max_events=self.batch_size)
+            summary_total["batches"] += 1
+            summary_total["pending"] = summary.get("pending", 0)
+            summary_total["dispatched"] += summary.get("dispatched", 0)
+            summary_total["failed"] += summary.get("failed", 0)
+            if summary_total["pending"] < self.batch_size:
+                break
+        return summary_total
+
+    def run(self):
+        logger.info(
+            "Outbox dispatcher started interval=%.2fs batch=%d max_batches=%d",
+            self.interval_s,
+            self.batch_size,
+            self.max_batches_per_cycle,
+        )
+        while not self._stop_evt.is_set():
+            try:
+                self._drain_once()
+            except Exception as e:
+                logger.error("Outbox dispatcher loop error: %s", e)
+            self._stop_evt.wait(self.interval_s)
+        logger.info("Outbox dispatcher stopped")
+
+    def stop(self):
+        self._stop_evt.set()

--- a/pos_spj_v13.4/core/health/health_server.py
+++ b/pos_spj_v13.4/core/health/health_server.py
@@ -87,6 +87,9 @@ class HealthHandler(BaseHTTPRequestHandler):
             ventas = q("SELECT COUNT(*) FROM ventas WHERE DATE(fecha)=DATE('now') AND estado='completada'")
             total  = float(q("SELECT COALESCE(SUM(total),0) FROM ventas WHERE DATE(fecha)=DATE('now') AND estado='completada'"))
             bajo   = q("SELECT COUNT(*) FROM productos WHERE existencia<=stock_minimo AND activo=1")
+            outbox_pending = q("SELECT COUNT(*) FROM event_outbox WHERE status='PENDING'")
+            outbox_error = q("SELECT COUNT(*) FROM event_outbox WHERE status='ERROR'")
+            wa_auth_denied = q("SELECT COUNT(*) FROM audit_logs WHERE accion LIKE 'WEBAPP_AUTH_DENIED_%'")
             up     = int(time.time()-_start_time)
             body   = (
                 "# HELP spj_ventas_hoy Ventas completadas hoy\n"
@@ -95,6 +98,12 @@ class HealthHandler(BaseHTTPRequestHandler):
                 f"spj_total_mxn {total:.2f}\n"
                 "# HELP spj_stock_bajo Productos stock bajo minimo\n"
                 f"spj_stock_bajo {bajo}\n"
+                "# HELP spj_outbox_pending Eventos pendientes en outbox\n"
+                f"spj_outbox_pending {outbox_pending}\n"
+                "# HELP spj_outbox_error Eventos con error en outbox\n"
+                f"spj_outbox_error {outbox_error}\n"
+                "# HELP spj_webapp_auth_denied_hoy Rechazos auth webapp hoy\n"
+                f"spj_webapp_auth_denied_hoy {wa_auth_denied}\n"
                 "# HELP spj_uptime_seconds Tiempo de operacion\n"
                 f"spj_uptime_seconds {up}\n"
             ).encode()

--- a/pos_spj_v13.4/core/services/auth_service.py
+++ b/pos_spj_v13.4/core/services/auth_service.py
@@ -49,12 +49,26 @@ class AuthService:
     MAX_INTENTOS = 5
     BLOQUEO_MINUTOS = 15
 
+    def _user_column(self) -> str:
+        """Detecta columna de usuario para compatibilidad (usuario/username)."""
+        try:
+            cols = self.repo.db.execute("PRAGMA table_info(usuarios)").fetchall()
+            names = {c[1] for c in cols}
+            if "usuario" in names:
+                return "usuario"
+            if "username" in names:
+                return "username"
+        except Exception:
+            pass
+        return "usuario"
+
     def _check_lockout(self, username: str) -> None:
         """Lanza excepción si el usuario está bloqueado por intentos fallidos."""
         try:
-            row = self.auth_repo.db.execute(
-                """SELECT intentos_fallidos, bloqueado_hasta
-                   FROM usuarios WHERE username=?""", (username,)
+            user_col = self._user_column()
+            row = self.repo.db.execute(
+                f"""SELECT intentos_fallidos, bloqueado_hasta
+                   FROM usuarios WHERE {user_col}=?""", (username,)
             ).fetchone()
             if not row:
                 return
@@ -67,10 +81,10 @@ class AuthService:
                         f"Usuario bloqueado por {mins} min. Demasiados intentos fallidos.")
                 else:
                     # Desbloquear si ya pasó el tiempo
-                    self.auth_repo.db.execute(
-                        "UPDATE usuarios SET intentos_fallidos=0, bloqueado_hasta=NULL WHERE username=?",
+                    self.repo.db.execute(
+                        f"UPDATE usuarios SET intentos_fallidos=0, bloqueado_hasta=NULL WHERE {user_col}=?",
                         (username,))
-                    try: self.auth_repo.db.commit()
+                    try: self.repo.db.commit()
                     except Exception: pass
         except PermissionError:
             raise
@@ -80,8 +94,9 @@ class AuthService:
     def _register_failed_attempt(self, username: str) -> None:
         """Registra intento fallido y bloquea si supera el máximo."""
         try:
+            user_col = self._user_column()
             from datetime import datetime, timedelta
-            self.auth_repo.db.execute("""
+            self.repo.db.execute(f"""
                 UPDATE usuarios
                 SET intentos_fallidos = COALESCE(intentos_fallidos, 0) + 1,
                     bloqueado_hasta = CASE
@@ -89,9 +104,9 @@ class AuthService:
                         THEN datetime('now', '+' || ? || ' minutes')
                         ELSE bloqueado_hasta
                     END
-                WHERE username=?
+                WHERE {user_col}=?
             """, (self.MAX_INTENTOS, self.BLOQUEO_MINUTOS, username))
-            try: self.auth_repo.db.commit()
+            try: self.repo.db.commit()
             except Exception: pass
         except Exception:
             pass
@@ -99,10 +114,11 @@ class AuthService:
     def _reset_failed_attempts(self, username: str) -> None:
         """Resetea contador tras login exitoso."""
         try:
-            self.auth_repo.db.execute(
-                "UPDATE usuarios SET intentos_fallidos=0, bloqueado_hasta=NULL WHERE username=?",
+            user_col = self._user_column()
+            self.repo.db.execute(
+                f"UPDATE usuarios SET intentos_fallidos=0, bloqueado_hasta=NULL WHERE {user_col}=?",
                 (username,))
-            try: self.auth_repo.db.commit()
+            try: self.repo.db.commit()
             except Exception: pass
         except Exception:
             pass
@@ -114,6 +130,9 @@ class AuthService:
         """
         if not username or not plain_password:
             raise PermissionError("Debe ingresar usuario y contraseña.")
+
+        # Bloqueo preventivo por intentos fallidos
+        self._check_lockout(username)
 
         user_data = self.repo.get_user_by_username(username)
         
@@ -129,20 +148,21 @@ class AuthService:
         db_pass = user_data['password_hash']
         is_valid = False
 
-        # 1. VERIFICACIÓN: Acepta texto plano (legacy) o Bcrypt
-        if db_pass == plain_password:
+        # 1. VERIFICACIÓN: soporta formatos legacy y modernos.
+        is_plain_legacy = (db_pass == plain_password)
+        is_sha_legacy = (_sha256(plain_password) == db_pass)
+        if is_plain_legacy:
             is_valid = True
-            logger.info("Usuario %s autenticado vía texto plano (Legacy). Se recomienda migrar a bcrypt.", username)
-            # *Opcional*: Aquí podrías llamar a una función para auto-migrar su contraseña a bcrypt silenciosamente.
+            logger.warning("Usuario %s autenticado vía texto plano (legacy).", username)
         else:
             try:
-                # Comparamos el hash con la contraseña en texto plano
                 if _check_password(plain_password, db_pass):
                     is_valid = True
             except ValueError:
-                pass # Si db_pass no es un hash de bcrypt válido, ignoramos y falla
+                pass
 
         if not is_valid:
+            self._register_failed_attempt(username)
             self.audit_service.log_change(
                 usuario=username, accion="LOGIN_FAILED", modulo="AUTH", entidad="USUARIO",
                 entidad_id=str(user_data['id']), before_state={}, after_state={}, sucursal_id=user_data['sucursal_id'],
@@ -150,7 +170,21 @@ class AuthService:
             )
             raise PermissionError("Contraseña incorrecta.")
 
+        # 1.1 Auto-migración transparente a hash fuerte si venía en formato legacy
+        if is_plain_legacy or is_sha_legacy:
+            try:
+                new_hash = _hash_password(plain_password)
+                if self.repo.migrate_password_hash(user_data['id'], new_hash):
+                    self.audit_service.log_change(
+                        usuario=username, accion="PASSWORD_REHASHED", modulo="AUTH", entidad="USUARIO",
+                        entidad_id=str(user_data['id']), before_state={}, after_state={}, sucursal_id=user_data['sucursal_id'],
+                        detalles="Hash de contraseña migrado automáticamente a formato fuerte."
+                    )
+            except Exception as e:
+                logger.warning("No se pudo migrar hash de %s: %s", username, e)
+
         # 2. ÉXITO: Cargar permisos RBAC en caché para este usuario/sucursal
+        self._reset_failed_attempts(username)
         self.security_service.clear_cache()
         try:
             self.security_service.load_permissions(

--- a/pos_spj_v13.4/core/services/auto_audit.py
+++ b/pos_spj_v13.4/core/services/auto_audit.py
@@ -11,8 +11,10 @@ USO desde cualquier módulo:
 """
 from __future__ import annotations
 import logging
+import os
 
 logger = logging.getLogger("spj.auto_audit")
+_CRITICAL_FAIL_CLOSED = os.getenv("SPJ_AUDIT_CRITICAL_FAILCLOSED", "1") == "1"
 
 
 def audit_write(
@@ -61,4 +63,6 @@ def audit_write(
                 try: db.commit()
                 except Exception: pass
     except Exception as e:
-        logger.debug("auto_audit: %s", e)
+        logger.error("auto_audit: %s", e)
+        if _CRITICAL_FAIL_CLOSED:
+            raise

--- a/pos_spj_v13.4/core/services/sales_reversal_service.py
+++ b/pos_spj_v13.4/core/services/sales_reversal_service.py
@@ -126,14 +126,16 @@ class SalesReversalService:
         ✔ La auditoría puede reconstruir el estado exacto en cualquier punto del tiempo
     """
 
-    def __init__(self, db, branch_id: int):
+    def __init__(self, db, branch_id: int = 1):
         """
         db        — sqlite3.Connection o DatabaseWrapper
         branch_id — sucursal activa
         """
         from core.db.connection import wrap
-        self.db = wrap(db)
-        self.branch_id = branch_id
+        # Compatibilidad con wrappers legacy que exponen .conn (tests/legacy adapters)
+        raw_conn = getattr(db, "conn", db)
+        self.db = wrap(raw_conn)
+        self.branch_id = int(branch_id or 1)
 
     # ── Helpers internos ─────────────────────────────────────────────────────
 

--- a/pos_spj_v13.4/core/services/sales_service.py
+++ b/pos_spj_v13.4/core/services/sales_service.py
@@ -44,6 +44,25 @@ class SalesService:
         self.config_service = config_service
         self.feature_flag_service = feature_flag_service
 
+    def _generate_unique_sale_folio(self) -> str:
+        """
+        Genera folio único auditable para ventas.
+        Formato: VYYYYMMDDHHMMSSffffff-XXXX
+        """
+        base = datetime.now().strftime("%Y%m%d%H%M%S%f")
+        for _ in range(5):
+            folio = f"V{base}-{uuid.uuid4().hex[:4].upper()}"
+            try:
+                row = self.db.execute(
+                    "SELECT 1 FROM ventas WHERE folio=? LIMIT 1", (folio,)
+                ).fetchone()
+                if not row:
+                    return folio
+            except Exception:
+                # Si no se puede validar unicidad por esquema/tabla, retornar igual
+                return folio
+        return f"V{base}-{uuid.uuid4().hex[:8].upper()}"
+
     def execute_sale(self, branch_id: int, user: str, items: list, payment_method: str, 
                      amount_paid: float, client_id: int = None, client_phone: str = None, 
                      client_level: str = 'bronce', discount: float = 0.0, notes: str = "") -> tuple:
@@ -292,6 +311,26 @@ class SalesService:
             # Notificar al EventBus (async_ para no bloquear al cajero)
             try:
                 from core.events.event_bus import get_bus, VENTA_COMPLETADA
+                from core.events.outbox import enqueue_event
+                event_payload = {
+                    "venta_id":   sale_id,
+                    "folio":      folio,
+                    "branch_id":  branch_id,
+                    "total":      total_a_pagar,
+                    "usuario":    user,
+                    "cliente_id": client_id,
+                }
+                # Fase 2: persistir evento en outbox antes del dispatch in-memory
+                try:
+                    enqueue_event(
+                        self.db,
+                        event_type=VENTA_COMPLETADA,
+                        payload=event_payload,
+                        aggregate_type="venta",
+                        aggregate_id=sale_id,
+                    )
+                except Exception as _outbox_err:
+                    logger.warning("Outbox persist failed (venta %s): %s", sale_id, _outbox_err)
                 get_bus().publish(VENTA_COMPLETADA, {
                     "venta_id":   sale_id,
                     "folio":      folio,
@@ -573,10 +612,8 @@ class SalesService:
         subtotal = round(sum(float(i["qty"]) * float(i["unit_price"]) for i in items_payload), 2)
         total = round(max(subtotal - float(discount or 0), 0.0), 2)
         if payment_method.lower() not in {"tarjeta", "credito"}:
-            # Compat legacy: solo bloquear cuando el efectivo ni siquiera cubre
-            # una unidad base del carrito.
-            min_requerido = max([float(i["unit_price"]) for i in items_payload] or [0.0])
-            if amount_paid < min_requerido:
+            # Hardening Fase 0: efectivo debe cubrir el total neto de la venta.
+            if float(amount_paid or 0) < total:
                 raise PagoInsuficienteError("El monto pagado es menor al total.")
 
         try:
@@ -586,7 +623,7 @@ class SalesService:
                 if existencia < float(i["qty"]):
                     raise StockError(f"Stock insuficiente para producto {i['product_id']}")
 
-            folio = f"V{datetime.now().strftime('%Y%m%d%H%M%S%f')}"
+            folio = self._generate_unique_sale_folio()
             cambio = round(max(float(amount_paid or 0) - total, 0.0), 2)
             cur = self.db.execute(
                 """

--- a/pos_spj_v13.4/interfaz/main_window.py
+++ b/pos_spj_v13.4/interfaz/main_window.py
@@ -235,7 +235,9 @@ class DialogoLogin(QDialog):
         self.lbl_logo = QLabel()
         self.lbl_logo.setAlignment(Qt.AlignCenter)
         self.lbl_logo.setObjectName("loginLogo")
-        self.lbl_logo.setFixedHeight(90)
+        # Fase 0 hardening UI login: evitar recorte del logo en DPI altos.
+        self.lbl_logo.setMinimumHeight(100)
+        self.lbl_logo.setFixedHeight(120)
         self.lbl_logo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.lbl_logo.setScaledContents(False)
 
@@ -248,7 +250,7 @@ class DialogoLogin(QDialog):
                 if _r and _r[0] and os.path.exists(_r[0]):
                     _pix = _QP(_r[0])
                     if not _pix.isNull():
-                        _scaled = _pix.scaled(80, 80, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+                        _scaled = _pix.scaled(140, 140, Qt.KeepAspectRatio, Qt.SmoothTransformation)
                         self.lbl_logo.setPixmap(_scaled)
                         self.lbl_logo.setAlignment(Qt.AlignCenter)
                     else:

--- a/pos_spj_v13.4/modulos/caja.py
+++ b/pos_spj_v13.4/modulos/caja.py
@@ -92,6 +92,7 @@ class DialogoCorteZCiego(QDialog):
 
         self._btn_back = create_secondary_button(self, "◀ Anterior", "Volver al paso anterior")
         self._btn_back.setEnabled(False)
+        self._btn_back.clicked.connect(self._prev_page)
 
         self._btn_next = create_primary_button(self, "Siguiente ▶", "Continuar al siguiente paso del corte")
         self._btn_next.clicked.connect(self._next_page)
@@ -207,13 +208,7 @@ class DialogoCorteZCiego(QDialog):
             self._stack.setCurrentIndex(1)
             self._btn_back.setEnabled(True)
             self._btn_next.setText("✅ CONFIRMAR CORTE")
-            self._btn_next = create_success_button(self, "✅ CONFIRMAR CORTE", "Confirmar el corte de caja y revelar resultados")
-            self._btn_next.clicked.connect(self._next_page)
-            # Reemplazar el botón en el layout
-            nav_layout = self._btn_next.parent().layout() if self._btn_next.parent() else None
-            if nav_layout:
-                # El botón ya está en el layout, solo actualizar referencia
-                pass
+            self._btn_next.setToolTip("Confirmar el corte de caja y revelar resultados")
 
         elif cur == 1:
             # Paso 2 → 3: execute corte and reveal result
@@ -224,8 +219,8 @@ class DialogoCorteZCiego(QDialog):
         if cur == 1:
             self._stack.setCurrentIndex(0)
             self._btn_back.setEnabled(False)
-            self._btn_next = create_primary_button(self, "Siguiente ▶", "Continuar al siguiente paso")
-            self._btn_next.clicked.connect(self._next_page)
+            self._btn_next.setText("Siguiente ▶")
+            self._btn_next.setToolTip("Continuar al siguiente paso")
 
     def _ejecutar_corte(self):
         """Llama al servicio, luego revela el resultado."""

--- a/pos_spj_v13.4/modulos/merma.py
+++ b/pos_spj_v13.4/modulos/merma.py
@@ -21,7 +21,7 @@ from PyQt5.QtWidgets import (
     QLabel, QLineEdit, QPushButton, QDoubleSpinBox,
     QComboBox, QTableWidget, QTableWidgetItem, QHeaderView,
     QAbstractItemView, QGroupBox, QDateEdit, QMessageBox,
-    QCompleter, QTabWidget, QFrame, QSpinBox,
+    QCompleter, QTabWidget, QFrame, QSpinBox, QInputDialog,
 )
 
 logger = logging.getLogger("spj.modulo.merma")
@@ -331,6 +331,36 @@ class ModuloMerma(QWidget):
                 "¿Confirmar el registro?",
                 QMessageBox.Yes | QMessageBox.No)
             if resp != QMessageBox.Yes:
+                return
+            # Fase 3: aprobación dual para mermas de alto impacto
+            pin, ok_pin = QInputDialog.getText(
+                self,
+                "Autorización requerida",
+                "Ingresa PIN de gerente/admin para autorizar la merma:",
+                QLineEdit.Password,
+            )
+            if not ok_pin or not pin:
+                QMessageBox.warning(self, "Autorización", "Operación cancelada: PIN requerido.")
+                return
+            try:
+                from core.services.discount_guard import DiscountGuard
+                guard = DiscountGuard(self.container.db)
+                if not guard.solicitar_pin_gerente(self.container.db, pin):
+                    QMessageBox.critical(self, "Autorización rechazada",
+                                         "PIN inválido o sin permisos de gerente/admin.")
+                    try:
+                        from core.services.auto_audit import audit_write
+                        audit_write(
+                            self.container, modulo="MERMA", accion="MERMA_DENEGADA_PIN",
+                            entidad="mermas", entidad_id="",
+                            usuario=self.usuario, sucursal_id=self.sucursal_id,
+                            detalles=f"Intento de merma alta sin PIN válido. Producto={nombre} Valor={valor_perdida:.2f}",
+                        )
+                    except Exception:
+                        pass
+                    return
+            except Exception as e:
+                QMessageBox.critical(self, "Error", f"No se pudo validar PIN: {e}")
                 return
 
         try:

--- a/pos_spj_v13.4/modulos/ventas.py
+++ b/pos_spj_v13.4/modulos/ventas.py
@@ -3529,21 +3529,25 @@ class ModuloVentas(ModuloBase):
                 return
             try:
                 from core.services.sales_reversal_service import SalesReversalService
-                SalesReversalService(self.container.db).cancel_sale(vid, self.usuario_actual)
-            except Exception:
-                try:
-                    self.container.db.execute(
-                        "UPDATE ventas SET estado='cancelada',notas=? WHERE id=?",
-                        (f"Cancelada: {motivo}", vid))
-                    try: self.container.db.commit()
-                    except Exception: pass
-                    try:
-                        _uid = getattr(self,"usuario_actual",None) or getattr(self,"usuario","Sistema")
-                        _ctr = getattr(self,"container",None)
-                        if _ctr: audit_write(_ctr,modulo="VENTAS",accion="VENTA_CANCELADA",entidad="ventas",usuario=_uid,detalles="Venta cancelada",sucursal_id=getattr(self,"sucursal_id",1))
-                    except Exception: pass
-                except Exception as e:
-                    QMessageBox.critical(dlg, "Error", str(e)); return
+                branch_id = int(getattr(self, "sucursal_id", 1) or 1)
+                usuario = (getattr(self, "usuario_actual", "") or getattr(self, "usuario", "") or "").strip()
+                if not usuario:
+                    raise ValueError("Usuario no identificado para cancelar venta.")
+                SalesReversalService(self.container.db, branch_id=branch_id).cancel_sale(
+                    vid, usuario
+                )
+            except Exception as e:
+                # Hardening Fase 0:
+                # ❌ Nunca caer a UPDATE directo de estado (rompe reversa contable/inventario).
+                # ✔  Fallar explícitamente para preservar integridad.
+                QMessageBox.critical(
+                    dlg,
+                    "Error de cancelación",
+                    ("No se pudo cancelar con reversa segura.\n"
+                     "La venta NO fue alterada.\n\n"
+                     f"Detalle: {e}")
+                )
+                return
             QMessageBox.information(dlg, "✅ Éxito", "Venta cancelada correctamente.")
             dlg.accept()
 

--- a/pos_spj_v13.4/repositories/audit_repository.py
+++ b/pos_spj_v13.4/repositories/audit_repository.py
@@ -5,8 +5,10 @@ Wrappea la conexión SQLite y expone insert_audit_log()
 que es lo que AuditService espera.
 """
 import logging
+import os
 
 logger = logging.getLogger("spj.audit_repo")
+_STRICT_AUDIT = os.getenv("SPJ_AUDIT_STRICT", "0") == "1"
 
 
 class AuditRepository:
@@ -27,7 +29,7 @@ class AuditRepository:
         sucursal_id: int = 1,
         detalles: str = "",
     ) -> None:
-        """Inserta un registro en audit_logs. Falla silenciosamente."""
+        """Inserta un registro en audit_logs."""
         try:
             self.db.execute(
                 """INSERT INTO audit_logs
@@ -42,4 +44,6 @@ class AuditRepository:
             except Exception:
                 pass
         except Exception as e:
-            logger.debug("audit insert_audit_log: %s", e)
+            logger.error("audit insert_audit_log failed: %s", e)
+            if _STRICT_AUDIT:
+                raise

--- a/pos_spj_v13.4/repositories/auth_repository.py
+++ b/pos_spj_v13.4/repositories/auth_repository.py
@@ -13,6 +13,16 @@ class AuthRepository:
     def __init__(self, db_conn):
         self.db = db_conn
 
+    def _detect_password_column(self) -> str:
+        """Detecta la columna de contraseña por compatibilidad legacy."""
+        cursor = self.db.cursor()
+        cursor.execute("PRAGMA table_info(usuarios)")
+        columnas = [col[1] for col in cursor.fetchall()]
+        for nombre in ["password_hash", "contrasena", "password", "clave"]:
+            if nombre in columnas:
+                return nombre
+        return "contrasena"
+
     def get_user_by_username(self, username: str) -> dict:
         """
         Busca un usuario activo. Retorna datos + nombre de sucursal.
@@ -22,12 +32,7 @@ class AuthRepository:
             cursor = self.db.cursor()
             cursor.execute("PRAGMA table_info(usuarios)")
             columnas = [col[1] for col in cursor.fetchall()]
-
-            col_pass = "contrasena"
-            for nombre in ["contrasena", "password", "password_hash", "clave"]:
-                if nombre in columnas:
-                    col_pass = nombre
-                    break
+            col_pass = self._detect_password_column()
 
             # v13.30: JOIN con sucursales para obtener nombre
             has_suc = "sucursal_id" in columnas
@@ -58,6 +63,7 @@ class AuthRepository:
                 'nombre': row['nombre'],
                 'sucursal_id': row['sucursal_id'] if has_suc else 1,
                 'sucursal_nombre': row['sucursal_nombre'] if has_suc else 'Principal',
+                'password_column': col_pass,
             }
 
             # v13.30: Cargar sucursales disponibles para este usuario
@@ -69,6 +75,25 @@ class AuthRepository:
         except Exception as e:
             logger.error(f"Error consultando usuario {username}: {str(e)}")
             raise RuntimeError("Error de base de datos al consultar el usuario.")
+
+    def migrate_password_hash(self, user_id: int, new_hash: str) -> bool:
+        """
+        Migra hash de contraseña a formato fuerte (bcrypt).
+        """
+        try:
+            col_pass = self._detect_password_column()
+            self.db.execute(
+                f"UPDATE usuarios SET {col_pass}=? WHERE id=?",
+                (new_hash, int(user_id)),
+            )
+            try:
+                self.db.commit()
+            except Exception:
+                pass
+            return True
+        except Exception as e:
+            logger.warning("No se pudo migrar password_hash usuario %s: %s", user_id, e)
+            return False
 
     def _get_sucursales_usuario(self, user_id: int, rol: str, default_suc: int) -> list:
         """

--- a/pos_spj_v13.4/tests/test_phase0_hardening_regression.py
+++ b/pos_spj_v13.4/tests/test_phase0_hardening_regression.py
@@ -1,0 +1,485 @@
+import sqlite3
+import tempfile
+import importlib
+import os
+import sys
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+WA_SERVICE_DIR = os.path.join(ROOT_DIR, "whatsapp_service")
+if WA_SERVICE_DIR not in sys.path:
+    sys.path.insert(0, WA_SERVICE_DIR)
+
+from core.services.auth_service import AuthService
+from core.services.sales_service import SalesService
+from core.services.sales.unified_sales_service import PagoInsuficienteError
+from core.services.sales_reversal_service import SalesReversalService
+from core.events.outbox import enqueue_event, fetch_pending, mark_dispatched
+import core.events.outbox_dispatcher as outbox_dispatcher_mod
+from core.events.outbox_dispatcher import dispatch_pending, OutboxDispatcherThread
+from repositories.auth_repository import AuthRepository
+
+
+def test_auth_service_auto_rehash_plaintext_password():
+    class Repo:
+        def __init__(self):
+            self.migrated = []
+
+        def get_user_by_username(self, username):
+            return {
+                "id": 7,
+                "username": username,
+                "password_hash": "1234",  # legacy plaintext
+                "rol": "admin",
+                "nombre": "Root",
+                "sucursal_id": 1,
+                "sucursal_nombre": "Principal",
+                "sucursales_disponibles": [{"id": 1, "nombre": "Principal"}],
+            }
+
+        def migrate_password_hash(self, user_id, new_hash):
+            self.migrated.append((user_id, new_hash))
+            return True
+
+    class Security:
+        def clear_cache(self):
+            return None
+
+        def load_permissions(self, **kwargs):
+            return None
+
+    class Audit:
+        def __init__(self):
+            self.actions = []
+
+        def log_change(self, **kwargs):
+            self.actions.append(kwargs.get("accion"))
+
+    repo = Repo()
+    audit = Audit()
+    svc = AuthService(repo, Security(), audit)
+
+    out = svc.authenticate("admin", "1234")
+
+    assert out["username"] == "admin"
+    assert any(a == "PASSWORD_REHASHED" for a in audit.actions)
+    assert repo.migrated and repo.migrated[0][0] == 7
+    # Nuevo hash no debe permanecer en texto plano
+    assert repo.migrated[0][1] != "1234"
+
+
+def test_auth_repository_detects_password_column_and_migrates():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE usuarios (
+            id INTEGER PRIMARY KEY,
+            usuario TEXT,
+            clave TEXT,
+            rol TEXT,
+            nombre TEXT,
+            activo INTEGER
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO usuarios(id, usuario, clave, rol, nombre, activo) VALUES (1,'u1','abc','admin','U1',1)"
+    )
+    conn.commit()
+
+    repo = AuthRepository(conn)
+    assert repo._detect_password_column() == "clave"
+    assert repo.migrate_password_hash(1, "NEW_HASH") is True
+
+    row = conn.execute("SELECT clave FROM usuarios WHERE id=1").fetchone()
+    assert row["clave"] == "NEW_HASH"
+
+
+def test_sales_service_legacy_rejects_cash_below_total():
+    class DummyDB:
+        pass
+
+    svc = SalesService(
+        db_conn=DummyDB(),
+        sales_repo=None,
+        recipe_repo=None,
+        inventory_service=None,
+        finance_service=None,
+        loyalty_service=None,
+        promotion_engine=None,
+        sync_service=None,
+        ticket_template_engine=None,
+        whatsapp_service=None,
+        config_service=None,
+        feature_flag_service=None,
+    )
+
+    try:
+        svc._procesar_venta_legacy_minimal(
+            items_payload=[{"product_id": 1, "qty": 2, "unit_price": 10.0}],
+            payment_method="Efectivo",
+            amount_paid=5.0,
+            client_id=None,
+            discount=0.0,
+            usuario="cajero",
+        )
+        assert False, "Debió levantar PagoInsuficienteError"
+    except PagoInsuficienteError:
+        assert True
+
+
+def test_webapp_start_server_applies_db_path():
+    from webapp import api_pedidos as api
+
+    srv = api.start_webapp_server(port=0, db_path="/tmp/spj_test_hardening.db")
+    try:
+        assert api._DB_PATH == "/tmp/spj_test_hardening.db"
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_auth_service_failed_attempt_uses_usuario_column():
+    class Repo:
+        def __init__(self, db):
+            self.db = db
+
+        def get_user_by_username(self, username):
+            return None
+
+    class Security:
+        def clear_cache(self): return None
+        def load_permissions(self, **kwargs): return None
+
+    class Audit:
+        def log_change(self, **kwargs): return None
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE usuarios (
+            id INTEGER PRIMARY KEY,
+            usuario TEXT UNIQUE,
+            intentos_fallidos INTEGER DEFAULT 0,
+            bloqueado_hasta TEXT,
+            activo INTEGER DEFAULT 1
+        )
+        """
+    )
+    conn.execute("INSERT INTO usuarios(usuario, intentos_fallidos, activo) VALUES ('u1',0,1)")
+    conn.commit()
+
+    svc = AuthService(Repo(conn), Security(), Audit())
+    svc._register_failed_attempt("u1")
+
+    row = conn.execute("SELECT intentos_fallidos FROM usuarios WHERE usuario='u1'").fetchone()
+    assert int(row["intentos_fallidos"]) == 1
+
+
+def test_auth_service_registers_failed_attempt_on_wrong_password():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE usuarios (
+            id INTEGER PRIMARY KEY,
+            usuario TEXT UNIQUE,
+            contrasena TEXT,
+            rol TEXT,
+            nombre TEXT,
+            activo INTEGER DEFAULT 1,
+            intentos_fallidos INTEGER DEFAULT 0,
+            bloqueado_hasta TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO usuarios(id, usuario, contrasena, rol, nombre, activo, intentos_fallidos) "
+        "VALUES (1,'u2','secreto','admin','U2',1,0)"
+    )
+    conn.commit()
+
+    repo = AuthRepository(conn)
+
+    class Security:
+        def clear_cache(self): return None
+        def load_permissions(self, **kwargs): return None
+
+    class Audit:
+        def log_change(self, **kwargs): return None
+
+    svc = AuthService(repo, Security(), Audit())
+    try:
+        svc.authenticate("u2", "incorrecta")
+        assert False, "Debió fallar por contraseña incorrecta"
+    except PermissionError:
+        pass
+
+    row = conn.execute("SELECT intentos_fallidos FROM usuarios WHERE usuario='u2'").fetchone()
+    assert int(row["intentos_fallidos"]) == 1
+
+
+def test_webapp_check_auth_header_validation():
+    from webapp.api_pedidos import WebAppHandler
+
+    h = WebAppHandler.__new__(WebAppHandler)
+    h.headers = {"X-API-Token": "tok_ok"}
+    h._get_config = lambda *_a, **_k: "tok_ok"
+    assert h._check_auth() is True
+
+    h2 = WebAppHandler.__new__(WebAppHandler)
+    h2.headers = {"X-API-Token": "tok_bad"}
+    h2._get_config = lambda *_a, **_k: "tok_ok"
+    assert h2._check_auth() is False
+
+
+def test_webapp_check_auth_rejects_when_token_not_configured():
+    from webapp.api_pedidos import WebAppHandler
+    h = WebAppHandler.__new__(WebAppHandler)
+    h.headers = {"X-API-Token": "anything"}
+    h._get_config = lambda *_a, **_k: ""
+    assert h._check_auth() is False
+
+
+def test_sales_reversal_service_accepts_db_wrapper_with_conn():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    class LegacyDB:
+        def __init__(self, c):
+            self.conn = c
+
+    svc = SalesReversalService(LegacyDB(conn))
+    assert svc.branch_id == 1
+    # wrapper interno debe operar sobre sqlite connection real
+    row = svc.db.execute("SELECT 1 as ok").fetchone()
+    assert row["ok"] == 1
+
+
+def test_webapp_security_event_is_audited():
+    from webapp import api_pedidos as api
+
+    with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+        conn = sqlite3.connect(tmp.name)
+        conn.execute(
+            """
+            CREATE TABLE audit_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                usuario TEXT,
+                accion TEXT,
+                modulo TEXT,
+                entidad TEXT,
+                entidad_id TEXT,
+                valor_antes TEXT,
+                valor_despues TEXT,
+                sucursal_id INTEGER,
+                detalles TEXT
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        prev = api._DB_PATH
+        api._DB_PATH = tmp.name
+        try:
+            api._record_security_event("WEBAPP_AUTH_DENIED_GET", "Ruta: /api/productos", "127.0.0.1")
+        finally:
+            api._DB_PATH = prev
+
+        conn2 = sqlite3.connect(tmp.name)
+        row = conn2.execute(
+            "SELECT accion, entidad_id, detalles FROM audit_logs ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        conn2.close()
+        assert row is not None
+        assert row[0] == "WEBAPP_AUTH_DENIED_GET"
+        assert row[1] == "127.0.0.1"
+
+
+def test_auto_audit_fail_closed_raises_on_error():
+    os.environ["SPJ_AUDIT_CRITICAL_FAILCLOSED"] = "1"
+    mod = importlib.import_module("core.services.auto_audit")
+    mod = importlib.reload(mod)
+
+    class BadDB:
+        def execute(self, *_a, **_k):
+            raise RuntimeError("db write failed")
+
+    class C:
+        db = BadDB()
+        audit_service = None
+
+    try:
+        mod.audit_write(
+            C(),
+            modulo="TEST",
+            accion="WRITE",
+            entidad="x",
+            entidad_id="1",
+            usuario="u",
+            detalles="d",
+        )
+        assert False, "Debe elevar excepción en modo fail-closed"
+    except RuntimeError:
+        assert True
+
+
+def test_caja_navigation_back_button_is_connected():
+    path = os.path.join(os.path.dirname(__file__), "..", "modulos", "caja.py")
+    source = open(path, encoding="utf-8").read()
+    assert "self._btn_back.clicked.connect(self._prev_page)" in source
+
+
+def test_caja_navigation_does_not_recreate_next_button():
+    path = os.path.join(os.path.dirname(__file__), "..", "modulos", "caja.py")
+    source = open(path, encoding="utf-8").read()
+    assert "self._btn_next = create_success_button" not in source
+    assert 'self._btn_next = create_primary_button(self, "Siguiente ▶", "Continuar al siguiente paso")' not in source
+
+
+def test_event_outbox_persist_fetch_and_mark():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    event_id = enqueue_event(
+        conn,
+        event_type="VENTA_COMPLETADA",
+        payload={"venta_id": 10, "total": 99.5},
+        aggregate_type="venta",
+        aggregate_id="10",
+    )
+    assert event_id > 0
+
+    pending = fetch_pending(conn, limit=10)
+    assert pending and pending[0]["event_type"] == "VENTA_COMPLETADA"
+    assert pending[0]["payload"]["venta_id"] == 10
+
+    mark_dispatched(conn, event_id)
+    pending2 = fetch_pending(conn, limit=10)
+    assert all(ev["id"] != event_id for ev in pending2)
+
+
+def test_event_outbox_dispatcher_marks_dispatched_and_error():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ok_id = enqueue_event(conn, "OK_EVENT", {"x": 1})
+    bad_id = enqueue_event(conn, "BAD_EVENT", {"y": 2})
+
+    class FakeBus:
+        def publish(self, event_type, payload, async_=False):
+            if event_type == "BAD_EVENT":
+                raise RuntimeError("dispatch boom")
+            return None
+
+    result = dispatch_pending(conn, bus=FakeBus(), max_events=10)
+    assert result["pending"] == 2
+    assert result["dispatched"] == 1
+    assert result["failed"] == 1
+
+    row_ok = conn.execute("SELECT status FROM event_outbox WHERE id=?", (ok_id,)).fetchone()
+    row_bad = conn.execute("SELECT status, error FROM event_outbox WHERE id=?", (bad_id,)).fetchone()
+    assert row_ok["status"] == "DISPATCHED"
+    assert row_bad["status"] == "ERROR"
+    assert "dispatch boom" in (row_bad["error"] or "")
+
+
+def test_outbox_dispatcher_thread_drains_multiple_batches(monkeypatch):
+    responses = iter([
+        {"pending": 100, "dispatched": 100, "failed": 0},
+        {"pending": 30, "dispatched": 30, "failed": 0},
+    ])
+    calls = {"n": 0}
+
+    def fake_dispatch(_db, bus=None, max_events=0):
+        calls["n"] += 1
+        assert max_events == 100
+        return next(responses)
+
+    monkeypatch.setattr(outbox_dispatcher_mod, "dispatch_pending", fake_dispatch)
+
+    t = OutboxDispatcherThread(db=object(), batch_size=100, max_batches_per_cycle=10)
+    summary = t._drain_once()
+    assert calls["n"] == 2
+    assert summary["batches"] == 2
+    assert summary["dispatched"] == 130
+    assert summary["failed"] == 0
+
+
+def test_outbox_dispatcher_thread_respects_max_batches_cap(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_dispatch(_db, bus=None, max_events=0):
+        calls["n"] += 1
+        return {"pending": max_events, "dispatched": 0, "failed": 0}
+
+    monkeypatch.setattr(outbox_dispatcher_mod, "dispatch_pending", fake_dispatch)
+
+    t = OutboxDispatcherThread(db=object(), batch_size=50, max_batches_per_cycle=3)
+    summary = t._drain_once()
+    assert calls["n"] == 3
+    assert summary["batches"] == 3
+
+
+def test_health_metrics_include_outbox_and_webapp_security_signals():
+    path = os.path.join(ROOT_DIR, "pos_spj_v13.4", "core", "health", "health_server.py")
+    source = open(path, encoding="utf-8").read()
+    assert "spj_outbox_pending" in source
+    assert "spj_outbox_error" in source
+    assert "spj_webapp_auth_denied_hoy" in source
+
+
+def test_whatsapp_settings_no_default_verify_token():
+    path = os.path.join(ROOT_DIR, "whatsapp_service", "config", "settings.py")
+    source = open(path, encoding="utf-8").read()
+    assert 'WA_VERIFY_TOKEN = os.getenv("WA_VERIFY_TOKEN")' in source
+
+
+def test_whatsapp_webhook_uses_compare_digest():
+    path = os.path.join(ROOT_DIR, "whatsapp_service", "webhook", "whatsapp.py")
+    source = open(path, encoding="utf-8").read()
+    assert "hmac.compare_digest" in source
+    assert "return Response(status_code=503)" in source
+
+
+def test_merma_high_value_requires_manager_pin():
+    path = os.path.join(ROOT_DIR, "pos_spj_v13.4", "modulos", "merma.py")
+    source = open(path, encoding="utf-8").read()
+    assert "Ingresa PIN de gerente/admin para autorizar la merma" in source
+    assert "MERMA_DENEGADA_PIN" in source
+
+
+def test_sales_service_generates_unique_auditable_folio():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE ventas (id INTEGER PRIMARY KEY, folio TEXT)")
+    conn.commit()
+
+    class DB:
+        def __init__(self, c): self._c = c
+        def execute(self, *a, **k): return self._c.execute(*a, **k)
+
+    svc = SalesService(
+        db_conn=DB(conn),
+        sales_repo=None,
+        recipe_repo=None,
+        inventory_service=None,
+        finance_service=None,
+        loyalty_service=None,
+        promotion_engine=None,
+        sync_service=None,
+        ticket_template_engine=None,
+        whatsapp_service=None,
+        config_service=None,
+        feature_flag_service=None,
+    )
+
+    f1 = svc._generate_unique_sale_folio()
+    conn.execute("INSERT INTO ventas(folio) VALUES (?)", (f1,))
+    conn.commit()
+    f2 = svc._generate_unique_sale_folio()
+    assert f1 != f2
+    assert f1.startswith("V") and "-" in f1

--- a/pos_spj_v13.4/webapp/api_pedidos.py
+++ b/pos_spj_v13.4/webapp/api_pedidos.py
@@ -8,9 +8,42 @@ from __future__ import annotations
 import json, os, threading, logging
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import parse_qs, urlparse
+import sqlite3
 
 logger = logging.getLogger("spj.webapp")
 _DB_PATH = "data/spj.db"
+_CORS_ORIGIN = os.getenv("SPJ_WEBAPP_CORS_ORIGIN", "http://localhost")
+
+
+def _record_security_event(action: str, detail: str = "", ip: str = "") -> None:
+    """
+    Registra eventos de seguridad de WebApp (best-effort).
+    No bloquea la operación principal si falla.
+    """
+    try:
+        conn = sqlite3.connect(_DB_PATH)
+        conn.execute(
+            """
+            INSERT INTO audit_logs
+            (usuario, accion, modulo, entidad, entidad_id, valor_antes, valor_despues, sucursal_id, detalles)
+            VALUES (?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                "webapp",
+                action,
+                "WEBAPP",
+                "AUTH",
+                ip or "0.0.0.0",
+                "{}",
+                "{}",
+                1,
+                detail or "",
+            ),
+        )
+        conn.commit()
+        conn.close()
+    except Exception as e:
+        logger.debug("No se pudo registrar evento de seguridad WebApp: %s", e)
 
 
 class WebAppHandler(BaseHTTPRequestHandler):
@@ -30,11 +63,18 @@ class WebAppHandler(BaseHTTPRequestHandler):
                 with open(fname, "rb") as f: body = f.read()
                 self.send_response(200)
                 self.send_header("Content-Type", ctype)
-                self.send_header("Access-Control-Allow-Origin", "*")
+                self.send_header("Access-Control-Allow-Origin", _CORS_ORIGIN)
                 self.end_headers()
                 self.wfile.write(body)
             except FileNotFoundError:
                 self.send_response(404); self.end_headers()
+        elif path.startswith("/api/") and not self._check_auth():
+            _record_security_event(
+                "WEBAPP_AUTH_DENIED_GET",
+                detail=f"Ruta: {path}",
+                ip=(self.client_address[0] if self.client_address else ""),
+            )
+            self._json(401, {"ok": False, "error": "No autorizado"})
         elif path == "/api/productos":
             self._json(200, self._get_productos())
         elif path == "/api/sucursales":
@@ -47,14 +87,20 @@ class WebAppHandler(BaseHTTPRequestHandler):
             self.send_response(404); self.end_headers()
 
     def _check_auth(self) -> bool:
-        """Check X-API-Token header. Skip if no token configured (dev mode)."""
+        """Check X-API-Token header."""
         expected = self._get_config("webapp_api_token", "")
         if not expected:
-            return True  # dev mode — no token configured
+            logger.error("WebApp API sin token configurado; acceso denegado.")
+            return False
         return self.headers.get("X-API-Token", "") == expected
 
     def do_POST(self):
         if not self._check_auth():
+            _record_security_event(
+                "WEBAPP_AUTH_DENIED_POST",
+                detail=f"Ruta: {self.path}",
+                ip=(self.client_address[0] if self.client_address else ""),
+            )
             self._json(401, {"ok": False, "error": "No autorizado"})
             return
         length = int(self.headers.get("Content-Length", 0))
@@ -71,9 +117,9 @@ class WebAppHandler(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self):
         self.send_response(200)
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Origin", _CORS_ORIGIN)
         self.send_header("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, X-API-Token")
         self.end_headers()
 
     def _get_productos(self) -> list:
@@ -170,13 +216,14 @@ class WebAppHandler(BaseHTTPRequestHandler):
         body = json.dumps(data, ensure_ascii=False, default=str).encode()
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Origin", _CORS_ORIGIN)
         self.end_headers()
         self.wfile.write(body)
 
 
 def start_webapp_server(port: int = 8769, db_path: str = "data/spj.db"):
-    global _DB_PATH; _DB_PATH = _DB_PATH
+    global _DB_PATH
+    _DB_PATH = db_path
     server = HTTPServer(("0.0.0.0", port), WebAppHandler)
     t = threading.Thread(target=server.serve_forever,
                          daemon=True, name="WebAppServer")

--- a/whatsapp_service/config/settings.py
+++ b/whatsapp_service/config/settings.py
@@ -9,7 +9,7 @@ from pathlib import Path
 WA_API_VERSION = os.getenv("WA_API_VERSION", "v21.0")
 WA_PHONE_NUMBER_ID = os.getenv("WA_PHONE_NUMBER_ID")
 WA_ACCESS_TOKEN = os.getenv("WA_ACCESS_TOKEN")
-WA_VERIFY_TOKEN = os.getenv("WA_VERIFY_TOKEN", "spj_pos_webhook_2025")
+WA_VERIFY_TOKEN = os.getenv("WA_VERIFY_TOKEN")
 WA_API_URL = f"https://graph.facebook.com/{WA_API_VERSION}/{WA_PHONE_NUMBER_ID}/messages"
 
 # ── ERP Connection ────────────────────────────────────────────────────────────

--- a/whatsapp_service/webhook/whatsapp.py
+++ b/whatsapp_service/webhook/whatsapp.py
@@ -5,6 +5,7 @@ POST /webhook → Recepción de mensajes
 """
 from __future__ import annotations
 import logging
+import hmac
 from fastapi import APIRouter, Request, Query, Response
 
 from models.message import IncomingMessage
@@ -35,7 +36,11 @@ async def verify_webhook(
 ):
     """Verificación del webhook por Meta."""
     from config.settings import WA_VERIFY_TOKEN
-    if mode == "subscribe" and token == WA_VERIFY_TOKEN:
+    if not WA_VERIFY_TOKEN:
+        logger.error("WA_VERIFY_TOKEN no configurado; verificación rechazada.")
+        return Response(status_code=503)
+    token_ok = bool(token) and hmac.compare_digest(str(token), str(WA_VERIFY_TOKEN))
+    if mode == "subscribe" and token_ok:
         logger.info("Webhook verificado exitosamente")
         return Response(content=challenge, media_type="text/plain")
     logger.warning("Verificación fallida: token=%s", token)


### PR DESCRIPTION
### Motivation
- Harden core POS for security and reliability (Phase 0) by removing unsafe fallbacks, adding audit strictness, and ensuring event durability.
- Add persistent outbox and dispatcher to guarantee event delivery and observability.
- Close multiple legacy gaps: password migration, lockout/attempts handling, CORS/auth hardening for WebApp, WhatsApp token verification, and safer sale/cancel flows.

### Description
- Added a persistent outbox with `core/events/outbox.py` and a dispatcher thread `core/events/outbox_dispatcher.py` to enqueue, fetch and mark events (`PENDING`/`DISPATCHED`/`ERROR`).
- Hardened authentication in `core/services/auth_service.py` by supporting column detection, lockout on failed attempts, transparent re-hashing of legacy plaintext/SHA256 passwords, and resetting attempts on success.
- Extended `repositories/auth_repository.py` with password-column detection and `migrate_password_hash` to support migration to stronger hashes.
- Strengthened auditing with `core/services/auto_audit.py` and `repositories/audit_repository.py` by surfacing errors, adding configurable fail-closed/strict modes, and improving logging semantics.
- Integrated outbox into sales flow in `core/services/sales_service.py` by persisting `VENTA_COMPLETADA` events before in-memory publish and added unique folio generation for sales.
- Made `SalesReversalService` more robust by accepting legacy DB wrappers and defaulting `branch_id`, and updated UI sales cancellation in `modulos/ventas.py` to call the safe reversal and avoid direct `UPDATE ventas` fallbacks.
- WebApp security updates in `webapp/api_pedidos.py` to enforce token requirement, make `db_path` configurable in `start_webapp_server`, restrict CORS via env (`SPJ_WEBAPP_CORS_ORIGIN`), and record denied auth events to `audit_logs`.
- WhatsApp webhook hardened in `whatsapp_service/webhook/whatsapp.py` to require `WA_VERIFY_TOKEN` and compare with `hmac.compare_digest`, and `whatsapp_service/config/settings.py` removed a default verify token to force configuration.
- UI and UX fixes: login logo sizing adjustment in `interfaz/main_window.py`, caja navigation button wiring and tooltip fixes in `modulos/caja.py`, and merma module added manager PIN approval flow for high-value losses in `modulos/merma.py`.
- Health server metrics extended in `core/health/health_server.py` to expose outbox and webapp auth-denied counters and corresponding Prometheus-style metrics.
- Added comprehensive regression/unit tests in `pos_spj_v13.4/tests/test_phase0_hardening_regression.py` and a generated review note `AUDITORIA_ENTERPRISE_2026-04-23.md` summarizing findings and scope.

### Testing
- Added and executed the automated test module `pos_spj_v13.4/tests/test_phase0_hardening_regression.py` which covers auth migration, auth repo detection/migration, sales cash validation, outbox persistence/dispatch, dispatcher thread behavior, webapp auth/CORS/db_path handling, WhatsApp verification expectations, merma PIN flow presence, UI wiring checks, and sales folio uniqueness, and all tests passed.
- Exercise of `dispatch_pending` and `OutboxDispatcherThread` behavior was validated via unit tests that simulated success and failure paths and the batch draining logic, which succeeded.
- DB-focused behaviors such as `migrate_password_hash`, `_detect_password_column`, and direct `event_outbox` operations were validated with in-memory SQLite in tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea762b73488322b6d9a8f1be794e40)