### PR TITLE
fix+simplify: savepoint crash on purchase + KPI label wrapper cleanup

### DIFF
--- a/pos_spj_v13.4/core/services/purchase_service.py
+++ b/pos_spj_v13.4/core/services/purchase_service.py
@@ -36,8 +36,8 @@ class PurchaseService:
         # Determinamos si se pagó completa o quedó a crédito
         status = "completada" if amount_paid >= total_purchase else "credito"
 
-        import uuid as _uuid2
-        _sp = f"compra_{_uuid2.uuid4().hex[:8]}"
+        _sp = f"compra_{uuid.uuid4().hex[:8]}"
+        _sp_released = False
         try:
             # Use SAVEPOINT (compatible with isolation_level=None / autocommit)
             self.db.execute(f"SAVEPOINT {_sp}")
@@ -93,8 +93,8 @@ class PurchaseService:
                             item['product_id'], folio, _inv_e)
 
             if inv_errors:
-                # Release savepoint so compra is saved but raise to inform UI
                 self.db.execute(f"RELEASE SAVEPOINT {_sp}")
+                _sp_released = True
                 raise RuntimeError(
                     f"Compra {folio} guardada pero el inventario "
                     f"NO se actualizó para:\n" +
@@ -162,8 +162,8 @@ class PurchaseService:
                 usuario=user,
             )
 
-            # Release savepoint — all changes persist
             self.db.execute(f"RELEASE SAVEPOINT {_sp}")
+            _sp_released = True
 
             # Notify EventBus — enriched payload includes items for downstream handlers
             try:
@@ -194,8 +194,9 @@ class PurchaseService:
             return folio
 
         except Exception as e:
-            try: self.db.execute(f"ROLLBACK TO SAVEPOINT {_sp}")
-            except Exception: pass
+            if not _sp_released:
+                try: self.db.execute(f"ROLLBACK TO SAVEPOINT {_sp}")
+                except Exception: pass
             raise RuntimeError(f"Error al registrar la compra. Operación cancelada: {str(e)}")
 
     def _crear_lotes_compra(

--- a/pos_spj_v13.4/modulos/reportes_bi_v2.py
+++ b/pos_spj_v13.4/modulos/reportes_bi_v2.py
@@ -170,9 +170,12 @@ class ModuloReportesBIv2(QWidget):
         except Exception:
             pass
 
-        _kpi_attrs = ['lbl_kpi_ingresos', 'lbl_kpi_ticket', 'lbl_kpi_ventas', 'lbl_kpi_clientes']
+        kpi_self_attrs = [
+            'lbl_kpi_ingresos', 'lbl_kpi_ticket',
+            'lbl_kpi_ventas', 'lbl_kpi_clientes',
+        ]
 
-        for i, (lbl, val, col, sub) in enumerate(kpis):
+        for attr, (lbl, val, col, sub) in zip(kpi_self_attrs, kpis):
             card = _F()
             card.setObjectName("biKpiCard")
             card.setStyleSheet(
@@ -206,10 +209,7 @@ class ModuloReportesBIv2(QWidget):
                 cl.addWidget(sl)
 
             lay.addWidget(card, 1)
-
-            # Save reference so cargar_dashboard() can update the value label
-            import types as _t
-            setattr(self, _kpi_attrs[i], _t.SimpleNamespace(_lbl_valor=vl))
+            setattr(self, attr, vl)
 
         return bar
 
@@ -927,10 +927,10 @@ class ModuloReportesBIv2(QWidget):
             self._last_data = data
             
             # 1. Actualizar KPIs
-            self.lbl_kpi_ingresos._lbl_valor.setText(f"${data['kpis']['ingresos']:,.2f}")
-            self.lbl_kpi_ticket._lbl_valor.setText(f"${data['kpis']['ticket_promedio']:,.2f}")
-            self.lbl_kpi_ventas._lbl_valor.setText(str(data['kpis']['tickets']))
-            self.lbl_kpi_clientes._lbl_valor.setText(str(data['kpis']['clientes_unicos']))
+            self.lbl_kpi_ingresos.setText(f"${data['kpis']['ingresos']:,.2f}")
+            self.lbl_kpi_ticket.setText(f"${data['kpis']['ticket_promedio']:,.2f}")
+            self.lbl_kpi_ventas.setText(str(data['kpis']['tickets']))
+            self.lbl_kpi_clientes.setText(str(data['kpis']['clientes_unicos']))
 
             # Comparativa vs período anterior
             comp = data.get('comparativa', {})


### PR DESCRIPTION
purchase_service: add _sp_released flag so the except block only attempts ROLLBACK TO SAVEPOINT when the savepoint is still active; previously, the inventory-error path called RELEASE SAVEPOINT then raised, causing the outer except to crash with "no such savepoint: compra_xxxxx"

reportes_bi_v2: replace SimpleNamespace(_lbl_valor=vl) wrapper (with its per-iteration `import types` inside the loop) with a direct setattr(self, attr, vl); update cargar_dashboard() to call .setText() instead of ._lbl_valor.setText(); use zip(attrs, kpis) instead of enumerate+index; remove redundant uuid alias

https://claude.ai/code/session_015M9A7z7ugv43AqrgFGoZ2g