### PR TITLE
fix(ui): 6 fixes — tables, buttons, search bar, sidebar focus, theme …

### DIFF
--- a/pos_spj_v13.4/interfaz/menu_lateral.py
+++ b/pos_spj_v13.4/interfaz/menu_lateral.py
@@ -123,6 +123,11 @@ def _build_sidebar_qss() -> str:
             background-color: {s.ACTIVE};
             color: {n.WHITE};
             font-weight: {Typography.WEIGHT_SEMIBOLD};
+            border: none;
+        }}
+        QFrame#MenuLateral QPushButton:focus {{
+            outline: none;
+            border: none;
         }}
         QFrame#MenuLateral QScrollBar:vertical {{
             background-color: {s.BG};

--- a/pos_spj_v13.4/modulos/clientes.py
+++ b/pos_spj_v13.4/modulos/clientes.py
@@ -130,7 +130,7 @@ class ModuloClientes(ModuloBase):
         # --- Barra de estado/botones de acción ---
         acciones_layout = QHBoxLayout()
         self.btn_editar_cliente = QPushButton("Editar")
-        self.btn_editar_cliente.setObjectName("secondaryBtn")
+        self.btn_editar_cliente.setObjectName("outlineBtn")
         self.btn_editar_cliente.setIcon(self.obtener_icono("edit.png"))
         self.btn_editar_cliente.setEnabled(False)
 

--- a/pos_spj_v13.4/modulos/finanzas_unificadas.py
+++ b/pos_spj_v13.4/modulos/finanzas_unificadas.py
@@ -449,8 +449,7 @@ class ModuloFinanzasUnificadas(QWidget):
         self._normalizar_botones_ui()
 
     def _normalizar_botones_ui(self):
-        """Evita botones full-width y mejora alineación visual general."""
-        is_light = self.palette().color(QPalette.Window).lightness() >= 160
+        """Evita botones full-width; delega colores al QSS global del tema."""
         for btn in self.findChildren(QPushButton):
             # Mantener icon-buttons compactos de tablas.
             if btn.maximumWidth() <= 36 or (btn.minimumWidth() and btn.minimumWidth() <= 36):
@@ -458,7 +457,9 @@ class ModuloFinanzasUnificadas(QWidget):
             btn.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
             if btn.minimumHeight() < 30:
                 btn.setMinimumHeight(30)
-            if is_light:
+            # Asignar objectName si aún no tiene uno definido, para que el QSS
+            # global lo estilice correctamente en cualquier tema (claro/oscuro).
+            if not btn.objectName() or btn.objectName() == btn.__class__.__name__:
                 txt = (btn.text() or "").lower()
                 if any(k in txt for k in ("eliminar", "baja", "cancelar", "retirar")):
                     btn.setObjectName("dangerBtn")
@@ -466,15 +467,11 @@ class ModuloFinanzasUnificadas(QWidget):
                     btn.setObjectName("primaryBtn")
                 else:
                     btn.setObjectName("secondaryBtn")
-                # Evitar estilos hardcodeados oscuros en tema claro.
+            # Limpiar cualquier estilo inline hardcodeado que anule el tema global.
+            if btn.styleSheet():
                 btn.setStyleSheet("")
-
-        if is_light:
-            for tbl in self.findChildren(QTableWidget):
-                tbl.setStyleSheet(
-                    "QTableWidget{background:#FFFFFF;color:#0F172A;border:1px solid #CBD5E1;}"
-                    "QHeaderView::section{background:#E2E8F0;color:#334155;font-weight:600;}"
-                )
+            btn.style().unpolish(btn)
+            btn.style().polish(btn)
     
     def _on_tab_changed(self, index):
         """Carga datos según la pestaña activa."""
@@ -528,7 +525,7 @@ class ModuloFinanzasUnificadas(QWidget):
             cell = QGroupBox(title)
             cell_l = QVBoxLayout(cell)
             lbl = QLabel("—")
-            lbl.setStyleSheet("font-size:20px;font-weight:bold;color:#2563EB;")
+            lbl.setObjectName("kpiValue")
             cell_l.addWidget(lbl, 0, Qt.AlignCenter)
             self._kpi_labels[key] = lbl
             g.addWidget(cell, row, col)
@@ -592,13 +589,13 @@ class ModuloFinanzasUnificadas(QWidget):
         r_lay = QHBoxLayout(grp_resumen)
         
         self._lbl_capital_invertido = QLabel("$0.00")
-        self._lbl_capital_invertido.setStyleSheet("font-size:22px;font-weight:bold;color:#27ae60;")
+        self._lbl_capital_invertido.setObjectName("kpiValue")
         self._lbl_capital_disponible = QLabel("$0.00")
-        self._lbl_capital_disponible.setStyleSheet("font-size:22px;font-weight:bold;color:#2980b9;")
+        self._lbl_capital_disponible.setObjectName("kpiValue")
         self._lbl_roi = QLabel("0%")
-        self._lbl_roi.setStyleSheet("font-size:18px;font-weight:bold;color:#8e44ad;")
+        self._lbl_roi.setObjectName("kpiValue")
         self._lbl_salud = QLabel("")
-        self._lbl_salud.setStyleSheet("font-size:14px;font-weight:bold;")
+        self._lbl_salud.setObjectName("subheading")
         
         for lbl_title, lbl_val in [
             ("Capital Invertido", self._lbl_capital_invertido),
@@ -608,7 +605,7 @@ class ModuloFinanzasUnificadas(QWidget):
         ]:
             col = QVBoxLayout()
             t = QLabel(lbl_title)
-            t.setStyleSheet("font-size:11px;color:#7f8c8d;")
+            t.setObjectName("caption")
             t.setAlignment(Qt.AlignCenter)
             lbl_val.setAlignment(Qt.AlignCenter)
             col.addWidget(t)
@@ -631,11 +628,13 @@ class ModuloFinanzasUnificadas(QWidget):
         self._txt_desc_capital.setPlaceholderText("Descripción (ej: Capital socio A)")
         
         btn_inyectar = QPushButton("➕ Inyectar Capital")
-        btn_inyectar.setStyleSheet("background:#27ae60;color:white;padding:8px 16px;font-weight:bold;border-radius:4px;")
+        btn_inyectar.setObjectName("successBtn")
+        btn_inyectar.setCursor(Qt.PointingHandCursor)
         btn_inyectar.clicked.connect(self._on_inyectar_capital)
-        
+
         btn_retirar = QPushButton("➖ Retirar Capital")
-        btn_retirar.setStyleSheet("background:#e74c3c;color:white;padding:8px 16px;font-weight:bold;border-radius:4px;")
+        btn_retirar.setObjectName("dangerBtn")
+        btn_retirar.setCursor(Qt.PointingHandCursor)
         btn_retirar.clicked.connect(self._on_retirar_capital)
         
         c_lay.addWidget(QLabel("Monto:"))
@@ -666,12 +665,13 @@ class ModuloFinanzasUnificadas(QWidget):
         layout = QVBoxLayout(widget)
         
         lbl = QLabel("Facturas y deudas pendientes con proveedores")
-        lbl.setStyleSheet("color: gray;")
+        lbl.setObjectName("caption")
         layout.addWidget(lbl)
 
         top = QHBoxLayout()
         btn_nuevo_cxp = QPushButton("➕ Nueva CxP")
-        btn_nuevo_cxp.setStyleSheet("background:#2563EB;color:white;font-weight:bold;padding:6px 12px;border-radius:4px;")
+        btn_nuevo_cxp.setObjectName("primaryBtn")
+        btn_nuevo_cxp.setCursor(Qt.PointingHandCursor)
         btn_nuevo_cxp.clicked.connect(self._dialogo_nueva_cxp)
         top.addWidget(btn_nuevo_cxp)
         btn_pago_global = QPushButton("💳 Pago global")
@@ -704,15 +704,17 @@ class ModuloFinanzasUnificadas(QWidget):
         layout = QVBoxLayout(widget)
         
         lbl = QLabel("Dinero pendiente de cobro a clientes")
-        lbl.setStyleSheet("color: gray;")
+        lbl.setObjectName("caption")
         layout.addWidget(lbl)
 
         top = QHBoxLayout()
         btn_nuevo_cliente = QPushButton("👤 Nuevo cliente")
-        btn_nuevo_cliente.setStyleSheet("background:#475569;color:white;font-weight:bold;padding:6px 12px;border-radius:4px;")
+        btn_nuevo_cliente.setObjectName("secondaryBtn")
+        btn_nuevo_cliente.setCursor(Qt.PointingHandCursor)
         btn_nuevo_cliente.clicked.connect(self._dialogo_nuevo_cliente)
         btn_nuevo_cxc = QPushButton("➕ Nueva CxC")
-        btn_nuevo_cxc.setStyleSheet("background:#16A34A;color:white;font-weight:bold;padding:6px 12px;border-radius:4px;")
+        btn_nuevo_cxc.setObjectName("successBtn")
+        btn_nuevo_cxc.setCursor(Qt.PointingHandCursor)
         btn_nuevo_cxc.clicked.connect(self._dialogo_nueva_cxc)
         top.addWidget(btn_nuevo_cliente)
         top.addWidget(btn_nuevo_cxc)
@@ -771,7 +773,8 @@ class ModuloFinanzasUnificadas(QWidget):
         ])
         
         btn_guardar = QPushButton("💾 Guardar Gasto")
-        btn_guardar.setStyleSheet("background:#e74c3c;color:white;font-weight:bold;padding:7px 16px;border-radius:5px;")
+        btn_guardar.setObjectName("dangerBtn")
+        btn_guardar.setCursor(Qt.PointingHandCursor)
         btn_guardar.clicked.connect(self._registrar_gasto)
         
         form_layout.addRow("Categoría:", self.cmb_categoria_gasto)
@@ -796,9 +799,10 @@ class ModuloFinanzasUnificadas(QWidget):
         # Header con botón nuevo
         hdr = QHBoxLayout()
         titulo = QLabel("🏭 Directorio de Proveedores")
-        titulo.setStyleSheet("font-size: 16px; font-weight: bold;")
+        titulo.setObjectName("heading")
         btn_nuevo = QPushButton("➕ Nuevo Proveedor")
-        btn_nuevo.setStyleSheet("background:#27ae60;color:white;padding:8px 16px;font-weight:bold;border-radius:4px;")
+        btn_nuevo.setObjectName("successBtn")
+        btn_nuevo.setCursor(Qt.PointingHandCursor)
         btn_nuevo.clicked.connect(self._nuevo_proveedor)
         hdr.addWidget(titulo)
         hdr.addStretch()
@@ -1003,35 +1007,22 @@ class ModuloFinanzasUnificadas(QWidget):
             logger.error(f"Error cargando CxC: {e}")
 
     def _create_compact_action_button(self, text: str, variant: str = "primary") -> QPushButton:
-        """
-        Botón compacto para acciones por fila en tablas (mismo estándar visual
-        de módulos como Productos y Clientes).
-        """
+        """Botón compacto para acciones por fila en tablas — usa objectName para herencia de tema."""
+        variant_map = {
+            "primary": "primaryBtn",
+            "success": "successBtn",
+            "danger": "dangerBtn",
+            "warning": "warningBtn",
+            "outline": "outlineBtn",
+            "secondary": "secondaryBtn",
+        }
         btn = QPushButton(text)
+        btn.setFixedHeight(26)
+        btn.setMinimumWidth(80)
+        btn.setMaximumWidth(110)
         btn.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
-        btn.setMinimumHeight(30)
-        btn.setMinimumWidth(98)
-        btn.setMaximumWidth(126)
         btn.setCursor(Qt.PointingHandCursor)
-
-        is_light = self.palette().color(QPalette.Window).lightness() >= 160
-        if is_light:
-            btn.setStyleSheet("")
-            btn.setObjectName("primaryBtn" if variant == "primary" else "successBtn")
-            return btn
-
-        if variant == "success":
-            btn.setStyleSheet(
-                "QPushButton{background:#27ae60;color:white;font-weight:600;"
-                "padding:5px 10px;border-radius:5px;}"
-                "QPushButton:hover{background:#219150;}"
-            )
-        else:
-            btn.setStyleSheet(
-                "QPushButton{background:#2E86C1;color:white;font-weight:600;"
-                "padding:5px 10px;border-radius:5px;}"
-                "QPushButton:hover{background:#1f6fa5;}"
-            )
+        btn.setObjectName(variant_map.get(variant, "primaryBtn"))
         return btn
     
     def _filtrar_cxc(self):
@@ -1349,12 +1340,16 @@ class ModuloFinanzasUnificadas(QWidget):
             
             btn_ed = QPushButton("✏️")
             btn_ed.setFixedSize(28, 26)
+            btn_ed.setObjectName("outlineBtn")
             btn_ed.setToolTip("Editar")
+            btn_ed.setCursor(Qt.PointingHandCursor)
             btn_ed.clicked.connect(lambda _, pid=pid: self._editar_por_id(pid))
-            
+
             btn_del = QPushButton("🗑️")
             btn_del.setFixedSize(28, 26)
+            btn_del.setObjectName("dangerBtn")
             btn_del.setToolTip("Eliminar")
+            btn_del.setCursor(Qt.PointingHandCursor)
             btn_del.clicked.connect(lambda _, pid=pid, nom=nombre: self._eliminar_proveedor(pid, nom))
             
             btn_lay.addWidget(btn_ed)

--- a/pos_spj_v13.4/modulos/productos.py
+++ b/pos_spj_v13.4/modulos/productos.py
@@ -4,7 +4,7 @@ from modulos.spj_styles import spj_btn, apply_btn_styles
 from modulos.design_tokens import Colors, Spacing, Typography, Borders
 from modulos.ui_components import (
     create_primary_button, create_success_button, create_danger_button,
-    create_secondary_button, create_input_field, create_input, create_combo,
+    create_secondary_button, create_table_button, create_input_field, create_input, create_combo,
     create_heading, create_subheading, create_caption, apply_tooltip,
     LoadingIndicator, EmptyStateWidget, PageHeader, Toast,
 )
@@ -664,28 +664,27 @@ class ModuloProductos(QWidget, RefreshMixin):
                 _cell = _QW(); _lay = _HL(_cell)
                 _lay.setContentsMargins(2, 2, 2, 2); _lay.setSpacing(2)
 
-                btn_editar = create_secondary_button(self, "✏️", "Editar producto")
-                btn_editar.setFixedWidth(30)
+                btn_editar = create_table_button(self, "✏️", "Editar producto", "outline")
+                btn_editar.setFixedSize(28, 26)
                 btn_editar.clicked.connect(lambda _, pid=prod_id: self.abrir_editar_producto(pid))
                 _lay.addWidget(btn_editar)
 
                 if activo:
                     # Producto activo: ocultar + eliminar
-                    btn_toggle = create_secondary_button(self, "🙈", "Ocultar del POS")
-                    btn_toggle.setFixedWidth(30)
+                    btn_toggle = create_table_button(self, "🙈", "Ocultar del POS", "warning")
+                    btn_toggle.setFixedSize(28, 26)
                     btn_toggle.clicked.connect(
                         lambda _, pid=prod_id, a=activo: self._toggle_activo(pid, a))
                     _lay.addWidget(btn_toggle)
 
-                    btn_del = create_danger_button(self, "🗑️", "Eliminar (soft delete)")
-                    btn_del.setFixedWidth(30)
+                    btn_del = create_table_button(self, "🗑️", "Eliminar (soft delete)", "danger")
+                    btn_del.setFixedSize(28, 26)
                     btn_del.clicked.connect(
                         lambda _, pid=prod_id, nom=row_data['nombre']: self.eliminar_producto(pid, nom))
                     _lay.addWidget(btn_del)
                 else:
-                    # v13.30: Producto eliminado: botón RESTAURAR
-                    btn_restaurar = create_success_button(self, "♻️", "Restaurar producto")
-                    btn_restaurar.setFixedWidth(30)
+                    btn_restaurar = create_table_button(self, "♻️", "Restaurar producto", "success")
+                    btn_restaurar.setFixedSize(28, 26)
                     btn_restaurar.clicked.connect(
                         lambda _, pid=prod_id, nom=row_data['nombre']: self._restaurar_producto(pid, nom))
                     _lay.addWidget(btn_restaurar)

--- a/pos_spj_v13.4/modulos/qss_builder.py
+++ b/pos_spj_v13.4/modulos/qss_builder.py
@@ -713,6 +713,33 @@ _TPL_OSCURO = f"""
             border: none;
             padding: 4px;
         }}
+
+        /* ===== FOCUS RINGS ===== */
+        QPushButton:focus {{
+            outline: none;
+        }}
+
+        /* ===== BUSCADOR DE PRODUCTOS (ProductSearchWidget) ===== */
+        QFrame#productSearchPopup {{
+            background-color: {Colors.NEUTRAL.SLATE_800};
+            border: 1px solid {Colors.NEUTRAL.SLATE_600};
+            border-radius: 8px;
+        }}
+        QListWidget#productSearchPopupList {{
+            background-color: {Colors.NEUTRAL.SLATE_800};
+            color: {Colors.NEUTRAL.SLATE_100};
+            border: none;
+        }}
+        QListWidget#productSearchPopupList::item {{
+            padding: 6px 10px;
+        }}
+        QListWidget#productSearchPopupList::item:hover {{
+            background-color: {Colors.NEUTRAL.SLATE_700};
+        }}
+        QListWidget#productSearchPopupList::item:selected {{
+            background-color: {Colors.PRIMARY.BASE};
+            color: {Colors.NEUTRAL.WHITE};
+        }}
     """
 
 
@@ -1407,6 +1434,33 @@ _TPL_CLARO = f"""
         QDockWidget::close-button, QDockWidget::float-button {{
             border: none;
             padding: 4px;
+        }}
+
+        /* ===== FOCUS RINGS ===== */
+        QPushButton:focus {{
+            outline: none;
+        }}
+
+        /* ===== BUSCADOR DE PRODUCTOS (ProductSearchWidget) ===== */
+        QFrame#productSearchPopup {{
+            background-color: {Colors.NEUTRAL.WHITE};
+            border: 1px solid {Colors.NEUTRAL.SLATE_300};
+            border-radius: 8px;
+        }}
+        QListWidget#productSearchPopupList {{
+            background-color: {Colors.NEUTRAL.WHITE};
+            color: {Colors.NEUTRAL.SLATE_900};
+            border: none;
+        }}
+        QListWidget#productSearchPopupList::item {{
+            padding: 6px 10px;
+        }}
+        QListWidget#productSearchPopupList::item:hover {{
+            background-color: {Colors.NEUTRAL.SLATE_100};
+        }}
+        QListWidget#productSearchPopupList::item:selected {{
+            background-color: {Colors.PRIMARY.BASE};
+            color: {Colors.NEUTRAL.WHITE};
         }}
     """
 

--- a/pos_spj_v13.4/modulos/spj_product_search.py
+++ b/pos_spj_v13.4/modulos/spj_product_search.py
@@ -37,6 +37,7 @@ class ProductSearchWidget(QWidget):
     - Soporte de scanner HID (detecta entrada rápida de teclado)
     - Popup de resultados con precio y stock
     - Teclas: Enter para seleccionar, Esc para cerrar popup
+    - Estilos heredados del tema global (sin hardcode)
     """
     producto_seleccionado = pyqtSignal(dict)   # emite el producto elegido
 
@@ -45,25 +46,17 @@ class ProductSearchWidget(QWidget):
         super().__init__(parent)
         self.db = db
         self.show_stock = show_stock
-        self._scanner_buffer = ""
         self._scanner_timer  = QTimer(self)
         self._scanner_timer.setSingleShot(True)
         self._scanner_timer.setInterval(80)   # 80ms = scanner timeout
         self._scanner_timer.timeout.connect(self._flush_scanner)
+        self._last_key_ms: float = 0.0   # timestamp of last keystroke (ms)
+        self._inter_key_ms: float = 9999.0  # ms between last two keystrokes
         self._last_results: list = []
         self._build_ui(placeholder)
 
     def set_db(self, db) -> None:
         self.db = db
-
-    def _is_dark_mode(self) -> bool:
-        """Detección robusta de tema oscuro para popups flotantes."""
-        app = QApplication.instance()
-        app_qss = app.styleSheet().lower() if app and hasattr(app, "styleSheet") else ""
-        dark_hints = ("0f172a", "1e293b", "#111827", "dark")
-        if any(h in app_qss for h in dark_hints):
-            return True
-        return self.palette().color(self.backgroundRole()).lightness() < 128
 
     # ── UI ────────────────────────────────────────────────────────────────────
 
@@ -71,78 +64,32 @@ class ProductSearchWidget(QWidget):
         lay = QHBoxLayout(self)
         lay.setContentsMargins(0, 0, 0, 0)
         lay.setSpacing(4)
-        dark_mode = self._is_dark_mode()
 
         self.txt_search = QLineEdit()
         self.txt_search.setPlaceholderText(placeholder)
-        if dark_mode:
-            self.txt_search.setStyleSheet(
-                "QLineEdit { padding:6px 10px; border:1px solid #334155;"
-                " background:#0F172A; color:#E2E8F0; border-radius:6px; font-size:13px; }"
-                "QLineEdit:focus { border-color:#2563EB; }"
-            )
-        else:
-            self.txt_search.setStyleSheet(
-                "QLineEdit { padding:6px 10px; border:1px solid #ced4da;"
-                " border-radius:5px; font-size:13px; }"
-                "QLineEdit:focus { border-color:#2E86C1; }"
-            )
+        self.txt_search.setObjectName("inputField")  # usa el QSS global del tema
         self.txt_search.textChanged.connect(self._on_text_changed)
         self.txt_search.returnPressed.connect(self._on_enter)
         self.txt_search.installEventFilter(self)   # for scanner detection
 
         btn_search = QPushButton("🔍")
         btn_search.setFixedWidth(36)
-        if dark_mode:
-            btn_search.setStyleSheet(
-                "QPushButton { background:#1E293B; color:#E2E8F0; border:1px solid #334155; border-radius:6px;"
-                " font-size:14px; padding:6px; }"
-                "QPushButton:hover { background:#334155; }"
-            )
-        else:
-            btn_search.setStyleSheet(
-                "QPushButton { background:#2E86C1; color:white; border-radius:5px;"
-                " font-size:14px; padding:6px; }"
-                "QPushButton:hover { background:#1A5276; }"
-            )
+        btn_search.setObjectName("secondaryBtn")
+        btn_search.setCursor(Qt.PointingHandCursor)
         btn_search.clicked.connect(lambda: self._buscar(self.txt_search.text()))
 
         lay.addWidget(self.txt_search, 1)
         lay.addWidget(btn_search)
 
-        # Popup de resultados (flotante)
+        # Popup de resultados (flotante) — hereda estilos del tema global
         self._popup = QFrame(self.window(), Qt.Popup | Qt.FramelessWindowHint)
-        if dark_mode:
-            self._popup.setObjectName("productSearchPopup")
-            self._popup.setAttribute(Qt.WA_StyledBackground, True)
-            self._popup.setStyleSheet(
-                "QFrame#productSearchPopup { background:#0F172A; border:1px solid #334155; border-radius:8px; }"
-            )
-        else:
-            self._popup.setStyleSheet(
-                "QFrame { background:white; border:1px solid #2E86C1;"
-                " border-radius:6px; }"
-            )
+        self._popup.setObjectName("productSearchPopup")
+        self._popup.setAttribute(Qt.WA_StyledBackground, True)
         self._popup_lay = QVBoxLayout(self._popup)
         self._popup_lay.setContentsMargins(4, 4, 4, 4)
         self._popup_lay.setSpacing(2)
         self._popup_list = QListWidget()
-        if dark_mode:
-            self._popup_list.setObjectName("productSearchPopupList")
-            self._popup_list.setStyleSheet(
-                "QListWidget#productSearchPopupList, QListView#productSearchPopupList, "
-                "QListWidget#productSearchPopupList::viewport { border:none; background:#0F172A; color:#E2E8F0; }"
-                "QListWidget#productSearchPopupList::item { padding:6px 10px; color:#E2E8F0; background:#0F172A; }"
-                "QListWidget#productSearchPopupList::item:hover { background:#1E293B; }"
-                "QListWidget#productSearchPopupList::item:selected { background:#2563EB; color:#FFFFFF; }"
-            )
-        else:
-            self._popup_list.setStyleSheet(
-                "QListWidget { border:none; }"
-                "QListWidget::item { padding:6px 10px; }"
-                "QListWidget::item:hover { background:#EBF5FB; }"
-                "QListWidget::item:selected { background:#2E86C1; color:white; }"
-            )
+        self._popup_list.setObjectName("productSearchPopupList")
         self._popup_list.itemClicked.connect(self._on_item_click)
         self._popup_list.setMaximumHeight(280)
         self._popup_lay.addWidget(self._popup_list)
@@ -151,7 +98,7 @@ class ProductSearchWidget(QWidget):
         # Debounce timer for live search
         self._search_timer = QTimer()
         self._search_timer.setSingleShot(True)
-        self._search_timer.setInterval(200)
+        self._search_timer.setInterval(250)
         self._search_timer.timeout.connect(lambda: self._buscar(self.txt_search.text()))
 
     # ── Events ───────────────────────────────────────────────────────────────
@@ -159,6 +106,7 @@ class ProductSearchWidget(QWidget):
     def eventFilter(self, obj, event) -> bool:
         """Detect HID scanner (rapid sequential keystrokes)."""
         from PyQt5.QtCore import QEvent
+        import time
         if obj is self.txt_search and event.type() == QEvent.KeyPress:
             key = event.key()
             if key == Qt.Key_Escape:
@@ -170,7 +118,11 @@ class ProductSearchWidget(QWidget):
                 if text:
                     self._flush_scanner_with(text)
                 return True
-            # Normal keystroke — restart debounce
+            # Track inter-key timing to distinguish scanner (< 50ms) from human typing
+            now_ms = time.monotonic() * 1000
+            self._inter_key_ms = now_ms - self._last_key_ms
+            self._last_key_ms = now_ms
+            # Restart scanner timer on each keystroke
             self._scanner_timer.stop()
             self._scanner_timer.start()
         return super().eventFilter(obj, event)
@@ -189,10 +141,18 @@ class ProductSearchWidget(QWidget):
     # ── Scanner ───────────────────────────────────────────────────────────────
 
     def _flush_scanner(self) -> None:
-        """Called after scanner timeout — treat current text as barcode."""
+        """Called after scanner timeout. Only does exact barcode lookup if typing speed
+        was scanner-like (< 50ms between keys). For normal human typing it falls through
+        to the regular search, preventing single-char field clears."""
         text = self.txt_search.text().strip()
-        if text:
+        if not text:
+            return
+        if self._inter_key_ms < 50:
+            # Scanner input — try exact barcode match first
             self._buscar_exacto(text)
+        else:
+            # Human typing — just show normal search results
+            self._buscar(text)
 
     def _flush_scanner_with(self, text: str) -> None:
         """Immediate barcode search (Enter received)."""

--- a/pos_spj_v13.4/ui/themes/theme_engine.py
+++ b/pos_spj_v13.4/ui/themes/theme_engine.py
@@ -56,31 +56,24 @@ def get_qss(theme_name: str) -> str:
 
 def apply_theme(widget, theme_name: str) -> bool:
     """
-    Aplica un tema GLOBALMENTE: primero a QApplication (todos los widgets),
-    después al widget específico si es distinto de la app.
+    Aplica un tema GLOBALMENTE vía QApplication.setStyleSheet.
 
-    Siempre persiste el tema en BD para que sobreviva reinicios.
+    Una sola llamada a app.setStyleSheet re-estiliza todos los widgets.
+    No se aplica al widget individual (doble aplicación no agrega nada
+    y duplica el trabajo de polish en todos los hijos).
     """
     global _current_theme
     qss = get_qss(theme_name)
     if not qss:
         return False
     try:
-        # 1. Aplicar a QApplication para que TODOS los widgets hereden el tema
-        try:
-            from PyQt5.QtWidgets import QApplication
-            app = QApplication.instance()
-            if app is not None:
-                app.setStyleSheet(qss)
-        except Exception:
-            pass
-
-        # 2. Aplicar también al widget específico (refuerzo)
-        if widget is not None:
-            try:
-                widget.setStyleSheet(qss)
-            except Exception:
-                pass
+        from PyQt5.QtWidgets import QApplication
+        app = QApplication.instance()
+        if app is not None:
+            app.setStyleSheet(qss)
+        elif widget is not None:
+            # Fallback sin QApplication — aplica solo al widget raíz
+            widget.setStyleSheet(qss)
 
         _current_theme = theme_name
         _persist_theme(theme_name)


### PR DESCRIPTION
…speed

1. finanzas_unificadas: remove all hardcoded setStyleSheet (tables, labels, buttons) — replaced with objectName so global theme QSS applies uniformly; _normalizar_botones_ui now uses polish() to force re-style after objectName change; _create_compact_action_button uses objectName only (no inline QSS)
2. CxC/CxP action buttons: fixed height (26px) and bounded width so they fit table rows without overflowing
3. Action buttons editar/eliminar/ocultar — proveedores table now has objectName("outlineBtn"/"dangerBtn"); productos uses create_table_button with outline/warning/danger variants; clientes edit is outlineBtn (blue)
4. spj_product_search: replaced all inline setStyleSheet with objectName (inputField, secondaryBtn, productSearchPopup, productSearchPopupList); scanner timer only clears field on exact match when inter-key < 50ms (scanner speed) — human typing no longer loses characters
5. Sidebar: added QPushButton:focus { outline:none; border:none } to _SIDEBAR_DARK_QSS to eliminate the white rectangle on module selection
6. theme_engine: removed redundant widget.setStyleSheet(qss) call — one app.setStyleSheet is sufficient and covers all widgets in one pass

https://claude.ai/code/session_01FKyuPRiDTnuGhk8ovxuARj