### PR TITLE
feat(phase-2): Route all stock mutations through apply_movement()

### DIFF
--- a/pos_spj_v13.4/core/services/erp_application_service.py
+++ b/pos_spj_v13.4/core/services/erp_application_service.py
@@ -197,89 +197,27 @@ class ERPApplicationService:
     # ══════════════════════════════════════════════════════════════════════════
 
     def _entrada_directa(self, prod_id, qty, costo, tipo, ref, usuario, sid):
-        """Registra entrada: actualiza movimientos + las 3 tablas de stock."""
-        with transaction(self.db) as c:
-            c.execute("""
-                INSERT INTO movimientos_inventario
-                    (uuid, producto_id, tipo, tipo_movimiento, cantidad,
-                     costo_unitario, costo_total, descripcion, referencia,
-                     usuario, sucursal_id, fecha)
-                VALUES (?,?,'ENTRADA',?,?,?,?,?,?,?,?,datetime('now'))
-            """, (str(uuid.uuid4()), prod_id, tipo, qty,
-                  costo, round(qty * costo, 2), tipo, ref, usuario, sid))
-            # inventario_actual (por sucursal) — costo promedio ponderado
-            c.execute("""
-                INSERT INTO inventario_actual
-                    (producto_id, sucursal_id, cantidad, costo_promedio)
-                VALUES (?, ?, ?, ?)
-                ON CONFLICT(producto_id, sucursal_id) DO UPDATE SET
-                    costo_promedio = CASE WHEN cantidad + excluded.cantidad > 0
-                        THEN (cantidad * costo_promedio
-                              + excluded.cantidad * excluded.costo_promedio)
-                             / (cantidad + excluded.cantidad)
-                        ELSE excluded.costo_promedio END,
-                    cantidad             = cantidad + excluded.cantidad,
-                    ultima_actualizacion = datetime('now')
-            """, (prod_id, sid, qty, costo))
-            # branch_inventory (leída por POS para validación de stock)
-            # Manual upsert: ON CONFLICT no puede usar UNIQUE(branch_id, product_id, batch_id)
-            # cuando batch_id es NULL (los NULLs son distintos en SQLite UNIQUE).
-            _bi_updated = c.execute("""
-                UPDATE branch_inventory
-                SET quantity = quantity + ?, updated_at = datetime('now')
-                WHERE product_id = ? AND branch_id = ? AND batch_id IS NULL
-            """, (qty, prod_id, sid)).rowcount
-            if not _bi_updated:
-                c.execute("""
-                    INSERT OR IGNORE INTO branch_inventory
-                        (product_id, branch_id, quantity, batch_id, updated_at)
-                    VALUES (?, ?, ?, NULL, datetime('now'))
-                """, (prod_id, sid, qty))
-            # productos.existencia = suma global de todas las sucursales
-            c.execute("""
-                UPDATE productos
-                SET existencia    = (SELECT COALESCE(SUM(cantidad),0)
-                                     FROM inventario_actual WHERE producto_id = ?),
-                    precio_compra = CASE WHEN ? > 0 THEN ? ELSE precio_compra END
-                WHERE id = ?
-            """, (prod_id, costo, costo, prod_id))
+        """Registra entrada via UnifiedInventoryService (canonical apply_movement)."""
+        from core.services.inventory.unified_inventory_service import UnifiedInventoryService
+        UnifiedInventoryService(self.db, sucursal_id=sid, usuario=usuario).process_movement(
+            product_id=prod_id,
+            quantity=qty,
+            movement_type=tipo,
+            reference=ref,
+            metadata={"unit_cost": costo},
+        )
 
     def _salida_directa(self, prod_id, qty, tipo, ref, usuario, sid):
-        """Registra salida: actualiza movimientos + las 3 tablas de stock."""
-        with transaction(self.db) as c:
-            c.execute("""
-                INSERT INTO movimientos_inventario
-                    (uuid, producto_id, tipo, tipo_movimiento, cantidad,
-                     descripcion, referencia, usuario, sucursal_id, fecha)
-                VALUES (?,?,'SALIDA',?,?,?,?,?,?,datetime('now'))
-            """, (str(uuid.uuid4()), prod_id, tipo, qty, tipo, ref, usuario, sid))
-            # inventario_actual
-            c.execute("""
-                INSERT INTO inventario_actual (producto_id, sucursal_id, cantidad)
-                VALUES (?, ?, ?)
-                ON CONFLICT(producto_id, sucursal_id) DO UPDATE SET
-                    cantidad             = MAX(0, cantidad - excluded.cantidad),
-                    ultima_actualizacion = datetime('now')
-            """, (prod_id, sid, qty))
-            # branch_inventory — manual upsert (ver nota en _entrada_directa)
-            _bi_updated = c.execute("""
-                UPDATE branch_inventory
-                SET quantity = MAX(0, quantity - ?), updated_at = datetime('now')
-                WHERE product_id = ? AND branch_id = ? AND batch_id IS NULL
-            """, (qty, prod_id, sid)).rowcount
-            if not _bi_updated:
-                c.execute("""
-                    INSERT OR IGNORE INTO branch_inventory
-                        (product_id, branch_id, quantity, batch_id, updated_at)
-                    VALUES (?, ?, 0, NULL, datetime('now'))
-                """, (prod_id, sid))
-            # productos.existencia = suma global
-            c.execute("""
-                UPDATE productos
-                SET existencia = (SELECT COALESCE(SUM(cantidad),0)
-                                  FROM inventario_actual WHERE producto_id = ?)
-                WHERE id = ?
-            """, (prod_id, prod_id))
+        """Registra salida via UnifiedInventoryService; caps at available stock (legacy MAX(0,...) behavior)."""
+        from core.services.inventory.unified_inventory_service import UnifiedInventoryService, StockInsuficienteError
+        svc = UnifiedInventoryService(self.db, sucursal_id=sid, usuario=usuario)
+        try:
+            svc.process_movement(product_id=prod_id, quantity=-qty, movement_type=tipo, reference=ref)
+        except StockInsuficienteError:
+            row = self.db.execute("SELECT COALESCE(existencia, 0) FROM productos WHERE id=?", (prod_id,)).fetchone()
+            available = float(row[0]) if row else 0.0
+            if available > 1e-9:
+                svc.process_movement(product_id=prod_id, quantity=-available, movement_type=tipo, reference=ref)
 
     def _get_costo_producto(self, producto_id: int) -> float:
         try:

--- a/pos_spj_v13.4/core/services/inventory/unified_inventory_service.py
+++ b/pos_spj_v13.4/core/services/inventory/unified_inventory_service.py
@@ -5,6 +5,66 @@ import logging, uuid
 from typing import List
 from core.db.connection import get_connection, transaction
 logger = logging.getLogger("spj.inventory")
+
+
+def _sync_branch_inventory(c, prod_id: int, sid: int, delta: float) -> None:
+    """Sync branch_inventory; handles schemas with or without batch_id column."""
+    if abs(delta) < 1e-9:
+        return
+    if delta > 0:
+        try:
+            updated = c.execute(
+                "UPDATE branch_inventory SET quantity = quantity + ?, updated_at = datetime('now') "
+                "WHERE product_id = ? AND branch_id = ? AND batch_id IS NULL",
+                (delta, prod_id, sid)
+            ).rowcount
+            if not updated:
+                c.execute(
+                    "INSERT OR IGNORE INTO branch_inventory "
+                    "(product_id, branch_id, quantity, batch_id, updated_at) "
+                    "VALUES (?, ?, ?, NULL, datetime('now'))",
+                    (prod_id, sid, delta)
+                )
+        except Exception:
+            try:
+                updated = c.execute(
+                    "UPDATE branch_inventory SET quantity = quantity + ?, updated_at = datetime('now') "
+                    "WHERE product_id = ? AND branch_id = ?",
+                    (delta, prod_id, sid)
+                ).rowcount
+                if not updated:
+                    c.execute(
+                        "INSERT OR IGNORE INTO branch_inventory "
+                        "(product_id, branch_id, quantity, updated_at) "
+                        "VALUES (?, ?, ?, datetime('now'))",
+                        (prod_id, sid, delta)
+                    )
+            except Exception:
+                pass  # branch_inventory table doesn't exist in this schema
+    else:
+        qty = abs(delta)
+        try:
+            updated = c.execute(
+                "UPDATE branch_inventory SET quantity = MAX(0, quantity - ?), updated_at = datetime('now') "
+                "WHERE product_id = ? AND branch_id = ? AND batch_id IS NULL",
+                (qty, prod_id, sid)
+            ).rowcount
+            if not updated:
+                c.execute(
+                    "INSERT OR IGNORE INTO branch_inventory "
+                    "(product_id, branch_id, quantity, batch_id, updated_at) "
+                    "VALUES (?, ?, 0, NULL, datetime('now'))",
+                    (prod_id, sid)
+                )
+        except Exception:
+            try:
+                c.execute(
+                    "UPDATE branch_inventory SET quantity = MAX(0, quantity - ?), updated_at = datetime('now') "
+                    "WHERE product_id = ? AND branch_id = ?",
+                    (qty, prod_id, sid)
+                )
+            except Exception:
+                pass
 MOVEMENT_TYPES = frozenset({"purchase","sale","adjustment","waste","production","return","transfer"})
 class InventoryError(Exception): pass
 class StockInsuficienteError(InventoryError):
@@ -80,6 +140,7 @@ class UnifiedInventoryService:
                         cantidad=excluded.cantidad,
                         ultima_actualizacion=datetime('now')
                 """, (producto_id, sid, stock_nuevo))
+            _sync_branch_inventory(c, producto_id, sid, delta)
         return mid
     def adjust_stock(self, producto_id, new_qty, reason="Ajuste", sucursal_id=None):
         """Ajusta el stock al valor exacto new_qty, creando movimiento de ajuste."""
@@ -223,6 +284,7 @@ class UnifiedInventoryService:
                         cantidad=excluded.cantidad,
                         ultima_actualizacion=datetime('now')
                 """, (product_id, sucursal_id, stock_nuevo))
+            _sync_branch_inventory(c, product_id, sucursal_id, delta)
 
         if conn is not None:
             _write(conn)
@@ -245,3 +307,5 @@ class UnifiedInventoryService:
         except Exception as _e:
             logger.warning("process_movement event non-fatal: %s", _e)
         return mid
+
+    apply_movement = process_movement

--- a/pos_spj_v13.4/core/services/sales_service.py
+++ b/pos_spj_v13.4/core/services/sales_service.py
@@ -611,9 +611,10 @@ class SalesService:
             raise VentaError(str(exc)) from exc
 
     def anular_venta(self, venta_id, motivo="", usuario_id=None):
-        """Cancela una venta: revierte stock en las 3 tablas y genera asiento contable."""
-        import uuid as _uuid
+        """Cancela una venta: revierte stock via apply_movement y genera asiento contable."""
         from core.services.sales.unified_sales_service import VentaError
+        from core.db.connection import transaction as _txn
+        from core.services.inventory.unified_inventory_service import UnifiedInventoryService as _UIS
         try:
             row = self.db.execute(
                 "SELECT id, folio, total, sucursal_id, estado FROM ventas WHERE id=?",
@@ -627,57 +628,40 @@ class SalesService:
             folio = row["folio"] or str(venta_id)
             total = float(row["total"] or 0)
             sucursal_id = int(row["sucursal_id"] or 1)
+            usuario = str(usuario_id or "sistema")
 
             detalles = self.db.execute(
                 "SELECT producto_id, cantidad FROM detalles_venta WHERE venta_id=?",
                 (int(venta_id),)
             ).fetchall()
 
-            with self.db.transaction("ANULAR_VENTA"):
+            with _txn(self.db):
                 for d in detalles:
                     pid = int(d["producto_id"])
                     qty = float(d["cantidad"] or 0)
-
-                    # 1. Tabla global
-                    self.db.execute(
-                        "UPDATE productos SET existencia = COALESCE(existencia,0) + ? WHERE id=?",
-                        (qty, pid)
+                    if qty <= 0:
+                        continue
+                    _UIS(self.db, sucursal_id=sucursal_id, usuario=usuario).process_movement(
+                        product_id=pid,
+                        quantity=qty,
+                        movement_type="DEVOLUCION_ANULACION",
+                        reference=folio,
+                        metadata={"notas": f"Anulación venta {folio}: {motivo}"},
                     )
-                    # 2. inventario_actual (por sucursal)
-                    self.db.execute("""
-                        INSERT INTO inventario_actual (producto_id, sucursal_id, cantidad)
-                        VALUES (?, ?, ?)
-                        ON CONFLICT(producto_id, sucursal_id)
-                        DO UPDATE SET cantidad = cantidad + excluded.cantidad,
-                                      ultima_actualizacion = datetime('now')
-                    """, (pid, sucursal_id, qty))
-                    # 3. branch_inventory (tabla leída por POS para validación)
-                    self.db.execute("""
-                        INSERT INTO branch_inventory (product_id, branch_id, quantity, updated_at)
-                        VALUES (?, ?, ?, datetime('now'))
-                        ON CONFLICT(product_id, branch_id)
-                        DO UPDATE SET quantity = quantity + excluded.quantity,
-                                      updated_at = excluded.updated_at
-                    """, (pid, sucursal_id, qty))
-                    # 4. Movimiento de auditoría
-                    self.db.execute("""
-                        INSERT INTO movimientos_inventario
-                            (uuid, producto_id, tipo, tipo_movimiento, cantidad,
-                             descripcion, referencia, usuario, sucursal_id)
-                        VALUES (?, ?, 'entrada', 'DEVOLUCION_ANULACION', ?, ?, ?, ?, ?)
-                    """, (str(_uuid.uuid4()), pid, qty,
-                          f"Anulación venta {folio}: {motivo}",
-                          folio,
-                          str(usuario_id or "sistema"),
-                          sucursal_id))
 
-                # 5. Marcar venta como cancelada
-                self.db.execute(
-                    "UPDATE ventas SET estado='cancelada', notas=? WHERE id=?",
-                    (motivo, int(venta_id))
-                )
+                # Marcar venta como cancelada
+                try:
+                    self.db.execute(
+                        "UPDATE ventas SET estado='cancelada', notas=? WHERE id=?",
+                        (motivo, int(venta_id))
+                    )
+                except Exception:
+                    self.db.execute(
+                        "UPDATE ventas SET estado='cancelada' WHERE id=?",
+                        (int(venta_id),)
+                    )
 
-                # 6. Asiento contable (debe=ventas ↔ haber=inventario)
+                # Asiento contable (debe=ventas ↔ haber=inventario)
                 if self.finance_service and total > 0:
                     try:
                         self.finance_service.registrar_asiento(

--- a/pos_spj_v13.4/tests/test_sales.py
+++ b/pos_spj_v13.4/tests/test_sales.py
@@ -33,7 +33,7 @@ class TestProcesarVenta:
             sales_svc.procesar_venta([_item(prod_id=4, qty=1.0)], _pago())
 
     def test_stock_se_descuenta(self, sales_svc, mem_db):
-        sales_svc.procesar_venta([_item(qty=3.0)], _pago())
+        sales_svc.procesar_venta([_item(qty=3.0)], _pago(recibido=500.0))
         stock = mem_db.execute("SELECT existencia FROM productos WHERE id=1").fetchone()[0]
         assert float(stock) == 47.0
 
@@ -84,7 +84,7 @@ class TestProcesarVenta:
 
 class TestAnularVenta:
     def test_anular_restaura_stock(self, sales_svc, mem_db):
-        result = sales_svc.procesar_venta([_item(qty=5.0)], _pago())
+        result = sales_svc.procesar_venta([_item(qty=5.0)], _pago(recibido=1000.0))
         stock_after_sale = float(mem_db.execute("SELECT existencia FROM productos WHERE id=1").fetchone()[0])
         sales_svc.anular_venta(result.venta_id, "test")
         stock_after_cancel = float(mem_db.execute("SELECT existencia FROM productos WHERE id=1").fetchone()[0])


### PR DESCRIPTION
- Add _sync_branch_inventory() helper to UnifiedInventoryService with try/except for schemas with and without batch_id column; called from both process_movement() and register_movement() to keep all 3 stock tables (productos.existencia, inventario_actual, branch_inventory) in sync.
- Add apply_movement = process_movement alias.
- Replace _entrada_directa() and _salida_directa() in ERPApplicationService with thin wrappers over UnifiedInventoryService.process_movement(); _salida_directa preserves legacy MAX(0,...) cap-at-zero behavior via StockInsuficienteError catch.
- Fix anular_venta() in SalesService: replace self.db.transaction() (fails on raw sqlite3.Connection) with core.db.connection.transaction(), replace 4-table direct SQL per item with process_movement() calls.
- Fix test_sales.py: payment fixtures used default recibido=200 which was insufficient for multi-qty items (qty×price > 200), causing PagoInsuficienteError before reaching the code under test.

Result: 87 failed → 87 failed (no regression), 623 → 655 passing (+32).

https://claude.ai/code/session_015M9A7z7ugv43AqrgFGoZ2g