### PR TITLE
Financial Core Enforcement: Fix double GL posting and ensure atomicity

### DIFF
--- a/pos_spj_v13.4/application/services/customer_credit_service.py
+++ b/pos_spj_v13.4/application/services/customer_credit_service.py
@@ -90,43 +90,45 @@ class CustomerCreditService:
         sucursal_id: int = 1,
     ) -> None:
         """
-        Registra la deuda en cuentas_por_cobrar y actualiza credit_balance del cliente.
-        Llamado DESPUÉS de que la transacción de venta ha sido confirmada (RELEASE SAVEPOINT).
+        Registra la deuda en cuentas_por_cobrar, actualiza credit_balance y asienta
+        el ledger DENTRO de la misma transacción.
+
+        NOTA: Este método es llamado post-SAVEPOINT para compatibilidad con flujos legacy.
+        Para nuevas ventas a crédito procesadas vía SalesService, CreditSaleFinanceHandler
+        maneja todo dentro del SAVEPOINT de forma atómica.
         """
         try:
-            # Registrar en CxC
             self.db.execute(
-                """INSERT INTO cuentas_por_cobrar
+                """INSERT OR IGNORE INTO cuentas_por_cobrar
                        (cliente_id, venta_id, folio, monto_original, saldo_pendiente,
                         sucursal_id, estado)
                    VALUES (?, ?, ?, ?, ?, ?, 'pendiente')""",
                 (cliente_id, sale_id, folio, monto, monto, sucursal_id),
             )
-            # Incrementar deuda en perfil del cliente
             self.db.execute(
                 "UPDATE clientes SET credit_balance = COALESCE(credit_balance, 0) + ? WHERE id = ?",
                 (monto, cliente_id),
             )
+
+            # Asiento contable DENTRO de la misma transacción (antes del commit)
+            # Garantiza que CxC y GL sean atómicos: si el asiento falla, la CxC no se graba.
+            if self._finance and hasattr(self._finance, "registrar_asiento"):
+                self._finance.registrar_asiento(
+                    debe          = "130.1-cuentas-por-cobrar",
+                    haber         = "401.0-ingresos-ventas",
+                    concepto      = f"Venta a crédito {folio}",
+                    monto         = monto,
+                    modulo        = "ventas",
+                    referencia_id = sale_id,
+                    sucursal_id   = sucursal_id,
+                    evento        = "VENTA_CREDITO",
+                    metadata      = {"cliente_id": cliente_id, "folio": folio},
+                )
+
             try:
                 self.db.commit()
             except Exception:
                 pass
-
-            # Asiento contable doble entrada (CLAUDE.md regla 11)
-            if self._finance and hasattr(self._finance, "registrar_asiento"):
-                try:
-                    self._finance.registrar_asiento(
-                        debe="130.1-cuentas-por-cobrar",
-                        haber="401.0-ingresos-ventas",
-                        concepto=f"Venta a crédito {folio}",
-                        monto=monto,
-                        modulo="ventas",
-                        referencia_id=sale_id,
-                        sucursal_id=sucursal_id,
-                        evento="VENTA_CREDITO",
-                    )
-                except Exception as e:
-                    logger.debug("registrar_asiento CxC: %s", e)
 
             logger.info(
                 "CxC registrada: cliente=%d venta=%d folio=%s monto=%.2f",
@@ -134,6 +136,11 @@ class CustomerCreditService:
             )
         except Exception as e:
             logger.error("register_credit_sale: %s", e)
+            try:
+                self.db.rollback()
+            except Exception:
+                pass
+            raise
 
     # ── Infraestructura ───────────────────────────────────────────────────────
 

--- a/pos_spj_v13.4/core/events/handlers/finance_handler.py
+++ b/pos_spj_v13.4/core/events/handlers/finance_handler.py
@@ -83,3 +83,155 @@ class SaleCreatedFinanceHandler:
             )
         except Exception as exc:
             logger.warning("SaleCreatedFinanceHandler: %s", exc)
+
+
+class CreditSaleFinanceHandler:
+    """
+    Subscribes to SALE_ITEMS_PROCESS for credit sales only.
+
+    Runs synchronously inside the sale SAVEPOINT (priority=85) so that both the
+    CxC record and the GL journal entry are atomic with the sale row.
+
+    Responsibilities:
+    1. INSERT into cuentas_por_cobrar
+    2. UPDATE clientes.credit_balance (increment debt)
+    3. registrar_asiento: debe=130.1-cuentas-por-cobrar / haber=401.0-ingresos-ventas
+
+    On any exception the handler re-raises so the SAVEPOINT rolls back the entire sale.
+    Non-credit sales are ignored silently.
+    """
+
+    def __init__(self, db_conn, finance_service):
+        self._db      = db_conn
+        self._finance = finance_service
+
+    def handle(self, payload: Dict[str, Any]) -> None:
+        payment_method = str(payload.get("payment_method", ""))
+        if payment_method != "Credito":
+            return
+
+        total       = float(payload.get("total", 0))
+        cliente_id  = payload.get("cliente_id") or payload.get("customer_id")
+        sale_id     = payload.get("sale_id") or payload.get("venta_id")
+        folio       = str(payload.get("folio", ""))
+        sucursal_id = int(payload.get("branch_id", payload.get("sucursal_id", 1)))
+
+        if total <= 0 or not cliente_id or not sale_id:
+            logger.warning(
+                "CreditSaleFinanceHandler: incomplete payload "
+                "total=%.2f cliente_id=%s sale_id=%s — skipping",
+                total, cliente_id, sale_id,
+            )
+            return
+
+        try:
+            self._db.execute(
+                """INSERT OR IGNORE INTO cuentas_por_cobrar
+                       (cliente_id, venta_id, folio, monto_original,
+                        saldo_pendiente, sucursal_id, estado)
+                   VALUES (?, ?, ?, ?, ?, ?, 'pendiente')""",
+                (cliente_id, sale_id, folio, total, total, sucursal_id),
+            )
+            self._db.execute(
+                "UPDATE clientes "
+                "SET credit_balance = COALESCE(credit_balance, 0) + ? "
+                "WHERE id = ?",
+                (total, cliente_id),
+            )
+
+            if hasattr(self._finance, "registrar_asiento"):
+                self._finance.registrar_asiento(
+                    debe         = "130.1-cuentas-por-cobrar",
+                    haber        = "401.0-ingresos-ventas",
+                    concepto     = f"Venta a crédito {folio}",
+                    monto        = total,
+                    modulo       = "ventas",
+                    referencia_id= sale_id,
+                    sucursal_id  = sucursal_id,
+                    evento       = "VENTA_CREDITO",
+                    metadata     = {"cliente_id": cliente_id, "folio": folio},
+                )
+
+            logger.info(
+                "CreditSaleFinanceHandler: CxC registrada cliente=%s venta=%s folio=%s monto=%.2f",
+                cliente_id, sale_id, folio, total,
+            )
+        except Exception as exc:
+            logger.error("CreditSaleFinanceHandler.handle: %s", exc)
+            raise  # re-raise: rolls back the SAVEPOINT
+
+
+class SaleCancelledFinanceHandler:
+    """
+    Subscribes to VENTA_CANCELADA (post-commit, async) and posts the GL reversal entry.
+
+    For cash sales: reverses the income journal (debe=401.0-ingresos-ventas / haber=110-caja).
+    For credit sales: reverses CxC (debe=401.0-ingresos-ventas / haber=130.1-cuentas-por-cobrar)
+                      and decrements credit_balance.
+
+    Errors are logged but do NOT re-raise (post-commit, sale already recorded as cancelled).
+    """
+
+    def __init__(self, db_conn, finance_service):
+        self._db      = db_conn
+        self._finance = finance_service
+
+    def handle(self, payload: Dict[str, Any]) -> None:
+        total          = float(payload.get("total", 0))
+        payment_method = str(payload.get("payment_method", payload.get("forma_pago", "")))
+        folio          = str(payload.get("folio", ""))
+        sale_id        = payload.get("venta_id") or payload.get("sale_id")
+        sucursal_id    = int(payload.get("sucursal_id", payload.get("branch_id", 1)))
+        cliente_id     = payload.get("cliente_id")
+
+        if total <= 0 or not sale_id:
+            return
+
+        try:
+            is_credit = payment_method == "Credito"
+
+            if is_credit:
+                # Reverse CxC: mark document as cancelled
+                self._db.execute(
+                    """UPDATE cuentas_por_cobrar
+                          SET estado='cancelada', saldo_pendiente=0
+                        WHERE venta_id=? AND sucursal_id=?""",
+                    (sale_id, sucursal_id),
+                )
+                if cliente_id:
+                    self._db.execute(
+                        "UPDATE clientes "
+                        "SET credit_balance = MAX(0, COALESCE(credit_balance,0) - ?) "
+                        "WHERE id = ?",
+                        (total, cliente_id),
+                    )
+                try:
+                    self._db.commit()
+                except Exception:
+                    pass
+                haber_cuenta = "130.1-cuentas-por-cobrar"
+            else:
+                haber_cuenta = "110-caja"
+
+            if hasattr(self._finance, "registrar_asiento"):
+                self._finance.registrar_asiento(
+                    debe         = "401.0-ingresos-ventas",
+                    haber        = haber_cuenta,
+                    concepto     = f"Reversal cancelación venta {folio}",
+                    monto        = total,
+                    modulo       = "ventas",
+                    referencia_id= sale_id,
+                    sucursal_id  = sucursal_id,
+                    evento       = "VENTA_CANCELADA",
+                    metadata     = {
+                        "folio":          folio,
+                        "payment_method": payment_method,
+                        "cliente_id":     cliente_id,
+                    },
+                )
+            logger.info(
+                "SaleCancelledFinanceHandler: reversal registrado venta=%s folio=%s total=%.2f",
+                sale_id, folio, total,
+            )
+        except Exception as exc:
+            logger.warning("SaleCancelledFinanceHandler.handle: %s", exc)

--- a/pos_spj_v13.4/core/events/wiring.py
+++ b/pos_spj_v13.4/core/events/wiring.py
@@ -80,71 +80,29 @@ def wire_all(container: "AppContainer") -> None:
 
 def _wire_flujos_criticos(bus, container) -> None:
     """
-    Wiring mínimo para operaciones críticas:
-      SALE_ITEMS_PROCESS -> inventory + finance  (Phase 1 — via SaleInventoryHandler/SaleFinanceHandler)
-      COMPRA_REGISTRADA  -> inventory/finance
-      MERMA_REGISTRADA   -> finance
+    DEPRECATED HANDLERS REMOVED — 2026-05-08 financial-core audit.
+
+    Previously subscribed:
+      - _compra_stock   on COMPRA_REGISTRADA: caused double inventory-IN because
+        PurchaseInventoryHandler (Phase 4) already handles stock via PURCHASE_ITEMS_PROCESS.
+      - _compra_egreso  on COMPRA_REGISTRADA (= PURCHASE_CREATED alias): caused double
+        GL posting because PurchaseFinanceHandler already posts the asiento via PURCHASE_CREATED.
+      - _merma_perdida  on MERMA_CREATED: caused double GL posting because
+        _wire_merma_financiero already calls registrar_asiento() with explicit debe/haber.
+
+    All three flows are now handled exclusively by their Phase handlers:
+      - Purchase inventory : PurchaseInventoryHandler  (PURCHASE_ITEMS_PROCESS, priority=100)
+      - Purchase GL        : PurchaseFinanceHandler     (PURCHASE_CREATED,       priority=80)
+      - Merma GL           : _wire_merma_financiero     (MERMA_CREATED,          priority=50)
+      - Merma stock        : _wire_merma_inventario     (MERMA_CREATED,          priority=80)
     """
-    from core.events.event_bus import (
-        COMPRA_REGISTRADA, MERMA_CREATED
-    )
-    # NOTE: VENTA_COMPLETADA → inventory/finance was removed here (Phase 1).
-    # That coupling now lives in SaleInventoryHandler / SaleFinanceHandler
-    # registered by _wire_sale_handlers(), which subscribe to SALE_ITEMS_PROCESS.
-
-    def _compra_stock(data: dict) -> None:
-        inv = getattr(container, "inventory_service", None)
-        if not inv or not hasattr(inv, "incrementar_stock"):
-            return
-        for item in data.get("items", []):
-            try:
-                inv.incrementar_stock(
-                    producto_id=item.get("producto_id"),
-                    cantidad=float(item.get("cantidad", 0)),
-                    unit_cost=float(item.get("costo_unitario", item.get("unit_cost", 0))),
-                    branch_id=data.get("sucursal_id", 1),
-                    referencia_id=data.get("compra_id", "COMPRA"),
-                    usuario=data.get("usuario", "sistema"),
-                    operation_id=data.get("operation_id"),
-                )
-            except Exception:
-                continue
-
-    def _compra_egreso(data: dict) -> None:
-        fs = getattr(container, "finance_service", None)
-        if not fs or not hasattr(fs, "registrar_egreso"):
-            return
-        fs.registrar_egreso(
-            concepto=f"Compra #{data.get('compra_id', '')}",
-            monto=float(data.get("total", data.get("monto", 0))),
-            referencia_id=data.get("compra_id"),
-            usuario_id=data.get("usuario_id"),
-            sucursal_id=data.get("sucursal_id", 1),
-            metadata={"proveedor_id": data.get("proveedor_id")},
-        )
-
-    def _merma_perdida(data: dict) -> None:
-        fs = getattr(container, "finance_service", None)
-        if not fs or not hasattr(fs, "registrar_perdida"):
-            return
-        fs.registrar_perdida(
-            concepto=f"Merma #{data.get('merma_id', '')}",
-            monto=float(data.get("valor", data.get("costo", 0))),
-            referencia_id=data.get("merma_id"),
-            usuario_id=data.get("usuario_id"),
-            sucursal_id=data.get("sucursal_id", 1),
-            metadata={"producto_id": data.get("producto_id")},
-        )
-
-    bus.subscribe(COMPRA_REGISTRADA, _compra_stock, priority=45, label="compra_stock_critico")
-    bus.subscribe(COMPRA_REGISTRADA, _compra_egreso, priority=45, label="compra_egreso_critico")
-    bus.subscribe(MERMA_CREATED, _merma_perdida, priority=45, label="merma_perdida_critico")
+    pass  # No active subscriptions — kept as named function for clarity in wire_all()
 
 
 # ── VENTA_COMPLETADA ──────────────────────────────────────────────────────────
 
 def _wire_venta(bus, container) -> None:
-    from core.events.event_bus import VENTA_COMPLETADA
+    from core.events.event_bus import VENTA_COMPLETADA, VENTA_CANCELADA
 
     # Prioridad 100: Sync (CRÍTICO)
     def _sync_venta(data: dict) -> None:
@@ -209,6 +167,16 @@ def _wire_venta(bus, container) -> None:
 
     bus.subscribe(VENTA_COMPLETADA, _audit_venta,
                   priority=30, label="audit_venta")
+
+    # VENTA_CANCELADA → GL reversal (post-commit, async — sale already cancelled)
+    fs = getattr(container, "finance_service", None)
+    db = getattr(container, "db", None)
+    if fs and db:
+        from core.events.handlers.finance_handler import SaleCancelledFinanceHandler
+        cancel_handler = SaleCancelledFinanceHandler(db_conn=db, finance_service=fs)
+        bus.subscribe(VENTA_CANCELADA, cancel_handler.handle,
+                      priority=50, label="sale_cancelled_reversal")
+        logger.debug("Registered SaleCancelledFinanceHandler on %s", VENTA_CANCELADA)
 
 
 # ── PEDIDO_NUEVO ──────────────────────────────────────────────────────────────
@@ -710,6 +678,18 @@ def _wire_sale_handlers(bus, container) -> None:
             label="sale_finance_income",
         )
         logger.debug("Registered SaleFinanceHandler on %s", SALE_ITEMS_PROCESS)
+
+    db = getattr(container, "db", None)
+    if fs and db:
+        from core.events.handlers.finance_handler import CreditSaleFinanceHandler
+        credit_handler = CreditSaleFinanceHandler(db_conn=db, finance_service=fs)
+        bus.subscribe(
+            SALE_ITEMS_PROCESS,
+            credit_handler.handle,
+            priority=85,
+            label="sale_credit_cxc",
+        )
+        logger.debug("Registered CreditSaleFinanceHandler on %s", SALE_ITEMS_PROCESS)
 
 
 # ── Phase 3: PRODUCTION_ITEMS_PROCESS handler ────────────────────────────────

--- a/pos_spj_v13.4/core/services/anticipo_service.py
+++ b/pos_spj_v13.4/core/services/anticipo_service.py
@@ -17,8 +17,9 @@ logger = logging.getLogger("spj.anticipo")
 
 class AnticipoCotizacionService:
 
-    def __init__(self, db_conn):
-        self.db = db_conn
+    def __init__(self, db_conn, finance_service=None):
+        self.db           = db_conn
+        self._finance     = finance_service
         self._config_cache: dict = {}
         self._rules_cache: list = []
         self._cache_ts: float = 0
@@ -244,12 +245,14 @@ class AnticipoCotizacionService:
 
     def registrar_anticipo_pagado(self, numero_orden: str,
                                    monto: float, metodo: str,
-                                   payment_id: str = "") -> None:
+                                   payment_id: str = "",
+                                   sucursal_id: int = 1,
+                                   usuario: str = "sistema") -> None:
         orden = self.get_orden(numero_orden)
         if not orden: return
         nuevo_estado = (
             "en_preparacion"
-            if (orden["anticipo_pagado"] + monto) >= orden["monto_anticipo"] - 0.01
+            if (orden.get("anticipo_pagado", 0) + monto) >= orden["monto_anticipo"] - 0.01
             else "anticipo_pendiente"
         )
         self.db.execute("""
@@ -260,6 +263,31 @@ class AnticipoCotizacionService:
                 estado          = ?
             WHERE numero_orden = ?
         """, (monto, metodo, payment_id, nuevo_estado, numero_orden))
+
+        # Asiento contable doble entrada para anticipo recibido (regla 11 CLAUDE.md)
+        # debe=caja/banco haber=anticipos_de_clientes
+        if self._finance and hasattr(self._finance, "registrar_asiento"):
+            try:
+                cuenta_debe = "110-caja" if metodo == "Efectivo" else "112-banco"
+                self._finance.registrar_asiento(
+                    debe          = cuenta_debe,
+                    haber         = "217-anticipos-de-clientes",
+                    concepto      = f"Anticipo recibido orden {numero_orden} — método {metodo}",
+                    monto         = monto,
+                    modulo        = "cotizaciones",
+                    referencia_id = numero_orden,
+                    sucursal_id   = sucursal_id,
+                    evento        = "ANTICIPO_PAGADO",
+                    metadata      = {
+                        "numero_orden": numero_orden,
+                        "cliente_id":   orden.get("cliente_id"),
+                        "metodo":       metodo,
+                        "payment_id":   payment_id,
+                    },
+                )
+            except Exception as exc:
+                logger.warning("registrar_anticipo_pagado asiento: %s", exc)
+
         try: self.db.commit()
         except Exception: pass
 

--- a/pos_spj_v13.4/core/services/cierre_caja_service.py
+++ b/pos_spj_v13.4/core/services/cierre_caja_service.py
@@ -18,10 +18,12 @@ logger = logging.getLogger("spj.caja.cierre")
 
 
 class CierreCajaService:
-    def __init__(self, conn=None, sucursal_id: int = 1, usuario: str = "admin"):
-        self.conn        = conn or get_connection()
-        self.sucursal_id = sucursal_id
-        self.usuario     = usuario
+    def __init__(self, conn=None, sucursal_id: int = 1, usuario: str = "admin",
+                 finance_service=None):
+        self.conn            = conn or get_connection()
+        self.sucursal_id     = sucursal_id
+        self.usuario         = usuario
+        self._finance        = finance_service
         self._init_tables()
 
     def _init_tables(self):
@@ -238,6 +240,34 @@ class CierreCajaService:
             resumen["cierre_id"] = cid
             logger.info("Corte Z generado #%d — ventas=%d total=$%.2f diff=$%.2f",
                         cid, resumen["num_ventas"], resumen["total_ventas"], diferencia)
+
+            # Asiento contable para discrepancia de caja (regla 11 CLAUDE.md)
+            if diferencia != 0 and self._finance and hasattr(self._finance, "registrar_asiento"):
+                try:
+                    if diferencia > 0:
+                        # Sobrante: caja tiene más efectivo del esperado
+                        debe, haber = "110-caja", "999-diferencias-caja"
+                    else:
+                        # Faltante: caja tiene menos efectivo del esperado
+                        debe, haber = "999-diferencias-caja", "110-caja"
+                    self._finance.registrar_asiento(
+                        debe          = debe,
+                        haber         = haber,
+                        concepto      = (f"Diferencia Corte Z #{cid} — cajero: {self.usuario} "
+                                         f"({'sobrante' if diferencia > 0 else 'faltante'})"),
+                        monto         = abs(diferencia),
+                        modulo        = "caja",
+                        referencia_id = cid,
+                        sucursal_id   = self.sucursal_id,
+                        evento        = "CORTE_Z",
+                        metadata      = {
+                            "efectivo_contado": efectivo_contado,
+                            "efectivo_esperado": resumen["total_efectivo"] + resumen["fondo_inicial"],
+                            "cajero": self.usuario,
+                        },
+                    )
+                except Exception as exc:
+                    logger.warning("Corte Z asiento diferencia: %s", exc)
         return resumen
 
     def get_historial(self, limit: int = 30) -> list:

--- a/pos_spj_v13.4/tests/test_financial_core_enforcement.py
+++ b/pos_spj_v13.4/tests/test_financial_core_enforcement.py
@@ -1,0 +1,522 @@
+# tests/test_financial_core_enforcement.py — SPJ ERP Financial Core Audit 2026-05-08
+"""
+Regression tests for the Financial Core Enforcement audit.
+
+Covers the six critical fixes applied:
+  1. No double GL posting on purchases (removed _compra_egreso/_compra_stock from wiring)
+  2. CreditSaleFinanceHandler — CxC + GL inside SAVEPOINT for credit sales
+  3. SaleCancelledFinanceHandler — GL reversal on sale cancellation
+  4. CustomerCreditService.register_credit_sale — GL asiento before commit
+  5. CierreCajaService.corte_z — asiento for cash discrepancies
+  6. AnticipoCotizacionService.registrar_anticipo_pagado — asiento for advance payments
+"""
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock, call, patch
+import pytest
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _memory_db() -> sqlite3.Connection:
+    """In-memory SQLite with Row factory and WAL disabled (no WAL in :memory:)."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS cuentas_por_cobrar (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            cliente_id      INTEGER NOT NULL,
+            venta_id        INTEGER,
+            folio           TEXT,
+            monto_original  REAL    NOT NULL,
+            saldo_pendiente REAL    NOT NULL,
+            estado          TEXT    DEFAULT 'pendiente',
+            sucursal_id     INTEGER DEFAULT 1,
+            fecha           DATETIME DEFAULT (datetime('now')),
+            fecha_pago      DATETIME
+        );
+        CREATE TABLE IF NOT EXISTS clientes (
+            id             INTEGER PRIMARY KEY,
+            nombre         TEXT,
+            activo         INTEGER DEFAULT 1,
+            credit_limit   REAL DEFAULT 0,
+            credit_balance REAL DEFAULT 0,
+            puntos         INTEGER DEFAULT 0,
+            allows_credit  INTEGER DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS financial_event_log (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            cuenta_debe TEXT,
+            cuenta_haber TEXT,
+            concepto    TEXT,
+            monto       REAL,
+            modulo      TEXT,
+            evento      TEXT,
+            sucursal_id INTEGER DEFAULT 1,
+            fecha       DATETIME DEFAULT (datetime('now'))
+        );
+        CREATE TABLE IF NOT EXISTS ventas (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            folio       TEXT,
+            total       REAL,
+            estado      TEXT DEFAULT 'completada',
+            sucursal_id INTEGER DEFAULT 1,
+            forma_pago  TEXT DEFAULT 'Efectivo',
+            fecha       DATETIME DEFAULT (datetime('now'))
+        );
+        CREATE TABLE IF NOT EXISTS cierres_caja (
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            uuid             TEXT UNIQUE DEFAULT (lower(hex(randomblob(16)))),
+            tipo             TEXT DEFAULT 'Z',
+            sucursal_id      INTEGER DEFAULT 1,
+            usuario          TEXT,
+            turno            TEXT,
+            fecha_apertura   DATETIME,
+            fecha_cierre     DATETIME DEFAULT (datetime('now')),
+            total_ventas     REAL DEFAULT 0,
+            num_ventas       INTEGER DEFAULT 0,
+            total_efectivo   REAL DEFAULT 0,
+            total_tarjeta    REAL DEFAULT 0,
+            total_transferencia REAL DEFAULT 0,
+            total_otros      REAL DEFAULT 0,
+            total_anulaciones REAL DEFAULT 0,
+            num_anulaciones  INTEGER DEFAULT 0,
+            efectivo_contado REAL DEFAULT 0,
+            fondo_inicial    REAL DEFAULT 0,
+            diferencia       REAL DEFAULT 0,
+            comentarios      TEXT,
+            estado           TEXT DEFAULT 'cerrado'
+        );
+        CREATE TABLE IF NOT EXISTS turno_actual (
+            sucursal_id    INTEGER PRIMARY KEY,
+            usuario        TEXT,
+            turno          TEXT,
+            fondo_inicial  REAL DEFAULT 0,
+            fecha_apertura DATETIME,
+            abierto        INTEGER DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS ordenes_cotizacion (
+            id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+            numero_orden         TEXT UNIQUE,
+            cotizacion_id        INTEGER,
+            cliente_id           INTEGER,
+            sucursal_id          INTEGER DEFAULT 1,
+            estado               TEXT DEFAULT 'anticipo_pendiente',
+            requiere_anticipo    INTEGER DEFAULT 0,
+            pct_anticipo_aplicado REAL DEFAULT 0,
+            razon_anticipo       TEXT,
+            monto_anticipo       REAL DEFAULT 0,
+            anticipo_pagado      REAL DEFAULT 0,
+            metodo_anticipo      TEXT,
+            payment_id           TEXT,
+            fecha_entrega        TEXT,
+            hora_entrega         TEXT,
+            tipo_entrega         TEXT,
+            notas                TEXT,
+            usuario_asigno       TEXT
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _mock_finance():
+    """Finance service mock that records registrar_asiento calls."""
+    fs = MagicMock()
+    fs.registrar_asiento = MagicMock()
+    return fs
+
+
+# ── 1. Double GL fix: _compra_egreso removed ─────────────────────────────────
+
+class TestNoPurchaseDoubleGL:
+    """Verify _compra_egreso is no longer wired on COMPRA_REGISTRADA."""
+
+    def test_wire_flujos_criticos_has_no_active_subscriptions(self):
+        """_wire_flujos_criticos must be a no-op (pass) after the audit fix."""
+        from core.events.wiring import _wire_flujos_criticos
+
+        bus     = MagicMock()
+        container = MagicMock()
+        _wire_flujos_criticos(bus, container)
+
+        bus.subscribe.assert_not_called()
+
+    def test_purchase_finance_handler_subscribes_once(self):
+        """PurchaseFinanceHandler registers exactly once on PURCHASE_CREATED."""
+        from core.events.wiring import _wire_purchase_items_handlers
+        from core.events.domain_events import PURCHASE_CREATED
+
+        bus = MagicMock()
+        container = MagicMock()
+        container.inventory_service = None   # disable inv handler to isolate
+        container.finance_service   = _mock_finance()
+
+        _wire_purchase_items_handlers(bus, container)
+
+        finance_subs = [c for c in bus.subscribe.call_args_list
+                        if c.args[0] == PURCHASE_CREATED]
+        assert len(finance_subs) == 1, (
+            f"PurchaseFinanceHandler must register exactly once; got {len(finance_subs)}"
+        )
+
+
+# ── 2. CreditSaleFinanceHandler ───────────────────────────────────────────────
+
+class TestCreditSaleFinanceHandler:
+
+    def setup_method(self):
+        self.db = _memory_db()
+        self.db.execute(
+            "INSERT INTO clientes (id, nombre, credit_limit, credit_balance) VALUES (1,'Ana',5000,0)"
+        )
+        self.db.commit()
+        self.fs = _mock_finance()
+
+    def _handler(self):
+        from core.events.handlers.finance_handler import CreditSaleFinanceHandler
+        return CreditSaleFinanceHandler(db_conn=self.db, finance_service=self.fs)
+
+    def test_credit_sale_creates_cxc_record(self):
+        handler = self._handler()
+        handler.handle({
+            "payment_method": "Credito",
+            "total": 1200.0,
+            "cliente_id": 1,
+            "sale_id": 42,
+            "folio": "VNT-001",
+            "sucursal_id": 1,
+        })
+        row = self.db.execute(
+            "SELECT saldo_pendiente, estado FROM cuentas_por_cobrar WHERE venta_id=42"
+        ).fetchone()
+        assert row is not None, "CxC record must be created for credit sale"
+        assert float(row["saldo_pendiente"]) == 1200.0
+        assert row["estado"] == "pendiente"
+
+    def test_credit_sale_increments_client_balance(self):
+        handler = self._handler()
+        handler.handle({
+            "payment_method": "Credito",
+            "total": 800.0,
+            "cliente_id": 1,
+            "sale_id": 43,
+            "folio": "VNT-002",
+            "sucursal_id": 1,
+        })
+        row = self.db.execute(
+            "SELECT credit_balance FROM clientes WHERE id=1"
+        ).fetchone()
+        assert float(row["credit_balance"]) == 800.0
+
+    def test_credit_sale_registers_ledger_entry(self):
+        handler = self._handler()
+        handler.handle({
+            "payment_method": "Credito",
+            "total": 500.0,
+            "cliente_id": 1,
+            "sale_id": 44,
+            "folio": "VNT-003",
+            "sucursal_id": 1,
+        })
+        self.fs.registrar_asiento.assert_called_once()
+        kwargs = self.fs.registrar_asiento.call_args.kwargs
+        assert "130.1-cuentas-por-cobrar" in kwargs["debe"]
+        assert "401.0-ingresos-ventas" in kwargs["haber"]
+        assert kwargs["monto"] == 500.0
+        assert kwargs["evento"] == "VENTA_CREDITO"
+
+    def test_cash_sale_ignored(self):
+        """Handler must be a no-op for non-credit payment methods."""
+        handler = self._handler()
+        handler.handle({
+            "payment_method": "Efectivo",
+            "total": 300.0,
+            "cliente_id": 1,
+            "sale_id": 45,
+            "folio": "VNT-004",
+        })
+        self.fs.registrar_asiento.assert_not_called()
+        row = self.db.execute(
+            "SELECT id FROM cuentas_por_cobrar WHERE venta_id=45"
+        ).fetchone()
+        assert row is None
+
+    def test_reraises_on_failure(self):
+        """Handler re-raises so the SAVEPOINT rolls back."""
+        self.fs.registrar_asiento.side_effect = RuntimeError("DB locked")
+        handler = self._handler()
+        with pytest.raises(RuntimeError):
+            handler.handle({
+                "payment_method": "Credito",
+                "total": 200.0,
+                "cliente_id": 1,
+                "sale_id": 46,
+                "folio": "VNT-005",
+                "sucursal_id": 1,
+            })
+
+
+# ── 3. SaleCancelledFinanceHandler ────────────────────────────────────────────
+
+class TestSaleCancelledFinanceHandler:
+
+    def setup_method(self):
+        self.db = _memory_db()
+        # Pre-create CxC record for credit sale cancellation test
+        self.db.execute(
+            "INSERT INTO clientes (id, nombre, credit_balance) VALUES (1,'Bob',1000)"
+        )
+        self.db.execute(
+            "INSERT INTO cuentas_por_cobrar "
+            "(cliente_id,venta_id,folio,monto_original,saldo_pendiente,sucursal_id) "
+            "VALUES (1,10,'VNT-010',1000,1000,1)"
+        )
+        self.db.commit()
+        self.fs = _mock_finance()
+
+    def _handler(self):
+        from core.events.handlers.finance_handler import SaleCancelledFinanceHandler
+        return SaleCancelledFinanceHandler(db_conn=self.db, finance_service=self.fs)
+
+    def test_cash_sale_cancellation_posts_reversal(self):
+        handler = self._handler()
+        handler.handle({
+            "venta_id": 99,
+            "folio": "VNT-099",
+            "total": 300.0,
+            "payment_method": "Efectivo",
+            "sucursal_id": 1,
+        })
+        self.fs.registrar_asiento.assert_called_once()
+        kwargs = self.fs.registrar_asiento.call_args.kwargs
+        assert kwargs["debe"] == "401.0-ingresos-ventas"
+        assert kwargs["haber"] == "110-caja"
+        assert kwargs["monto"] == 300.0
+        assert kwargs["evento"] == "VENTA_CANCELADA"
+
+    def test_credit_sale_cancellation_reverses_cxc(self):
+        handler = self._handler()
+        handler.handle({
+            "venta_id": 10,
+            "folio": "VNT-010",
+            "total": 1000.0,
+            "payment_method": "Credito",
+            "sucursal_id": 1,
+            "cliente_id": 1,
+        })
+        # CxC should be marked cancelled
+        row = self.db.execute(
+            "SELECT estado, saldo_pendiente FROM cuentas_por_cobrar WHERE venta_id=10"
+        ).fetchone()
+        assert row["estado"] == "cancelada"
+        assert float(row["saldo_pendiente"]) == 0.0
+
+        # Client balance decremented
+        bal = self.db.execute(
+            "SELECT credit_balance FROM clientes WHERE id=1"
+        ).fetchone()
+        assert float(bal["credit_balance"]) == 0.0
+
+        # GL reversal posted with CxC account
+        kwargs = self.fs.registrar_asiento.call_args.kwargs
+        assert kwargs["haber"] == "130.1-cuentas-por-cobrar"
+
+    def test_zero_total_skipped(self):
+        handler = self._handler()
+        handler.handle({"venta_id": 1, "total": 0.0, "payment_method": "Efectivo"})
+        self.fs.registrar_asiento.assert_not_called()
+
+
+# ── 4. CustomerCreditService atomicity ───────────────────────────────────────
+
+class TestCustomerCreditServiceAtomicity:
+    """registrar_asiento must be called BEFORE commit — if it fails, CxC is not persisted."""
+
+    def setup_method(self):
+        self.db = _memory_db()
+        self.db.execute(
+            "INSERT INTO clientes (id, nombre, credit_balance) VALUES (5,'Carlos',0)"
+        )
+        self.db.commit()
+
+    def _svc(self, fs):
+        from application.services.customer_credit_service import CustomerCreditService
+        return CustomerCreditService(db_conn=self.db, finance_service=fs)
+
+    def test_asiento_called_before_commit(self):
+        """registrar_asiento must appear before db.commit in the call sequence."""
+        call_order = []
+
+        class TrackedConn:
+            """Thin wrapper that records asiento/commit ordering."""
+            def __init__(self, conn):
+                self._conn = conn
+            def execute(self, *a, **kw):
+                return self._conn.execute(*a, **kw)
+            def commit(self):
+                call_order.append("commit")
+                self._conn.commit()
+            def rollback(self):
+                self._conn.rollback()
+            def executescript(self, *a, **kw):
+                return self._conn.executescript(*a, **kw)
+
+        wrapped = TrackedConn(self.db)
+
+        fs = _mock_finance()
+        def tracked_asiento(**kwargs):
+            call_order.append("asiento")
+        fs.registrar_asiento.side_effect = tracked_asiento
+
+        from application.services.customer_credit_service import CustomerCreditService
+        svc = CustomerCreditService(db_conn=wrapped, finance_service=fs)
+        svc.register_credit_sale(5, 100, "VNT-100", 500.0, sucursal_id=1)
+
+        assert "asiento" in call_order, "registrar_asiento must be called"
+        assert "commit" in call_order, "db.commit must be called"
+        # _ensure_cxc_table() in __init__ emits an early commit; we care that
+        # registrar_asiento precedes the LAST commit (the one in register_credit_sale).
+        last_commit_idx  = len(call_order) - 1 - call_order[::-1].index("commit")
+        asiento_idx      = call_order.index("asiento")
+        assert asiento_idx < last_commit_idx, (
+            f"registrar_asiento must be called BEFORE the final db.commit(); "
+            f"call_order={call_order}"
+        )
+
+    def test_cxc_persisted_on_success(self):
+        svc = self._svc(_mock_finance())
+        svc.register_credit_sale(5, 101, "VNT-101", 750.0, sucursal_id=1)
+        row = self.db.execute(
+            "SELECT saldo_pendiente FROM cuentas_por_cobrar WHERE venta_id=101"
+        ).fetchone()
+        assert row is not None
+        assert float(row["saldo_pendiente"]) == 750.0
+
+
+# ── 5. CierreCajaService corte Z discrepancy asiento ─────────────────────────
+
+class TestCierreCajaDiscrepancyAsiento:
+
+    def setup_method(self):
+        self.db = _memory_db()
+        # Open a shift
+        self.db.execute(
+            "INSERT INTO turno_actual (sucursal_id, usuario, turno, fondo_inicial, "
+            "fecha_apertura, abierto) VALUES (1,'cajero1','Mañana',100,datetime('now'),1)"
+        )
+        # Add a completed cash sale
+        self.db.execute(
+            "INSERT INTO ventas (folio,total,estado,sucursal_id,forma_pago,fecha) "
+            "VALUES ('V001',500,'completada',1,'Efectivo',datetime('now'))"
+        )
+        self.db.commit()
+        self.fs = _mock_finance()
+
+    def _svc(self):
+        from core.services.cierre_caja_service import CierreCajaService
+        return CierreCajaService(conn=self.db, sucursal_id=1,
+                                  usuario="cajero1", finance_service=self.fs)
+
+    def test_surplus_posts_asiento(self):
+        """Efectivo_contado > expected → sobrante → asiento debe=caja haber=diferencias."""
+        svc = self._svc()
+        # Expected: 500 (ventas) + 100 (fondo) = 600; countado 650 → +50 surplus
+        result = svc.corte_z(efectivo_contado=650.0)
+        assert result["diferencia"] == pytest.approx(50.0, abs=0.01)
+        self.fs.registrar_asiento.assert_called_once()
+        kwargs = self.fs.registrar_asiento.call_args.kwargs
+        assert kwargs["debe"] == "110-caja"
+        assert kwargs["haber"] == "999-diferencias-caja"
+        assert kwargs["monto"] == pytest.approx(50.0, abs=0.01)
+        assert kwargs["evento"] == "CORTE_Z"
+
+    def test_shortage_posts_asiento(self):
+        """Efectivo_contado < expected → faltante → asiento debe=diferencias haber=caja."""
+        svc = self._svc()
+        result = svc.corte_z(efectivo_contado=580.0)
+        assert result["diferencia"] == pytest.approx(-20.0, abs=0.01)
+        kwargs = self.fs.registrar_asiento.call_args.kwargs
+        assert kwargs["debe"] == "999-diferencias-caja"
+        assert kwargs["haber"] == "110-caja"
+        assert kwargs["monto"] == pytest.approx(20.0, abs=0.01)
+
+    def test_zero_difference_skips_asiento(self):
+        """Exact cash count produces no asiento."""
+        svc = self._svc()
+        result = svc.corte_z(efectivo_contado=600.0)
+        assert result["diferencia"] == pytest.approx(0.0, abs=0.01)
+        self.fs.registrar_asiento.assert_not_called()
+
+    def test_corte_z_without_finance_service_does_not_crash(self):
+        from core.services.cierre_caja_service import CierreCajaService
+        svc = CierreCajaService(conn=self.db, sucursal_id=1, usuario="cajero1")
+        result = svc.corte_z(efectivo_contado=620.0)
+        # Should complete without error even if no finance_service
+        assert "cierre_id" in result
+
+
+# ── 6. AnticipoCotizacionService asiento ─────────────────────────────────────
+
+class TestAnticipoAsiento:
+
+    def setup_method(self):
+        self.db = _memory_db()
+        self.db.execute("""
+            INSERT INTO ordenes_cotizacion
+              (numero_orden, cotizacion_id, cliente_id, sucursal_id,
+               monto_anticipo, anticipo_pagado, estado)
+            VALUES ('ORD-001', 1, 7, 1, 1000.0, 0.0, 'anticipo_pendiente')
+        """)
+        self.db.commit()
+        self.fs = _mock_finance()
+
+    def _svc(self):
+        from core.services.anticipo_service import AnticipoCotizacionService
+        return AnticipoCotizacionService(db_conn=self.db, finance_service=self.fs)
+
+    def test_efectivo_anticipo_posts_caja_haber_anticipos(self):
+        svc = self._svc()
+        svc.registrar_anticipo_pagado("ORD-001", 500.0, "Efectivo", sucursal_id=1)
+        self.fs.registrar_asiento.assert_called_once()
+        kwargs = self.fs.registrar_asiento.call_args.kwargs
+        assert kwargs["debe"] == "110-caja"
+        assert kwargs["haber"] == "217-anticipos-de-clientes"
+        assert kwargs["monto"] == 500.0
+        assert kwargs["evento"] == "ANTICIPO_PAGADO"
+
+    def test_transferencia_anticipo_posts_banco(self):
+        svc = self._svc()
+        svc.registrar_anticipo_pagado("ORD-001", 300.0, "Transferencia", sucursal_id=1)
+        kwargs = self.fs.registrar_asiento.call_args.kwargs
+        assert kwargs["debe"] == "112-banco"
+
+    def test_anticipo_updates_orden_estado(self):
+        svc = self._svc()
+        svc.registrar_anticipo_pagado("ORD-001", 1000.0, "Efectivo", sucursal_id=1)
+        row = self.db.execute(
+            "SELECT estado, anticipo_pagado FROM ordenes_cotizacion WHERE numero_orden='ORD-001'"
+        ).fetchone()
+        assert row["estado"] == "en_preparacion"
+        assert float(row["anticipo_pagado"]) == 1000.0
+
+    def test_anticipo_finance_failure_does_not_crash(self):
+        """Finance failure logs but does not propagate — orden state must still update."""
+        self.fs.registrar_asiento.side_effect = RuntimeError("timeout")
+        svc = self._svc()
+        svc.registrar_anticipo_pagado("ORD-001", 200.0, "Efectivo", sucursal_id=1)
+        row = self.db.execute(
+            "SELECT anticipo_pagado FROM ordenes_cotizacion WHERE numero_orden='ORD-001'"
+        ).fetchone()
+        assert float(row["anticipo_pagado"]) == 200.0
+
+    def test_no_finance_service_does_not_crash(self):
+        from core.services.anticipo_service import AnticipoCotizacionService
+        svc = AnticipoCotizacionService(db_conn=self.db)
+        svc.registrar_anticipo_pagado("ORD-001", 100.0, "Efectivo")
+        row = self.db.execute(
+            "SELECT anticipo_pagado FROM ordenes_cotizacion WHERE numero_orden='ORD-001'"
+        ).fetchone()
+        assert float(row["anticipo_pagado"]) == 100.0


### PR DESCRIPTION
## Summary

This PR implements critical fixes to the financial core to eliminate double GL postings and ensure atomicity between database records and ledger entries. The changes address six specific issues identified in the 2026-05-08 financial audit.

## Key Changes

### 1. **Remove deprecated double-posting handlers** (`core/events/wiring.py`)
   - Removed `_compra_stock` and `_compra_egreso` subscriptions from `_wire_flujos_criticos()` that were causing duplicate GL entries on purchase registration
   - These operations are now handled exclusively by `PurchaseFinanceHandler` (PURCHASE_CREATED) and `PurchaseInventoryHandler` (PURCHASE_ITEMS_PROCESS)
   - Removed `_merma_perdida` handler that was duplicating GL posts already made by `_wire_merma_financiero()`

### 2. **Add CreditSaleFinanceHandler** (`core/events/handlers/finance_handler.py`)
   - New handler for credit sales that runs synchronously inside the sale SAVEPOINT (priority=85)
   - Atomically creates CxC record, updates client credit balance, and posts GL entry (debe=130.1-cuentas-por-cobrar / haber=401.0-ingresos-ventas)
   - Re-raises exceptions to trigger SAVEPOINT rollback on failure, ensuring consistency

### 3. **Add SaleCancelledFinanceHandler** (`core/events/handlers/finance_handler.py`)
   - New handler for sale cancellations that posts GL reversals post-commit
   - For cash sales: reverses income entry (debe=401.0-ingresos-ventas / haber=110-caja)
   - For credit sales: reverses CxC entry and decrements client credit balance
   - Registered on VENTA_CANCELADA event in `_wire_venta()`

### 4. **Ensure GL atomicity in CustomerCreditService** (`application/services/customer_credit_service.py`)
   - Modified `register_credit_sale()` to call `registrar_asiento()` BEFORE `db.commit()`
   - Guarantees that if GL posting fails, the CxC record is not persisted
   - Maintains backward compatibility with legacy post-SAVEPOINT calls

### 5. **Add cash discrepancy asiento in CierreCajaService** (`core/services/cierre_caja_service.py`)
   - Modified `corte_z()` to post GL entries for cash count discrepancies
   - Surplus: debe=110-caja / haber=999-diferencias-caja
   - Shortage: debe=999-diferencias-caja / haber=110-caja
   - Skips posting if difference is zero

### 6. **Add advance payment asiento in AnticipoCotizacionService** (`core/services/anticipo_service.py`)
   - Modified `registrar_anticipo_pagado()` to post GL entries for advance payments
   - debe=110-caja (or 112-banco for transfers) / haber=217-anticipos-de-clientes
   - Updates orden estado to "en_preparacion" when advance is fully paid
   - Gracefully handles finance service failures without crashing

## Implementation Details

- All GL postings now follow the double-entry principle (regla 11 from CLAUDE.md)
- Event handlers use consistent metadata structure with `evento`, `referencia_id`, and `metadata` fields
- Finance service is optional; services degrade gracefully if not available
- Comprehensive regression test suite added (`tests/test_financial_core_enforcement.py`) covering all six fixes with 522 lines of test code
- All changes maintain backward compatibility with existing code paths

## Testing

Added 522 lines of regression tests covering:
- Purchase double-posting prevention
- Credit sale CxC + GL atomicity
- Sale cancellation reversals
- Cash discrepancy handling
- Advance payment GL entries
- Graceful degradation when finance service is unavailable

https://claude.ai/code/session_01Pp6Dd39NA8Eza8YMiJh3gz