### PR TITLE
fix: resolve 5 runtime bugs (Qt WebEngine, delivery buttons, finance,…

### DIFF
--- a/pos_spj_v13.4/core/services/purchase_service.py
+++ b/pos_spj_v13.4/core/services/purchase_service.py
@@ -121,6 +121,19 @@ class PurchaseService:
                                 amount_paid,
                                 f"Pago compra {folio} — {notes or 'proveedor'}"
                             )
+                        # Double-entry journal — always, regardless of open shift
+                        if hasattr(self.finance_service, 'registrar_asiento'):
+                            self.finance_service.registrar_asiento(
+                                debe="inventario",
+                                haber="caja_efectivo",
+                                concepto=f"Compra contado {folio}",
+                                monto=float(amount_paid),
+                                modulo="compras",
+                                referencia_id=compra_id,
+                                evento="COMPRA_REGISTRADA",
+                                metadata={"folio": folio, "provider_id": provider_id,
+                                          "payment_method": payment_method},
+                            )
                 except Exception as _fe:
                     import logging
                     logging.getLogger(__name__).warning("FinanceService compra: %s", _fe)

--- a/pos_spj_v13.4/main.py
+++ b/pos_spj_v13.4/main.py
@@ -1,6 +1,10 @@
 # main.py — SPJ POS v13
 import sys, os, logging, traceback
 from PyQt5.QtWidgets import QApplication, QMessageBox
+from PyQt5.QtCore import Qt
+
+# Must be set before QApplication is constructed when QtWebEngine is loaded
+QApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
 
 # Asegurar que el directorio del proyecto esté PRIMERO en el path
 _BASE_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/pos_spj_v13.4/modulos/compras_pro.py
+++ b/pos_spj_v13.4/modulos/compras_pro.py
@@ -710,8 +710,9 @@ class ModuloComprasPro(QWidget, RefreshMixin):
             for item in self.carrito_compra:
                 r = self.container.db.execute(
                     """SELECT COUNT(*) as n FROM recetas
-                       WHERE producto_id=? AND activa=1""",
-                    (item['producto_id'],)
+                       WHERE (producto_id=? OR producto_base_id=?)
+                         AND (activa=1 OR activo=1)""",
+                    (item['producto_id'], item['producto_id'])
                 ).fetchone()
                 if r and r['n'] > 0:
                     result.append(item)
@@ -735,16 +736,27 @@ class ModuloComprasPro(QWidget, RefreshMixin):
                     )
                     nombres.append(item['nombre'])
                 else:
-                    # Fallback: use canonical product_recipe_components
+                    # Fallback: query receta_componentes (m000 schema), then product_recipe_components
                     receta = self.container.db.execute("""
-                        SELECT rc.component_product_id AS insumo_id,
+                        SELECT rc.producto_id AS insumo_id,
                                COALESCE(rc.cantidad, 0) AS cantidad_insumo,
                                p.nombre AS insumo_nombre
-                        FROM product_recipe_components rc
-                        JOIN product_recipes r ON r.id = rc.recipe_id
-                        JOIN productos p ON p.id = rc.component_product_id
-                        WHERE r.base_product_id=? AND r.is_active=1
-                    """, (item['producto_id'],)).fetchall()
+                        FROM receta_componentes rc
+                        JOIN recetas r ON r.id = rc.receta_id
+                        JOIN productos p ON p.id = rc.producto_id
+                        WHERE (r.producto_base_id=? OR r.producto_id=?)
+                          AND (r.activo=1 OR r.activa=1)
+                    """, (item['producto_id'], item['producto_id'])).fetchall()
+                    if not receta:
+                        receta = self.container.db.execute("""
+                            SELECT rc.component_product_id AS insumo_id,
+                                   COALESCE(rc.cantidad, 0) AS cantidad_insumo,
+                                   p.nombre AS insumo_nombre
+                            FROM product_recipe_components rc
+                            JOIN product_recipes r ON r.id = rc.recipe_id
+                            JOIN productos p ON p.id = rc.component_product_id
+                            WHERE r.base_product_id=? AND r.is_active=1
+                        """, (item['producto_id'],)).fetchall()
                     if receta:
                         _app = getattr(self.container, 'app_service', None)
                         for comp in receta:

--- a/pos_spj_v13.4/modulos/delivery.py
+++ b/pos_spj_v13.4/modulos/delivery.py
@@ -622,10 +622,15 @@ if(drivers.length===0){{
             self._det_acciones_layout.addWidget(b)
 
         if estado == "pendiente":
-            b = create_primary_button(self, "Asignar repartidor", "")
-            b.setFixedHeight(32)
-            b.clicked.connect(lambda _, p=pid: self.ejecutar_accion(p, "asignar"))
-            self._det_acciones_layout.addWidget(b)
+            b_prep = create_success_button(self, "▶ Preparar", "")
+            b_prep.setFixedHeight(32)
+            b_prep.clicked.connect(lambda _, p=pid: self.ejecutar_accion(p, "preparar"))
+            self._det_acciones_layout.addWidget(b_prep)
+
+            b_asig = create_primary_button(self, "Asignar repartidor", "")
+            b_asig.setFixedHeight(32)
+            b_asig.clicked.connect(lambda _, p=pid: self.ejecutar_accion(p, "asignar"))
+            self._det_acciones_layout.addWidget(b_asig)
 
         if estado == "preparacion":
             b = create_primary_button(self, "→ En ruta", "")
@@ -640,10 +645,20 @@ if(drivers.length===0){{
             self._det_acciones_layout.addWidget(b)
 
         if estado not in ("entregado", "cancelado"):
-            b = create_danger_button(self, "✕ Cancelar", "")
-            b.setFixedHeight(32)
-            b.clicked.connect(lambda _, p=pid: self.ejecutar_accion(p, "cancelado"))
-            self._det_acciones_layout.addWidget(b)
+            b_wa = create_secondary_button(self, "📲 Notif. WA", "")
+            b_wa.setFixedHeight(32)
+            b_wa.clicked.connect(lambda _, p=pid: self.ejecutar_accion(p, "notificar_wa"))
+            self._det_acciones_layout.addWidget(b_wa)
+
+            b_link = create_secondary_button(self, "💳 Link pago", "")
+            b_link.setFixedHeight(32)
+            b_link.clicked.connect(lambda _, p=pid: self.ejecutar_accion(p, "link_pago"))
+            self._det_acciones_layout.addWidget(b_link)
+
+            b_cancel = create_danger_button(self, "✕ Cancelar", "")
+            b_cancel.setFixedHeight(32)
+            b_cancel.clicked.connect(lambda _, p=pid: self.ejecutar_accion(p, "cancelado"))
+            self._det_acciones_layout.addWidget(b_cancel)
 
         self._det_acciones_layout.addStretch()
 
@@ -847,7 +862,56 @@ if(drivers.length===0){{
 
     def ejecutar_accion(self, pedido_id: int, accion: str):
         try:
-            if accion == "asignar":
+            if accion == "preparar":
+                self.conexion.execute(
+                    "UPDATE delivery_orders SET estado='preparacion', "
+                    "fecha_actualizacion=datetime('now') WHERE id=?",
+                    (pedido_id,)
+                )
+                self.delivery_service.update_status(
+                    pedido_id, "preparacion", usuario=self.usuario
+                )
+                try: self.conexion.commit()
+                except Exception: pass
+                self.cargar_pedidos()
+                return
+            elif accion == "notificar_wa":
+                row = self.conexion.execute(
+                    "SELECT cliente_nombre, cliente_tel, estado FROM delivery_orders WHERE id=?",
+                    (pedido_id,)
+                ).fetchone()
+                if not row or not row[1]:
+                    QMessageBox.warning(self, "Sin teléfono", "El pedido no tiene teléfono de cliente."); return
+                self._notificar_whatsapp(pedido_id, row[2], {})
+                Toast.success(self, "WhatsApp", f"Notificación enviada a {row[1]}")
+                return
+            elif accion == "link_pago":
+                row = self.conexion.execute(
+                    "SELECT id, folio, total FROM delivery_orders WHERE id=?",
+                    (pedido_id,)
+                ).fetchone()
+                folio = (row[1] or f"DEL-{pedido_id}") if row else f"DEL-{pedido_id}"
+                total = float(row[2] or 0) if row else 0
+                link = f"https://pay.spjpos.mx/delivery/{folio}"
+                from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QDialogButtonBox
+                dlg_link = QDialog(self)
+                dlg_link.setWindowTitle("Link de pago")
+                dlg_link.setMinimumWidth(420)
+                lay_link = QVBoxLayout(dlg_link)
+                lay_link.addWidget(QLabel(f"<b>Pedido #{pedido_id}</b> — Total: ${total:.2f}"))
+                txt_link = QLineEdit(link)
+                txt_link.setReadOnly(True)
+                txt_link.selectAll()
+                lay_link.addWidget(txt_link)
+                bbs = QDialogButtonBox(QDialogButtonBox.Ok)
+                bbs.accepted.connect(dlg_link.accept)
+                lay_link.addWidget(bbs)
+                dlg_link.exec_()
+                from PyQt5.QtWidgets import QApplication as _App
+                _App.clipboard().setText(link)
+                Toast.success(self, "Link copiado", "Link de pago copiado al portapapeles.")
+                return
+            elif accion == "asignar":
                 dlg = AsignarDriverDialog(pedido_id, self)
                 if dlg.exec_() != QDialog.Accepted: return
                 data = dlg.get_data()


### PR DESCRIPTION
… recipes)

main.py: set Qt.AA_ShareOpenGLContexts before QApplication to silence
  QtWebEngine initialization warning.

delivery.py: add missing action buttons to list-view detail panel —
  Preparar (pendiente→preparacion without requiring driver), Notif. WA
  (sends WhatsApp notification to client), Link pago (generates/copies
  payment URL); add ejecutar_accion handlers for all three new actions.

purchase_service.py: add registrar_asiento double-entry journal for
  cash purchases (Inventario DR / Caja CR) so Finanzas shows the
  transaction regardless of whether a cash register shift is open.
  Credit purchases already had a journal via crear_cxp.

compras_pro.py: fix _detectar_recetas to query both column name
  variants (producto_id/producto_base_id, activa/activo) to handle
  m000 vs migration-030 schema divergence; fix _procesar_recetas
  fallback to query receta_componentes (correct m000 table) with
  the same dual-column strategy, keeping product_recipe_components
  as secondary fallback.

https://claude.ai/code/session_01GB9oWqX4otyvX1AsXtQNT3