### PR TITLE
delivery: completar módulo con arquitectura Service/Repository + WA + geocoding/mapa

### DIFF
--- a/pos_spj_v13.4/core/services/delivery_service.py
+++ b/pos_spj_v13.4/core/services/delivery_service.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from repositories.delivery_repository import DeliveryRepository
+from core.services.delivery_whatsapp_service import DeliveryWhatsAppService
+from core.services.geocoding_service import GeocodingService
+
+logger = logging.getLogger("spj.services.delivery")
+
+
+class DeliveryService:
+    def __init__(
+        self,
+        db,
+        repository: Optional[DeliveryRepository] = None,
+        whatsapp_service: Optional[DeliveryWhatsAppService] = None,
+        geocoding_service: Optional[GeocodingService] = None,
+    ):
+        self.db = db
+        self.repository = repository or DeliveryRepository(db)
+        self.whatsapp_service = whatsapp_service or DeliveryWhatsAppService()
+        self.geocoding_service = geocoding_service or GeocodingService()
+
+    def list_orders(self, estado: Optional[str] = None) -> List[Dict[str, Any]]:
+        self.pull_orders_from_whatsapp()
+        return self.repository.list_orders(estado=estado)
+
+    def create_order(self, data: Dict[str, Any], usuario: str = "sistema") -> int:
+        direccion = (data.get("direccion") or "").strip()
+        if not direccion:
+            raise ValueError("No se puede crear pedido sin dirección válida")
+
+        coords = data.get("coords") or self.geocoding_service.geocode(direccion)
+        if coords:
+            data["lat"] = coords.get("lat")
+            data["lng"] = coords.get("lng")
+        else:
+            # fallback manual: permite guardar pero sin bloquear flujo
+            data["lat"] = data.get("lat")
+            data["lng"] = data.get("lng")
+
+        data["usuario"] = usuario
+        order_id = self.repository.create_order(data)
+        self._publish("pedido_delivery_creado", {"order_id": order_id})
+        self._publish("pedido_whatsapp_recibido", {"order_id": order_id, "canal": "whatsapp"})
+
+        order = self.repository.get_order(order_id) or {}
+        self._safe_wa_notify(order, "pedido_recibido")
+        return order_id
+
+    def update_status(self, order_id: int, status: str, usuario: str, responsable: str = "") -> None:
+        if status == "entregado" and not responsable:
+            raise ValueError("No se puede entregar sin responsable")
+
+        self.repository.update_status(order_id, status, usuario=usuario, responsable=responsable)
+        order = self.repository.get_order(order_id) or {}
+
+        if status == "cancelado":
+            self._release_stock(order_id)
+        if status == "en_ruta":
+            self._publish("pedido_en_ruta", {"order_id": order_id})
+        if status == "entregado":
+            self._publish("pedido_entregado", {"order_id": order_id, "responsable": responsable})
+
+        self._safe_wa_notify(order, status)
+        wa_id = order.get("whatsapp_order_id")
+        self.whatsapp_service.sync_status(str(wa_id or ""), status)
+
+    def autocomplete_address(self, query: str):
+        return self.geocoding_service.autocomplete(query)
+
+    def pull_orders_from_whatsapp(self) -> None:
+        for item in self.whatsapp_service.pull_orders():
+            try:
+                oid = self.repository.upsert_order_from_whatsapp(item)
+                self._publish("pedido_whatsapp_recibido", {"order_id": oid, "payload": item})
+            except Exception as exc:
+                logger.debug("pull_orders_from_whatsapp error: %s", exc)
+
+    def _safe_wa_notify(self, order: Dict[str, Any], status: str) -> None:
+        ok = self.whatsapp_service.notify_status(
+            phone=order.get("cliente_tel", ""),
+            folio=order.get("folio") or str(order.get("id") or ""),
+            status=status,
+        )
+        self._publish("notificacion_whatsapp_enviada", {
+            "order_id": order.get("id"), "status": status, "ok": bool(ok)
+        })
+
+    def _release_stock(self, order_id: int) -> None:
+        self._publish("stock_liberar_solicitado", {"order_id": order_id})
+
+    def _publish(self, event: str, payload: Dict[str, Any]) -> None:
+        try:
+            from core.events.event_bus import get_bus
+
+            get_bus().publish(event, payload)
+        except Exception:
+            pass

--- a/pos_spj_v13.4/core/services/delivery_whatsapp_service.py
+++ b/pos_spj_v13.4/core/services/delivery_whatsapp_service.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable
+
+from core.integrations.whatsapp_client import WhatsAppClient
+
+logger = logging.getLogger("spj.services.delivery_whatsapp")
+
+
+class DeliveryWhatsAppService:
+    STATUS_MESSAGES = {
+        "pedido_recibido": "✅ Recibimos tu pedido {folio}. Lo estamos validando.",
+        "preparacion": "👩‍🍳 Tu pedido {folio} está en preparación.",
+        "en_ruta": "🛵 Tu pedido {folio} va en ruta.",
+        "entregado": "🎉 Tu pedido {folio} fue entregado. ¡Gracias!",
+        "cancelado": "❌ Tu pedido {folio} fue cancelado.",
+    }
+
+    def __init__(self, client: WhatsAppClient | None = None):
+        self.client = client or WhatsAppClient()
+
+    def notify_status(self, phone: str, folio: str, status: str) -> bool:
+        if not phone:
+            return False
+        msg_template = self.STATUS_MESSAGES.get(status)
+        if not msg_template:
+            return False
+        try:
+            return bool(self.client.enviar_mensaje(phone, msg_template.format(folio=folio or "")))
+        except Exception as exc:
+            logger.warning("notify_status failed (%s): %s", status, exc)
+            return False
+
+    def pull_orders(self) -> Iterable[Dict]:
+        try:
+            payload = self.client._get("/api/delivery/orders/pending") or {}
+            items = payload.get("orders") if isinstance(payload, dict) else None
+            return items or []
+        except Exception as exc:
+            logger.debug("pull_orders: %s", exc)
+            return []
+
+    def sync_status(self, whatsapp_order_id: str, status: str) -> bool:
+        if not whatsapp_order_id:
+            return False
+        try:
+            payload = {"whatsapp_order_id": whatsapp_order_id, "status": status}
+            result = self.client._post("/api/delivery/orders/status", payload) or {}
+            return bool(result.get("ok", False))
+        except Exception as exc:
+            logger.debug("sync_status: %s", exc)
+            return False

--- a/pos_spj_v13.4/core/services/geocoding_service.py
+++ b/pos_spj_v13.4/core/services/geocoding_service.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import logging
+import urllib.parse
+import urllib.request
+from typing import Dict, List, Optional
+
+logger = logging.getLogger("spj.services.geocoding")
+
+
+class GeocodingService:
+    def __init__(self, timeout: int = 4):
+        self.timeout = timeout
+        self._headers = {"User-Agent": "SPJ-POS-Delivery/1.0"}
+
+    def autocomplete(self, query: str, limit: int = 5) -> List[Dict[str, str]]:
+        if not query or len(query.strip()) < 4:
+            return []
+        params = urllib.parse.urlencode({"q": query, "format": "json", "addressdetails": 1, "limit": limit})
+        url = f"https://nominatim.openstreetmap.org/search?{params}"
+        req = urllib.request.Request(url, headers=self._headers)
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+            return [
+                {
+                    "label": p.get("display_name", ""),
+                    "lat": p.get("lat"),
+                    "lng": p.get("lon"),
+                }
+                for p in payload
+            ]
+        except Exception as exc:
+            logger.debug("autocomplete error: %s", exc)
+            return []
+
+    def geocode(self, address: str) -> Optional[Dict[str, float]]:
+        suggestions = self.autocomplete(address, limit=1)
+        if not suggestions:
+            return None
+        first = suggestions[0]
+        try:
+            return {"lat": float(first["lat"]), "lng": float(first["lng"]), "label": first["label"]}
+        except Exception:
+            return None

--- a/pos_spj_v13.4/modulos/delivery.py
+++ b/pos_spj_v13.4/modulos/delivery.py
@@ -15,16 +15,17 @@ from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QTableWidget,
     QTableWidgetItem, QComboBox, QLineEdit, QGroupBox, QFormLayout,
     QMessageBox, QHeaderView, QSplitter, QTextEdit, QDialog, QDialogButtonBox,
-    QSpinBox, QDoubleSpinBox, QFrame
+    QSpinBox, QDoubleSpinBox, QFrame, QListWidget, QListWidgetItem
 )
 from PyQt5.QtCore import Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QFont, QColor
 from core.db.connection import get_connection
+from core.services.delivery_service import DeliveryService
 logger = logging.getLogger("spj.delivery")
 
-ESTADOS = ["pendiente","asignado","en_camino","entregado","cancelado"]
+ESTADOS = ["pendiente","preparacion","en_ruta","entregado","cancelado"]
 ESTADO_COLOR = {
-    "pendiente": Colors.WARNING_BASE,"asignado":Colors.PRIMARY_BASE,"en_camino":Colors.ACCENT_BASE,
+    "pendiente": Colors.WARNING_BASE,"preparacion":Colors.PRIMARY_BASE,"en_ruta":Colors.ACCENT_BASE,
     "entregado":Colors.SUCCESS_BASE,"cancelado":Colors.DANGER_BASE
 }
 
@@ -70,30 +71,57 @@ class AsignarDriverDialog(QDialog):
         }
 
 class NuevoPedidoDialog(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, delivery_service: DeliveryService, parent=None):
         super().__init__(parent)
+        self.delivery_service = delivery_service
+        self._selected_coords = None
         self.setWindowTitle("Nuevo Pedido Delivery")
         self.setMinimumWidth(500)
         layout = QVBoxLayout(self)
         form = QFormLayout()
         self.txt_cliente = QLineEdit(); self.txt_cliente.setPlaceholderText("Buscar cliente...")
-        self.txt_direccion = QTextEdit(); self.txt_direccion.setMaximumHeight(80)
+        self.txt_direccion = QLineEdit(); self.txt_direccion.setPlaceholderText("Escribe dirección (mín. 4 caracteres)")
+        self.lst_sugerencias = QListWidget()
+        self.lst_sugerencias.setMaximumHeight(130)
+        self.lst_sugerencias.hide()
         self.txt_notas = QLineEdit(); self.txt_notas.setPlaceholderText("Notas del pedido")
         self.combo_sucursal = QComboBox()
         self.combo_sucursal.addItems(["Sucursal Principal","Sucursal 2","Sucursal 3"])
         form.addRow("Cliente:", self.txt_cliente)
         form.addRow("Dirección:", self.txt_direccion)
+        form.addRow("Sugerencias:", self.lst_sugerencias)
         form.addRow("Notas:", self.txt_notas)
         form.addRow("Sucursal:", self.combo_sucursal)
         layout.addLayout(form)
         btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         btns.accepted.connect(self.accept); btns.rejected.connect(self.reject)
         layout.addWidget(btns)
+        self.txt_direccion.textChanged.connect(self._buscar_sugerencias)
+        self.lst_sugerencias.itemClicked.connect(self._tomar_sugerencia)
+
+    def _buscar_sugerencias(self, text: str):
+        self.lst_sugerencias.clear()
+        self._selected_coords = None
+        if len(text.strip()) < 4:
+            self.lst_sugerencias.hide()
+            return
+        for item in self.delivery_service.autocomplete_address(text):
+            w = QListWidgetItem(item.get("label", ""))
+            w.setData(Qt.UserRole, item)
+            self.lst_sugerencias.addItem(w)
+        self.lst_sugerencias.setVisible(self.lst_sugerencias.count() > 0)
+
+    def _tomar_sugerencia(self, item: QListWidgetItem):
+        data = item.data(Qt.UserRole) or {}
+        self.txt_direccion.setText(data.get("label", ""))
+        self._selected_coords = data
+        self.lst_sugerencias.hide()
 
     def get_data(self):
         return {
             "cliente": self.txt_cliente.text().strip(),
-            "direccion": self.txt_direccion.toPlainText().strip(),
+            "direccion": self.txt_direccion.text().strip(),
+            "coords": self._selected_coords,
             "notas": self.txt_notas.text().strip(),
             "sucursal_id": self.combo_sucursal.currentIndex() + 1
         }
@@ -145,12 +173,12 @@ class TarjetaPedido(QFrame):
             btn.setFixedWidth(90)
             btn.clicked.connect(lambda _, pid=self.pedido["id"]: self.accion_requerida.emit(pid,"asignar"))
             btns.addWidget(btn)
-        if estado == "asignado":
-            btn = create_primary_button(self, "En Camino", "Marcar pedido como en camino")
+        if estado == "preparacion":
+            btn = create_primary_button(self, "En Ruta", "Marcar pedido como en ruta")
             btn.setFixedWidth(90)
-            btn.clicked.connect(lambda _, pid=self.pedido["id"]: self.accion_requerida.emit(pid,"en_camino"))
+            btn.clicked.connect(lambda _, pid=self.pedido["id"]: self.accion_requerida.emit(pid,"en_ruta"))
             btns.addWidget(btn)
-        if estado == "en_camino":
+        if estado == "en_ruta":
             btn = create_success_button(self, "Entregado", "Confirmar entrega del pedido")
             btn.setFixedWidth(90)
             btn.clicked.connect(lambda _, pid=self.pedido["id"]: self.accion_requerida.emit(pid,"entregado"))
@@ -173,6 +201,8 @@ class ModuloDelivery(QWidget, RefreshMixin):
             self.container = None
             self.conexion  = conexion_o_container
         self.usuario = usuario
+        self.delivery_service = DeliveryService(self.conexion)
+        self._pedidos_cache = []
         self._init_ui()
         self._init_tables()
         # EventBus: recarga reactiva al completar/modificar pedido
@@ -256,7 +286,7 @@ class ModuloDelivery(QWidget, RefreshMixin):
         # Filtro de estado
         filtro_layout = QHBoxLayout()
         filtro_layout.addWidget(QLabel("Filtrar:"))
-        self.combo_filtro = create_combo(self, ["Todos","pendiente","asignado","en_camino","entregado","cancelado"], "Seleccionar estado para filtrar")
+        self.combo_filtro = create_combo(self, ["Todos","pendiente","preparacion","en_ruta","entregado","cancelado"], "Seleccionar estado para filtrar")
         self.combo_filtro.currentTextChanged.connect(self.cargar_pedidos)
         filtro_layout.addWidget(self.combo_filtro); filtro_layout.addStretch()
         # Stats
@@ -278,7 +308,7 @@ class ModuloDelivery(QWidget, RefreshMixin):
         # Kanban board
         splitter = QSplitter(Qt.Horizontal)
         self.columnas = {}
-        for estado in ["pendiente","asignado","en_camino","entregado"]:
+        for estado in ["pendiente","preparacion","en_ruta","entregado"]:
             col_widget = QWidget()
             col_layout = QVBoxLayout(col_widget)
             color = ESTADO_COLOR[estado]
@@ -312,7 +342,7 @@ class ModuloDelivery(QWidget, RefreshMixin):
         try:
             from PyQt5.QtWebEngineWidgets import QWebEngineView
             view = QWebEngineView()
-            # Build drivers data
+            # Build drivers data + pedidos geolocalizados
             try:
                 rows = self.conexion.execute(
                     "SELECT c.nombre, dl.lat, dl.lng, dl.actualizado "
@@ -324,6 +354,18 @@ class ModuloDelivery(QWidget, RefreshMixin):
                                    "lng": float(r[2] or -89.623)} for r in rows])
             except Exception:
                 drivers_js = "[]"
+            pedidos_js = str([
+                {
+                    "id": p.get("id"),
+                    "cliente": p.get("cliente_nombre", ""),
+                    "direccion": p.get("direccion", ""),
+                    "estado": p.get("estado", "pendiente"),
+                    "lat": float(p.get("lat") or 20.967),
+                    "lng": float(p.get("lng") or -89.623),
+                }
+                for p in (self._pedidos_cache or [])
+                if p.get("lat") is not None and p.get("lng") is not None
+            ])
 
             html = f"""<!DOCTYPE html><html><head>
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
@@ -334,10 +376,15 @@ var map = L.map('map').setView([20.967, -89.623], 13);
 L.tileLayer('https://{{s}}.tile.openstreetmap.org/{{z}}/{{x}}/{{y}}.png',
     {{attribution:'© OpenStreetMap'}}).addTo(map);
 var drivers = {drivers_js};
+var pedidos = {pedidos_js};
 var icon = L.icon({{iconUrl:'https://cdn-icons-png.flaticon.com/32/3050/3050553.png',iconSize:[32,32]}});
 drivers.forEach(function(d){{
     L.marker([d.lat,d.lng],{{icon:icon}}).addTo(map)
      .bindPopup('<b>' + d.name + '</b>').openPopup();
+}});
+pedidos.forEach(function(p){{
+    L.circleMarker([p.lat,p.lng],{{radius:8,color:'#ef4444'}}).addTo(map)
+      .bindPopup('Pedido #' + p.id + '<br/>' + p.estado + '<br/>' + p.cliente + '<br/>' + p.direccion);
 }});
 if(drivers.length===0){{
     L.marker([20.967,-89.623]).addTo(map)
@@ -475,11 +522,9 @@ if(drivers.length===0){{
                 item = col_layout.takeAt(0)
                 if item.widget(): item.widget().deleteLater()
         try:
-            sql = """SELECT d.*, dr.nombre as driver_nombre
-                     FROM delivery_orders d
-                     LEFT JOIN drivers dr ON dr.id = d.driver_id
-                     ORDER BY d.fecha_solicitud DESC LIMIT 100"""
-            pedidos = [dict(r) for r in self.conexion.execute(sql).fetchall()]
+            filtro_repo = None if filtro == "Todos" else filtro
+            pedidos = self.delivery_service.list_orders(filtro_repo)
+            self._pedidos_cache = pedidos
             counts = {e:0 for e in ESTADOS}
             for p in pedidos:
                 estado = p.get("estado","pendiente")
@@ -491,7 +536,7 @@ if(drivers.length===0){{
                     self.columnas[estado].insertWidget(self.columnas[estado].count()-1, card)
                     visibles += 1
             stats = "  ".join(f"{ESTADO_COLOR.get(e,'#FFF')} {e}:{n}" for e,n in counts.items() if n>0)
-            self.lbl_stats.setText(f"Pedidos activos: {sum(counts.get(e,0) for e in ['pendiente','asignado','en_camino'])}")
+            self.lbl_stats.setText(f"Pedidos activos: {sum(counts.get(e,0) for e in ['pendiente','preparacion','en_ruta'])}")
             self._empty.setVisible(visibles == 0)
         except Exception as e:
             logger.error("cargar_pedidos: %s", e)
@@ -508,11 +553,10 @@ if(drivers.length===0){{
                 if not data["driver_id"]:
                     QMessageBox.warning(self,"Sin repartidor","Primero registra repartidores."); return
                 self.conexion.execute(
-                    "UPDATE delivery_orders SET estado='asignado',driver_id=?,tiempo_estimado=?,notas=?,fecha_asignacion=datetime('now') WHERE id=?",
+                    "UPDATE delivery_orders SET estado='preparacion',driver_id=?,tiempo_estimado=?,notas=?,fecha_asignacion=datetime('now') WHERE id=?",
                     (data["driver_id"],data["tiempo"],data["notas"],pedido_id))
-                # WhatsApp
-                self._notificar_whatsapp(pedido_id, "asignado", data)
-            elif accion in ("en_camino","entregado","cancelado"):
+                self.delivery_service.update_status(pedido_id, "preparacion", usuario=self.usuario)
+            elif accion in ("en_ruta","entregado","cancelado"):
                 fecha_col = "fecha_entrega" if accion == "entregado" else "fecha_asignacion"
                 
                 # If delivered, capture payment method and amount
@@ -571,8 +615,12 @@ if(drivers.length===0){{
                         )
                     except Exception: pass
                 
-                if accion in ("en_camino","entregado"):
-                    self._notificar_whatsapp(pedido_id, accion, {})
+                self.delivery_service.update_status(
+                    pedido_id,
+                    accion,
+                    usuario=self.usuario,
+                    responsable=(self.usuario if accion == "entregado" else ""),
+                )
             try: self.conexion.commit()
             except Exception: pass
             self.cargar_pedidos()
@@ -595,7 +643,7 @@ if(drivers.length===0){{
             if not row or not row[1]: return
             from integrations.whatsapp_service import WhatsAppService
             wa = WhatsAppService(self.conexion)
-            if accion == "en_camino":
+            if accion == "en_ruta":
                 dr = data.get("repartidor","Repartidor")
                 wa.notificar_delivery_en_camino(row[1],row[0],str(pedido_id),dr,data.get("tiempo",30))
             elif accion == "entregado":
@@ -604,17 +652,19 @@ if(drivers.length===0){{
             logger.debug("WA notify: %s", e)
 
     def nuevo_pedido(self):
-        dlg = NuevoPedidoDialog(self)
+        dlg = NuevoPedidoDialog(self.delivery_service, self)
         if dlg.exec_() != QDialog.Accepted: return
         data = dlg.get_data()
         if not data["direccion"]:
             QMessageBox.warning(self,"Dirección requerida","Ingresa la dirección de entrega."); return
         try:
-            self.conexion.execute(
-                "INSERT INTO delivery_orders(cliente_nombre,direccion,notas,sucursal_id) VALUES(?,?,?,?)",
-                (data["cliente"],data["direccion"],data["notas"],data["sucursal_id"]))
-            try: self.conexion.commit()
-            except Exception: pass
+            self.delivery_service.create_order({
+                "cliente_nombre": data["cliente"],
+                "direccion": data["direccion"],
+                "coords": data.get("coords"),
+                "notas": data["notas"],
+                "sucursal_id": data["sucursal_id"],
+            }, usuario=self.usuario)
             self.cargar_pedidos()
             QMessageBox.information(self,"Pedido creado","Pedido de delivery creado exitosamente.")
         except Exception as e:

--- a/pos_spj_v13.4/repositories/delivery_repository.py
+++ b/pos_spj_v13.4/repositories/delivery_repository.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("spj.repositories.delivery")
+
+
+class DeliveryRepository:
+    """Capa de acceso a datos para delivery_orders y su trazabilidad."""
+
+    def __init__(self, db):
+        self.db = db
+        self.ensure_schema()
+
+    def ensure_schema(self) -> None:
+        self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS delivery_orders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                venta_id INTEGER,
+                folio TEXT,
+                whatsapp_order_id TEXT,
+                cliente_id INTEGER,
+                cliente_nombre TEXT,
+                cliente_tel TEXT,
+                direccion TEXT NOT NULL,
+                lat REAL,
+                lng REAL,
+                estado TEXT DEFAULT 'pendiente',
+                notas TEXT,
+                total REAL DEFAULT 0,
+                responsable_entrega TEXT,
+                usuario TEXT,
+                fecha DATETIME DEFAULT (datetime('now')),
+                fecha_actualizacion DATETIME,
+                historial_cambios TEXT,
+                driver_id INTEGER,
+                sucursal_id INTEGER DEFAULT 1
+            )
+            """
+        )
+        self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS delivery_order_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                order_id INTEGER NOT NULL,
+                estado_anterior TEXT,
+                estado_nuevo TEXT,
+                usuario TEXT,
+                fecha DATETIME DEFAULT (datetime('now')),
+                observacion TEXT
+            )
+            """
+        )
+        for col in (
+            "folio TEXT",
+            "whatsapp_order_id TEXT",
+            "lat REAL",
+            "lng REAL",
+            "responsable_entrega TEXT",
+            "usuario TEXT",
+            "fecha_actualizacion DATETIME",
+            "historial_cambios TEXT",
+        ):
+            try:
+                self.db.execute(f"ALTER TABLE delivery_orders ADD COLUMN {col}")
+            except Exception:
+                pass
+        self.db.execute("CREATE INDEX IF NOT EXISTS idx_delivery_estado ON delivery_orders(estado, fecha)")
+        self.db.execute("CREATE INDEX IF NOT EXISTS idx_delivery_wa ON delivery_orders(whatsapp_order_id)")
+        try:
+            self.db.commit()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _normalize_status(status: str) -> str:
+        mapping = {
+            "asignado": "preparacion",
+            "listo": "preparacion",
+            "en_camino": "en_ruta",
+        }
+        return mapping.get((status or "").strip().lower(), (status or "pendiente").strip().lower())
+
+    def list_orders(self, estado: Optional[str] = None, limit: int = 200) -> List[Dict[str, Any]]:
+        sql = (
+            "SELECT d.*, v.id as venta_relacionada "
+            "FROM delivery_orders d "
+            "LEFT JOIN ventas v ON v.id = d.venta_id "
+            "WHERE 1=1 "
+        )
+        params: List[Any] = []
+        if estado and estado != "Todos":
+            sql += " AND lower(d.estado) = ?"
+            params.append(self._normalize_status(estado))
+        sql += " ORDER BY COALESCE(d.fecha_actualizacion,d.fecha) DESC LIMIT ?"
+        params.append(limit)
+
+        rows = self.db.execute(sql, tuple(params)).fetchall()
+        result: List[Dict[str, Any]] = []
+        for r in rows:
+            item = dict(r)
+            item["estado"] = self._normalize_status(item.get("estado"))
+            item["venta_validada"] = bool(item.get("venta_relacionada") or not item.get("venta_id"))
+            result.append(item)
+        return result
+
+    def create_order(self, data: Dict[str, Any]) -> int:
+        hist = [{"estado": "pendiente", "usuario": data.get("usuario", "sistema")}]
+        cur = self.db.execute(
+            """
+            INSERT INTO delivery_orders(
+                venta_id, folio, whatsapp_order_id, cliente_id, cliente_nombre, cliente_tel,
+                direccion, lat, lng, estado, notas, total, usuario, historial_cambios,
+                sucursal_id
+            ) VALUES(?,?,?,?,?,?,?,?,?,'pendiente',?,?,?,?,?)
+            """,
+            (
+                data.get("venta_id"),
+                data.get("folio"),
+                data.get("whatsapp_order_id"),
+                data.get("cliente_id"),
+                data.get("cliente_nombre"),
+                data.get("cliente_tel"),
+                data["direccion"],
+                data.get("lat"),
+                data.get("lng"),
+                data.get("notas", ""),
+                float(data.get("total", 0) or 0),
+                data.get("usuario", "sistema"),
+                json.dumps(hist, ensure_ascii=False),
+                int(data.get("sucursal_id", 1)),
+            ),
+        )
+        oid = int(cur.lastrowid)
+        self._insert_history(oid, None, "pendiente", data.get("usuario", "sistema"), "creación")
+        self.db.commit()
+        return oid
+
+    def upsert_order_from_whatsapp(self, payload: Dict[str, Any], usuario: str = "whatsapp") -> int:
+        wa_id = payload.get("whatsapp_order_id") or payload.get("order_id")
+        row = None
+        if wa_id:
+            row = self.db.execute(
+                "SELECT id FROM delivery_orders WHERE whatsapp_order_id=?", (str(wa_id),)
+            ).fetchone()
+        data = {
+            "folio": payload.get("folio") or payload.get("codigo"),
+            "whatsapp_order_id": str(wa_id) if wa_id else None,
+            "cliente_nombre": payload.get("cliente") or payload.get("cliente_nombre"),
+            "cliente_tel": payload.get("telefono") or payload.get("cliente_tel"),
+            "direccion": payload.get("direccion") or "",
+            "lat": payload.get("lat"),
+            "lng": payload.get("lng"),
+            "total": payload.get("total") or 0,
+            "notas": payload.get("notas", ""),
+            "usuario": usuario,
+            "sucursal_id": payload.get("sucursal_id", 1),
+        }
+        if row:
+            oid = int(row[0])
+            self.db.execute(
+                """
+                UPDATE delivery_orders
+                SET folio=COALESCE(?, folio), cliente_nombre=COALESCE(?,cliente_nombre),
+                    cliente_tel=COALESCE(?,cliente_tel), direccion=COALESCE(?,direccion),
+                    lat=COALESCE(?,lat), lng=COALESCE(?,lng), total=COALESCE(?,total),
+                    notas=COALESCE(?,notas), fecha_actualizacion=datetime('now')
+                WHERE id=?
+                """,
+                (
+                    data["folio"], data["cliente_nombre"], data["cliente_tel"], data["direccion"],
+                    data["lat"], data["lng"], data["total"], data["notas"], oid,
+                ),
+            )
+        else:
+            oid = self.create_order(data)
+        self.db.commit()
+        return oid
+
+    def update_status(self, order_id: int, new_status: str, usuario: str, observacion: str = "", responsable: str = "") -> None:
+        row = self.db.execute(
+            "SELECT estado, historial_cambios FROM delivery_orders WHERE id=?", (order_id,)
+        ).fetchone()
+        if not row:
+            raise ValueError("Pedido no encontrado")
+        prev = self._normalize_status(row[0])
+        new_status = self._normalize_status(new_status)
+        hist = []
+        if row[1]:
+            try:
+                hist = json.loads(row[1])
+            except Exception:
+                hist = []
+        hist.append({"estado": new_status, "usuario": usuario})
+        self.db.execute(
+            """
+            UPDATE delivery_orders
+            SET estado=?, responsable_entrega=COALESCE(?, responsable_entrega),
+                usuario=?, fecha_actualizacion=datetime('now'), historial_cambios=?
+            WHERE id=?
+            """,
+            (new_status, responsable or None, usuario, json.dumps(hist, ensure_ascii=False), order_id),
+        )
+        self._insert_history(order_id, prev, new_status, usuario, observacion)
+        self.db.commit()
+
+    def _insert_history(self, order_id: int, old: Optional[str], new: str, usuario: str, obs: str) -> None:
+        self.db.execute(
+            """
+            INSERT INTO delivery_order_history(order_id, estado_anterior, estado_nuevo, usuario, observacion)
+            VALUES(?,?,?,?,?)
+            """,
+            (order_id, old, new, usuario, obs),
+        )
+
+    def get_order(self, order_id: int) -> Optional[Dict[str, Any]]:
+        row = self.db.execute("SELECT * FROM delivery_orders WHERE id=?", (order_id,)).fetchone()
+        return dict(row) if row else None

--- a/pos_spj_v13.4/tests/test_delivery_service.py
+++ b/pos_spj_v13.4/tests/test_delivery_service.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.services.delivery_service import DeliveryService
+
+
+class DummyGeo:
+    def geocode(self, address):
+        return {"lat": 19.4, "lng": -99.1, "label": address}
+
+    def autocomplete(self, q):
+        return [{"label": "Calle 1", "lat": "19.4", "lng": "-99.1"}]
+
+
+class DummyWA:
+    def __init__(self):
+        self.status = []
+
+    def notify_status(self, phone, folio, status):
+        self.status.append((phone, folio, status))
+        return True
+
+    def pull_orders(self):
+        return [{"whatsapp_order_id": "wa-1", "direccion": "Calle 10", "cliente": "Ana"}]
+
+    def sync_status(self, whatsapp_order_id, status):
+        return True
+
+
+def _db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE ventas(id INTEGER PRIMARY KEY)")
+    return db
+
+
+def test_create_and_update_delivery_order():
+    svc = DeliveryService(_db(), whatsapp_service=DummyWA(), geocoding_service=DummyGeo())
+    oid = svc.create_order({"cliente_nombre": "Ana", "direccion": "Calle Falsa 123"}, usuario="tester")
+    assert oid > 0
+
+    orders = svc.list_orders()
+    assert any(o["id"] == oid for o in orders)
+
+    svc.update_status(oid, "en_ruta", usuario="tester")
+    svc.update_status(oid, "entregado", usuario="tester", responsable="carlos")
+
+    order = svc.repository.get_order(oid)
+    assert order["estado"] == "entregado"
+    assert order["responsable_entrega"] == "carlos"
+
+
+def test_pull_orders_from_whatsapp_upserts():
+    svc = DeliveryService(_db(), whatsapp_service=DummyWA(), geocoding_service=DummyGeo())
+    svc.pull_orders_from_whatsapp()
+    orders = svc.repository.list_orders()
+    assert len(orders) == 1
+    assert orders[0]["whatsapp_order_id"] == "wa-1"


### PR DESCRIPTION
### Motivation
- Unificar y corregir el flujo de delivery separando UI, lógica de negocio y acceso a datos para evitar consultas SQL y lógica en la UI.  
- Conectar el POS con un microservicio WhatsApp real y añadir geocoding/autocompletar para mejorar la captura de direcciones y mostrar pedidos en el mapa.  
- Añadir trazabilidad y reglas de negocio (validaciones y liberación de stock) para robustecer la operación de delivery.  

### Description
- Se añadió la capa de persistencia `repositories/delivery_repository.py` que crea/asegura el esquema `delivery_orders` y `delivery_order_history`, normaliza estados y centraliza queries (`create_order`, `upsert_order_from_whatsapp`, `list_orders`, `update_status`).  
- Se añadió la capa de negocio `core/services/delivery_service.py` que orquesta validaciones y reglas: no crear pedido sin dirección (`create_order`), no marcar `entregado` sin `responsable` (`update_status`), emitir eventos (`pedido_delivery_creado`, `pedido_whatsapp_recibido`, `pedido_en_ruta`, `pedido_entregado`, `notificacion_whatsapp_enviada`) y coordinar sincronización con WA y liberación de stock.  
- Se creó `core/services/delivery_whatsapp_service.py` que usa el cliente HTTP (`core.integrations.whatsapp_client.WhatsAppClient`) para `pull_orders`, `notify_status` y `sync_status` con el microservicio WhatsApp; los errores de WA son tolerados (no bloquean el flujo).  
- Se añadió `core/services/geocoding_service.py` con `autocomplete` y `geocode` usando Nominatim (OpenStreetMap) y fallback manual cuando falla la API.  
- Se actualizó la UI `modulos/delivery.py` para usar `DeliveryService` en lugar de SQL directo: estados normalizados a `pendiente`, `preparacion`, `en_ruta`, `entregado`; se implementó `NuevoPedidoDialog` con autocompletado y selección de coordenadas; se separó la lógica de transición hacia `DeliveryService`; el mapa (`QWebEngineView`) ahora dibuja repartidores y pedidos geolocalizados con Leaflet.  

### Testing
- Ejecutadas las pruebas unitarias `pytest -q tests/test_delivery_service.py tests/test_wa_client.py` y todas pasaron: `7 passed`.  
- Se compiló con `python -m py_compile` los nuevos/actualizados módulos `core/services/delivery_service.py`, `core/services/delivery_whatsapp_service.py`, `core/services/geocoding_service.py`, `repositories/delivery_repository.py`, `modulos/delivery.py` sin errores.  
- Se añadieron tests nuevos en `tests/test_delivery_service.py` que validan creación de pedido con geocoding simulado, pull/upsert desde WA y transiciones de estado incluyendo `entregado` con `responsable`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebab8b0af08322b2686746a008c5ed)