### PR TITLE
polish(pos): section labels, action hierarchy, standard color, propor…

### DIFF
--- a/pos_spj_v13.4/modulos/design_tokens.py
+++ b/pos_spj_v13.4/modulos/design_tokens.py
@@ -183,6 +183,11 @@ class Colors:
     ACCENT_BASE = "#7C3AED"
     ACCENT_HOVER = "#8B5CF6"
 
+    # Color estándar de acción para botones sin semántica específica
+    POS_ACTION_BASE: str = "#00755E"
+    POS_ACTION_HOVER: str = "#00967A"
+    POS_ACTION_ACTIVE: str = "#005A47"
+
     # Alias legacy de texto (evita crashes por atributos faltantes).
     TEXT_PRIMARY = NeutralColors().SLATE_800
     TEXT_SECONDARY = NeutralColors().SLATE_500

--- a/pos_spj_v13.4/modulos/qss_builder.py
+++ b/pos_spj_v13.4/modulos/qss_builder.py
@@ -1590,6 +1590,7 @@ def _block_pos_module(
     category_active_bg: str, category_active_text: str,
     cobrar_disabled_bg: str, cobrar_disabled_text: str,
     warning: str, critical: str, out_stock_bg: str,
+    action: str, action_hover: str,
 ) -> str:
     """Genera el QSS para el módulo POS (ventas.py)."""
     return f"""
@@ -1801,6 +1802,64 @@ def _block_pos_module(
             font-weight: 700;
         }}
 
+        /* ===== POS: SECTION HEADERS ===== */
+        QLabel#posSectionHeader {{
+            color: {muted};
+            font-size: 10px;
+            font-weight: 700;
+            background: transparent;
+            border: none;
+            padding: 0px;
+        }}
+
+        /* ===== POS: STANDARD ACTION BUTTON (#00755E) ===== */
+        QPushButton#posActionBtn {{
+            background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+                stop:0 {action_hover}, stop:1 {action});
+            color: white;
+            border: none;
+            border-radius: 5px;
+            padding: 3px 8px;
+            font-weight: 600;
+            font-size: 11px;
+            min-height: 22px;
+        }}
+        QPushButton#posActionBtn:hover {{
+            background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+                stop:0 #00C49A, stop:1 {action_hover});
+        }}
+        QPushButton#posActionBtn:pressed {{
+            background-color: {action};
+        }}
+        QPushButton#posActionBtn:disabled {{
+            background-color: {cobrar_disabled_bg};
+            color: {cobrar_disabled_text};
+        }}
+
+        /* ===== POS: UTILITY ACTION BUTTON (outline teal) ===== */
+        QPushButton#posUtilBtn {{
+            background: transparent;
+            color: {action};
+            border: 1px solid {action};
+            border-radius: 5px;
+            padding: 3px 8px;
+            font-weight: 600;
+            font-size: 11px;
+            min-height: 22px;
+        }}
+        QPushButton#posUtilBtn:hover {{
+            background-color: {action};
+            color: white;
+        }}
+        QPushButton#posUtilBtn:pressed {{
+            background-color: {action_hover};
+            color: white;
+        }}
+        QPushButton#posUtilBtn:disabled {{
+            color: {muted};
+            border-color: {border};
+        }}
+
         /* ===== POS: TOTALS BREAKDOWN CARD ===== */
         QFrame#posTotalsCard {{
             background-color: {card};
@@ -1855,9 +1914,11 @@ def _block_pos_module(
         }}
         QLabel#posFinancialMetric {{
             color: {muted};
-            font-size: 10px;
+            font-size: 12px;
+            font-weight: 600;
             background: transparent;
             border: none;
+            padding: 1px 0px;
         }}
         QLabel#posCommissionBadge {{
             color: {success};
@@ -1875,10 +1936,10 @@ def _block_pos_module(
                 stop:0 {success_hover}, stop:1 {success});
             color: white;
             border: none;
-            border-radius: 10px;
-            font-size: 16px;
+            border-radius: 8px;
+            font-size: 15px;
             font-weight: 800;
-            min-height: 56px;
+            min-height: 44px;
             letter-spacing: 0.3px;
         }}
         QPushButton#btnCobrarPOS:hover {{
@@ -1948,6 +2009,8 @@ def _modern_blocks(theme: str) -> str:
                 warning=Colors.WARNING.BASE,
                 critical=Colors.DANGER.BASE,
                 out_stock_bg=Colors.NEUTRAL.SLATE_900,
+                action=Colors.POS_ACTION_BASE,
+                action_hover=Colors.POS_ACTION_HOVER,
             )
         )
     # Claro
@@ -2000,6 +2063,8 @@ def _modern_blocks(theme: str) -> str:
             warning=Colors.WARNING.BASE,
             critical=Colors.DANGER.BASE,
             out_stock_bg=Colors.NEUTRAL.SLATE_100,
+            action=Colors.POS_ACTION_BASE,
+            action_hover=Colors.POS_ACTION_HOVER,
         )
     )
 

--- a/pos_spj_v13.4/modulos/ventas.py
+++ b/pos_spj_v13.4/modulos/ventas.py
@@ -1311,10 +1311,10 @@ class ModuloVentas(ModuloBase):
         layout_derecho.addWidget(group_carrito, 1)
 
         # QUICK DISCOUNT BUTTONS
-        desc_frame = QFrame()
-        desc_frame.setObjectName("card")
+        desc_frame = QGroupBox("DESCUENTOS")
+        desc_frame.setProperty("class", "discount-group")
         desc_lay = QHBoxLayout(desc_frame)
-        desc_lay.setContentsMargins(8, 5, 8, 5)
+        desc_lay.setContentsMargins(8, 6, 8, 6)
         desc_lay.setSpacing(5)
         for pct in [5, 10, 15, 20]:
             btn_d = QPushButton(f"{pct}%")
@@ -1339,6 +1339,10 @@ class ModuloVentas(ModuloBase):
         totals_layout = QVBoxLayout(totals_card)
         totals_layout.setContentsMargins(12, 8, 12, 8)
         totals_layout.setSpacing(4)
+
+        lbl_resumen_header = QLabel("RESUMEN")
+        lbl_resumen_header.setObjectName("posSectionHeader")
+        totals_layout.addWidget(lbl_resumen_header)
 
         row_sub = QHBoxLayout()
         row_sub.setSpacing(4)
@@ -1386,9 +1390,10 @@ class ModuloVentas(ModuloBase):
         totals_layout.addLayout(row_total)
 
         metrics_row = QHBoxLayout()
-        metrics_row.setSpacing(12)
-        self.lbl_peso_bascula = QLabel("0.000 kg")
-        self.lbl_puntos_venta = QLabel("+ 0 pts")
+        metrics_row.setSpacing(16)
+        metrics_row.setContentsMargins(0, 4, 0, 0)
+        self.lbl_peso_bascula = QLabel("⚖ 0.000 kg")
+        self.lbl_puntos_venta = QLabel("★ 0 pts")
         self.lbl_comision_turno = QLabel("")
         self.lbl_peso_bascula.setObjectName("posFinancialMetric")
         self.lbl_puntos_venta.setObjectName("posFinancialMetric")
@@ -1408,12 +1413,11 @@ class ModuloVentas(ModuloBase):
         self._banner_sin_impresora.setVisible(False)
         layout_derecho.addWidget(self._banner_sin_impresora)
 
-        # ── CHECKOUT ACTIONS ─────────────────────────────────────────────────
-        # Hierarchy: COBRAR (dominant) → workflow secondary → post-sale → danger
-        group_acciones = QGroupBox()
+        # ── PRIMARY TRANSACTION ACTIONS ──────────────────────────────────────
+        group_acciones = QGroupBox("ACCIONES DE VENTA")
         group_acciones.setProperty("class", "venta-group")
         acciones_layout = QVBoxLayout(group_acciones)
-        acciones_layout.setContentsMargins(8, 8, 8, 8)
+        acciones_layout.setContentsMargins(8, 10, 8, 8)
         acciones_layout.setSpacing(5)
 
         # PRIMARY: COBRAR — dominant full-width green button
@@ -1421,14 +1425,15 @@ class ModuloVentas(ModuloBase):
         self.btn_cobrar.setObjectName("btnCobrarPOS")
         self.btn_cobrar.setProperty("fill_parent", True)
         self.btn_cobrar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        self.btn_cobrar.setMinimumHeight(56)
+        self.btn_cobrar.setMinimumHeight(44)
         acciones_layout.addWidget(self.btn_cobrar)
 
-        # SECONDARY: workflow actions — Suspender / Reanudar
+        # WORKFLOW: Suspender / Reanudar
         row_workflow = QHBoxLayout()
         row_workflow.setSpacing(5)
         self.btn_suspender = create_warning_button(self, "⏸ Suspender", "Suspender venta actual para atender otra")
         self.btn_reanudar  = create_primary_button(self, "▶ Reanudar (0)", "Reanudar venta suspendida")
+        self.btn_reanudar.setObjectName("posActionBtn")
         for _b in (self.btn_suspender, self.btn_reanudar):
             _b.setProperty("fill_parent", True)
             _b.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
@@ -1437,42 +1442,50 @@ class ModuloVentas(ModuloBase):
         row_workflow.addWidget(self.btn_reanudar)
         acciones_layout.addLayout(row_workflow)
 
-        # SECONDARY: post-sale / returns — Devolución / Factura / Reimprimir
-        row_postsale = QHBoxLayout()
-        row_postsale.setSpacing(5)
+        # DANGER ZONE: visual separator + Cancelar
+        _danger_sep = QFrame()
+        _danger_sep.setFrameShape(QFrame.HLine)
+        _danger_sep.setObjectName("posTotalsDivider")
+        _danger_sep.setFixedHeight(1)
+        acciones_layout.addWidget(_danger_sep)
+
+        self.btn_cancelar = create_danger_button(self, "✕ Cancelar venta", "Cancelar venta actual")
+        self.btn_cancelar.setProperty("fill_parent", True)
+        self.btn_cancelar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.btn_cancelar.setMinimumHeight(32)
+        acciones_layout.addWidget(self.btn_cancelar)
+
+        layout_derecho.addWidget(group_acciones)
+
+        # ── UTILITY ACTIONS ───────────────────────────────────────────────────
+        group_utilidad = QGroupBox("ACCIONES UTILITARIAS")
+        group_utilidad.setProperty("class", "venta-group")
+        utilidad_layout = QHBoxLayout(group_utilidad)
+        utilidad_layout.setContentsMargins(8, 10, 8, 8)
+        utilidad_layout.setSpacing(5)
+
         self.btn_devolucion = create_secondary_button(
             self, "↩ Devolución",
             "Cancelar o devolver una venta anterior (requiere permiso)")
+        self.btn_devolucion.setObjectName("posUtilBtn")
         self.btn_devolucion.setEnabled(False)
         self.btn_factura = create_secondary_button(self, "🧾 Factura", "Generar CFDI de la última venta")
+        self.btn_factura.setObjectName("posUtilBtn")
         self.btn_factura.setEnabled(False)
         self.btn_factura.clicked.connect(self._generar_factura)
         self.btn_reimprimir = create_secondary_button(self, "🖨️ Reimpr.", "Reimprimir el ticket de la última venta")
+        self.btn_reimprimir.setObjectName("posUtilBtn")
         self.btn_reimprimir.setEnabled(False)
         self.btn_reimprimir.clicked.connect(self._reimprimir_ultima_venta)
         for _b in (self.btn_devolucion, self.btn_factura, self.btn_reimprimir):
             _b.setProperty("fill_parent", True)
             _b.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-            _b.setMinimumHeight(32)
-        row_postsale.addWidget(self.btn_devolucion)
-        row_postsale.addWidget(self.btn_factura)
-        row_postsale.addWidget(self.btn_reimprimir)
-        acciones_layout.addLayout(row_postsale)
+            _b.setMinimumHeight(30)
+        utilidad_layout.addWidget(self.btn_devolucion)
+        utilidad_layout.addWidget(self.btn_factura)
+        utilidad_layout.addWidget(self.btn_reimprimir)
 
-        # DANGER ZONE: visual separator + Cancelar
-        danger_sep = QFrame()
-        danger_sep.setFrameShape(QFrame.HLine)
-        danger_sep.setObjectName("posTotalsDivider")
-        danger_sep.setFixedHeight(1)
-        acciones_layout.addWidget(danger_sep)
-
-        self.btn_cancelar = create_danger_button(self, "✕ Cancelar venta", "Cancelar venta actual")
-        self.btn_cancelar.setProperty("fill_parent", True)
-        self.btn_cancelar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        self.btn_cancelar.setMinimumHeight(34)
-        acciones_layout.addWidget(self.btn_cancelar)
-
-        layout_derecho.addWidget(group_acciones)
+        layout_derecho.addWidget(group_utilidad)
 
         splitter.addWidget(panel_izquierdo)
         splitter.addWidget(panel_derecho)


### PR DESCRIPTION
…tionate COBRAR

Issue 1 — COBRAR height reduced: 56px → 44px (border-radius 10→8, font-size 16→15) Remains dominant but proportionate within the right panel.

Issue 2 — Utility actions separated into own labeled group:
- Devolución / Factura / Reimpr. moved to new QGroupBox("ACCIONES UTILITARIAS")
- Primary group QGroupBox("ACCIONES DE VENTA") now contains only: COBRAR | Suspender | Reanudar | ─ separator ─ | Cancelar

Issue 3 — Scale/points metrics area improved:
- posFinancialMetric font-size 10px → 12px, font-weight 600, 1px top padding
- metrics_row spacing 12 → 16, added 4px top margin
- Default label text: "⚖ 0.000 kg" / "★ 0 pts" (more scannable)

Issue 4 — Section headers added throughout right panel:
- DESCUENTOS: QFrame(card) → QGroupBox("DESCUENTOS")
- RESUMEN: QLabel#posSectionHeader added at top of totals card
- ACCIONES DE VENTA / ACCIONES UTILITARIAS: group box titles
- CLIENTE / CARRITO already had titles (no change needed)

Issue 5 — Standard enterprise action color #00755E:
- Colors.POS_ACTION_BASE/HOVER/ACTIVE added to design_tokens.py
- posActionBtn QSS: solid teal gradient, white text (Reanudar uses this)
- posUtilBtn QSS: teal outline on transparent bg (utility group buttons)
- posSectionHeader QSS: compact uppercase muted label

No regressions: 22 targeted tests pass.

https://claude.ai/code/session_01BeUQNddwRX3aLAs1c3HRcg