### PR TITLE
Refactor caja module: extract CajaApplicationService, fix corte Z bugs

### DIFF
--- a/docs/refactor/caja_auditoria_real.md
+++ b/docs/refactor/caja_auditoria_real.md
@@ -1,0 +1,207 @@
+# Auditoría Real — Módulo Caja (pos_spj v13.4)
+**Fecha:** 2026-05-19  
+**Auditor:** Claude Code — ERP Architect
+
+---
+
+## 1. Mapa de Archivos
+
+| Archivo | Líneas | Rol |
+|---------|--------|-----|
+| `modulos/caja.py` | 1,188 | UI PyQt5 — contiene SQL directo (VIOLACIÓN) |
+| `repositories/caja.py` | 290 | CajaRepository — enterprise, dual-write |
+| `core/services/enterprise/finance_service.py` | 1,600+ | FinanceService — métodos caja en líneas 1113-1266 |
+| `core/services/cierre_caja_service.py` | 278 | CierreCajaService — servicio legacy v9 (DUPLICADO) |
+| `core/app_container.py` | 965 | AppContainer — NO registra CajaRepository ni CajaApplicationService |
+| `migrations/m000_base_schema.py` | 3,100+ | Esquema base — define 6 tablas de caja |
+
+---
+
+## 2. Flujo Actual — Abrir Turno
+
+```
+UI.abrir_caja()
+  → QInputDialog.getDouble() → fondo
+  → container.finance_service.abrir_turno(sucursal_id, usuario, fondo)
+      → SELECT id FROM turnos_caja WHERE cajero=? AND estado='abierto'
+      → INSERT INTO turnos_caja (sucursal_id, cajero, fondo_inicial, estado, fecha_apertura)
+      → db.commit()
+  → Toast.success()
+  → hardware_service.open_cash_drawer()
+  → verificar_estado_caja()
+```
+
+**Problemas:**
+- No publica evento de dominio CAJA_TURNO_ABIERTO
+- No valida sucursal existente
+- No registra en turno_actual (tabla de CierreCajaService)
+- Sin transacción atómica
+
+---
+
+## 3. Flujo Actual — Registrar Movimiento
+
+```
+UI.registrar_movimiento()
+  → lee cmb_tipo_movimiento, txt_monto_mov, txt_concepto
+  → container.finance_service.registrar_movimiento_manual(turno_id, sucursal_id, usuario, tipo, monto, concepto)
+      → INSERT INTO movimientos_caja (turno_id, sucursal_id, tipo, monto, concepto, usuario, fecha)
+      → db.commit()
+  → _cargar_movimientos_turno()  ← SQL directo en UI
+```
+
+**Problemas:**
+- No publica evento
+- No valida que turno esté abierto antes de insertar
+- _cargar_movimientos_turno usa self.container.db.execute() directamente
+
+---
+
+## 4. Flujo Actual — Corte Z
+
+```
+UI.cerrar_caja()
+  → DialogoCorteZCiego.exec_()
+      → _ejecutar_corte()
+          → container.finance_service.generar_corte_z(turno_id, sucursal_id, cajero, efectivo)
+              [1] SUM(total) FROM ventas WHERE sucursal_id=? AND usuario=?  ← TODOS los pagos
+              [2] SUM(INGRESO) - SUM(RETIRO) FROM movimientos_caja
+              [3] fondo_inicial FROM turnos_caja
+              [4] esperado = fondo + total_ventas + ingresos - retiros  ← BUG: suma tarjeta/transferencia
+              [5] UPDATE turnos_caja SET estado='cerrado'...
+              [6] NO inserta en cierres_caja  ← BUG CRÍTICO
+              [7] NO publica eventos  ← BUG
+              [8] NO usa transacción  ← BUG
+              [9] NO registra asiento si diferencia  ← BUG
+          → nav.indexOf(...)  ← BUG: nav fuera de scope
+  → imprimir_ticket_corte(resultado)
+  → verificar_estado_caja()
+```
+
+**Bugs críticos:**
+1. `total_ventas` incluye tarjeta y transferencia → efectivo esperado incorrecto
+2. No inserta en `cierres_caja` → historial siempre vacío
+3. Variable `nav` fuera de scope → crash en línea 298
+4. Sin transacción → inconsistencia si falla a mitad
+5. No publica eventos de dominio
+
+---
+
+## 5. Tablas Usadas
+
+| Tabla | Propósito | Estado |
+|-------|-----------|--------|
+| `turnos_caja` | Turnos de cajero (fuente principal) | ✅ Activa |
+| `movimientos_caja` | Movimientos manuales + ventas | ✅ Activa (legacy) |
+| `caja_operations` | Operaciones enterprise con idempotency | ✅ Activa (nueva) |
+| `cierres_caja` | Historial de cortes Z/X | ⚠️ No se llena desde flujo principal |
+| `turno_actual` | Estado abierto por sucursal (CierreCajaService) | ⚠️ No se usa en flujo principal |
+| `cajas` | Registro de cajas físicas | ⚠️ No integrada al flujo actual |
+
+---
+
+## 6. Servicios Duplicados
+
+| Funcionalidad | finance_service | cierre_caja_service | Ganador |
+|---------------|----------------|---------------------|---------|
+| abrir turno | `abrir_turno()` | `abrir_turno()` | finance_service |
+| corte Z | `generar_corte_z()` | `corte_z()` | **cierre_caja_service** (más completo) |
+| historial | — | `get_historial()` | cierre_caja_service |
+| movimiento manual | `registrar_movimiento_manual()` | — | finance_service |
+| estado turno | `get_estado_turno()` | `turno_activo()` | finance_service |
+
+**Decisión:** Consolidar en `CajaApplicationService` como fuente única de verdad.
+
+---
+
+## 7. SQL Directo en UI (VIOLACIONES)
+
+| Línea | Tabla | Descripción |
+|-------|-------|-------------|
+| 365 | `turnos_caja` | KPI bar: fondo + ventas |
+| 373 | `movimientos_caja` | KPI bar: conteo movimientos |
+| 378 | `cortes_z` | KPI bar: cortes hoy (tabla inexistente!) |
+| 931-937 | `movimientos_caja` | Cargar movimientos del turno |
+| 977 | `turnos_caja` | Obtener fondo_inicial |
+| 1036-1042 | `cierres_caja` | Historial de cortes |
+| 1064 | `cierres_caja` | Reimprimir corte |
+| 1169 | `turno_actual` | Calcular arqueo (tabla no mantenida) |
+
+---
+
+## 8. Eventos Existentes y Faltantes
+
+### Existentes:
+- `CAJA_MOVIMIENTO` — publicado por CajaRepository.registrar_movimiento()
+
+### Faltantes (a crear):
+- `CAJA_TURNO_ABIERTO` — al abrir turno
+- `CAJA_TURNO_CERRADO` — al cerrar turno
+- `CAJA_CORTE_Z_GENERADO` — al ejecutar corte Z
+- `CAJA_DIFERENCIA_DETECTADA` — si diferencia != 0
+
+---
+
+## 9. Código Muerto / Bugs
+
+| Tipo | Ubicación | Descripción |
+|------|-----------|-------------|
+| Dead code | `_crear_caja_kpi_bar` líneas 398-403 | Código inalcanzable después de `return bar` |
+| Bug scope | `_ejecutar_corte` línea 298 | `nav` no definido en este scope → NameError |
+| Bug objectName | `_build_tab_arqueo` línea 1132-1133 | Double setObjectName: el segundo sobrescribe el primero, rompiendo findChild |
+| Bug KPI | Línea 378 | Consulta tabla `cortes_z` que no existe (debería ser `cierres_caja`) |
+| Bug cálculo | `generar_corte_z` línea 1186 | Suma todas las formas de pago en esperado (no solo efectivo) |
+| Sin transacción | `generar_corte_z` completo | No usa SAVEPOINT, puede dejar estado inconsistente |
+| Sin cierres | `generar_corte_z` completo | No inserta en `cierres_caja` → historial vacío |
+
+---
+
+## 10. Riesgos de Datos
+
+| Riesgo | Severidad | Descripción |
+|--------|-----------|-------------|
+| Cálculo incorrecto de efectivo esperado | 🔴 CRÍTICO | Suma tarjeta/transferencia → diferencia incorrecta → desconfianza en cortes |
+| Historial vacío | 🔴 CRÍTICO | No se insertan registros en cierres_caja → imposible auditar cierres pasados |
+| Race condition en corte Z | 🟡 MEDIO | Sin SAVEPOINT dos cajeros pueden cerrar simultáneamente |
+| turno_actual desincronizado | 🟡 MEDIO | CierreCajaService y finance_service usan tablas diferentes |
+| Arqueo con datos falsos | 🟡 MEDIO | `_calcular_arqueo` lee de turno_actual que no se actualiza en el flujo principal |
+| Tabla cortes_z inexistente | 🟠 ALTO | KPI bar hace SELECT en tabla que no existe → silenciado por except |
+
+---
+
+## 11. Fuente Única de Verdad (Fase 2)
+
+**Ruta canónica establecida:**
+```
+UI (modulos/caja.py)
+  → container.caja_service (CajaApplicationService)
+      → CajaRepository (repositories/caja.py) para operaciones enterprise
+      → finance_service.registrar_asiento() para asientos contables
+      → event_bus.publish() para eventos de dominio
+      → DB: turnos_caja (master), movimientos_caja (log), cierres_caja (historial)
+```
+
+**Integración en AppContainer:**
+```python
+from repositories.caja import CajaRepository
+from application.services.caja_application_service import CajaApplicationService
+
+self.caja_repo = CajaRepository(self.db)
+self.caja_service = CajaApplicationService(
+    db=self.db,
+    caja_repo=self.caja_repo,
+    finance_service=self.finance_service,
+)
+```
+
+---
+
+## 12. Archivos Modificados en Refactor
+
+1. `core/events/event_bus.py` — agregar constantes CAJA_*
+2. `application/services/caja_application_service.py` — NUEVO
+3. `core/app_container.py` — registrar caja_repo y caja_service
+4. `modulos/caja.py` — eliminar SQL, corregir bugs
+5. `core/services/enterprise/finance_service.py` — corregir generar_corte_z
+6. `core/services/caja_ticket_service.py` — NUEVO, extrae lógica de impresión
+7. `tests/test_caja.py` — NUEVO, tests de regresión

--- a/pos_spj_v13.4/application/services/caja_application_service.py
+++ b/pos_spj_v13.4/application/services/caja_application_service.py
@@ -1,0 +1,521 @@
+# application/services/caja_application_service.py
+"""
+CajaApplicationService — Fuente única de verdad para operaciones de caja.
+
+Ruta canónica: UI → CajaApplicationService → DB
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Dict, List, Optional
+
+logger = logging.getLogger("spj.application.caja")
+
+# Forma de pago que se considera efectivo
+_EFECTIVO_FORMAS = frozenset({"Efectivo", "efectivo", "EFECTIVO", "cash", "Cash"})
+
+
+class TurnoNoEncontradoError(Exception):
+    pass
+
+
+class TurnoYaAbiertroError(Exception):
+    pass
+
+
+class TurnoCerradoError(Exception):
+    pass
+
+
+class CajaApplicationService:
+    """
+    Orquesta operaciones de caja: turnos, movimientos, corte Z.
+    Depende de: db, finance_service (para asientos contables y registrar_movimiento_manual).
+    """
+
+    def __init__(self, db, finance_service=None, caja_repo=None):
+        self.db = db
+        self._finance = finance_service
+        self._caja_repo = caja_repo
+
+    def _get_bus(self):
+        try:
+            from core.events.event_bus import get_bus
+            return get_bus()
+        except Exception:
+            return None
+
+    def _publish(self, event_type: str, payload: dict) -> None:
+        bus = self._get_bus()
+        if bus:
+            try:
+                bus.publish(event_type, payload)
+            except Exception as e:
+                logger.debug("event publish %s: %s", event_type, e)
+
+    # ── Estado ────────────────────────────────────────────────────────────────
+
+    def get_estado_turno(self, sucursal_id: int, usuario: str) -> Optional[Dict]:
+        """Retorna el turno abierto actual o None."""
+        try:
+            row = self.db.execute(
+                """SELECT id, fondo_inicial, fecha_apertura, cajero
+                   FROM turnos_caja
+                   WHERE sucursal_id=? AND cajero=? AND estado='abierto'
+                   ORDER BY fecha_apertura DESC LIMIT 1""",
+                (sucursal_id, usuario),
+            ).fetchone()
+            return dict(row) if row else None
+        except Exception as e:
+            logger.warning("get_estado_turno: %s", e)
+            return None
+
+    # ── Abrir turno ───────────────────────────────────────────────────────────
+
+    def abrir_turno(self, sucursal_id: int, usuario: str, fondo_inicial: float) -> int:
+        """Abre un nuevo turno. Lanza TurnoYaAbiertroError si ya hay uno abierto."""
+        existing = self.get_estado_turno(sucursal_id, usuario)
+        if existing:
+            raise TurnoYaAbiertroError("Ya hay un turno abierto para este cajero.")
+
+        cur = self.db.execute(
+            """INSERT INTO turnos_caja
+               (sucursal_id, cajero, usuario, fondo_inicial, estado, fecha_apertura)
+               VALUES (?,?,?,?,'abierto', datetime('now'))""",
+            (sucursal_id, usuario, usuario, fondo_inicial),
+        )
+        try:
+            self.db.commit()
+        except Exception:
+            pass
+        turno_id = cur.lastrowid
+        logger.info("Turno abierto id=%d cajero=%s fondo=%.2f", turno_id, usuario, fondo_inicial)
+
+        self._publish("CAJA_TURNO_ABIERTO", {
+            "turno_id": turno_id,
+            "sucursal_id": sucursal_id,
+            "usuario": usuario,
+            "fondo_inicial": fondo_inicial,
+        })
+        return turno_id
+
+    # ── Movimientos manuales ──────────────────────────────────────────────────
+
+    def registrar_movimiento_manual(
+        self,
+        turno_id: int,
+        sucursal_id: int,
+        usuario: str,
+        tipo: str,
+        monto: float,
+        concepto: str,
+    ) -> None:
+        """Registra INGRESO o RETIRO manual en el turno activo."""
+        if monto <= 0:
+            raise ValueError("El monto debe ser mayor a cero.")
+        if tipo not in ("INGRESO", "RETIRO"):
+            raise ValueError(f"Tipo inválido: {tipo}. Use INGRESO o RETIRO.")
+
+        self.db.execute(
+            """INSERT INTO movimientos_caja
+               (turno_id, sucursal_id, tipo, monto, concepto, usuario, fecha)
+               VALUES (?,?,?,?,?,?, datetime('now'))""",
+            (turno_id, sucursal_id, tipo, monto, concepto, usuario),
+        )
+        try:
+            self.db.commit()
+        except Exception:
+            pass
+
+        self._publish("CAJA_MOVIMIENTO", {
+            "turno_id": turno_id,
+            "sucursal_id": sucursal_id,
+            "usuario": usuario,
+            "tipo": tipo,
+            "monto": monto,
+            "concepto": concepto,
+        })
+
+    # ── Movimientos del turno ─────────────────────────────────────────────────
+
+    def get_movimientos_turno(self, turno_id: int, rol: str = "cajero") -> List[Dict]:
+        """Retorna movimientos del turno. Filtra montos si es cajero."""
+        try:
+            rows = self.db.execute(
+                """SELECT fecha, tipo,
+                          COALESCE(concepto, descripcion, '') AS concepto,
+                          monto, COALESCE(usuario,'Sistema') AS usuario,
+                          turno_id
+                   FROM movimientos_caja
+                   WHERE turno_id=?
+                   ORDER BY fecha DESC""",
+                (turno_id,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        except Exception as e:
+            logger.warning("get_movimientos_turno: %s", e)
+            return []
+
+    # ── KPIs para barra de estado ─────────────────────────────────────────────
+
+    def get_caja_kpis(self, sucursal_id: int, usuario: str) -> Dict:
+        """Retorna datos para la barra de KPIs de caja."""
+        kpis = {
+            "fondo_inicial": 0.0,
+            "total_ventas_turno": 0.0,
+            "num_movimientos_hoy": 0,
+            "num_cortes_hoy": 0,
+        }
+        try:
+            turno = self.get_estado_turno(sucursal_id, usuario)
+            if turno:
+                kpis["fondo_inicial"] = float(turno.get("fondo_inicial", 0) or 0)
+                row_v = self.db.execute(
+                    """SELECT COALESCE(SUM(total), 0)
+                       FROM ventas
+                       WHERE sucursal_id=? AND cajero=? AND estado='completada'
+                         AND fecha >= (SELECT fecha_apertura FROM turnos_caja WHERE id=?)""",
+                    (sucursal_id, usuario, turno["id"]),
+                ).fetchone()
+                kpis["total_ventas_turno"] = float(row_v[0] or 0) if row_v else 0.0
+        except Exception as e:
+            logger.debug("kpis ventas: %s", e)
+        try:
+            row_m = self.db.execute(
+                "SELECT COUNT(*) FROM movimientos_caja WHERE DATE(fecha)=DATE('now') AND sucursal_id=?",
+                (sucursal_id,),
+            ).fetchone()
+            kpis["num_movimientos_hoy"] = int(row_m[0] or 0) if row_m else 0
+        except Exception as e:
+            logger.debug("kpis movs: %s", e)
+        try:
+            row_c = self.db.execute(
+                "SELECT COUNT(*) FROM cierres_caja WHERE DATE(fecha_cierre)=DATE('now') AND sucursal_id=?",
+                (sucursal_id,),
+            ).fetchone()
+            kpis["num_cortes_hoy"] = int(row_c[0] or 0) if row_c else 0
+        except Exception as e:
+            logger.debug("kpis cortes: %s", e)
+        return kpis
+
+    # ── Historial de cortes ───────────────────────────────────────────────────
+
+    def get_historial_cortes(self, sucursal_id: int, limit: int = 100) -> List[Dict]:
+        """Retorna historial de cortes Z de la sucursal."""
+        try:
+            rows = self.db.execute(
+                """SELECT tipo, fecha_cierre, usuario, total_ventas,
+                          total_efectivo, id, diferencia, fondo_inicial,
+                          efectivo_contado, comentarios
+                   FROM cierres_caja
+                   WHERE sucursal_id=?
+                   ORDER BY fecha_cierre DESC LIMIT ?""",
+                (sucursal_id, limit),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        except Exception as e:
+            logger.warning("get_historial_cortes: %s", e)
+            return []
+
+    def get_cierre_por_id(self, cierre_id: int) -> Optional[Dict]:
+        """Retorna un cierre por su ID para reimpresión."""
+        try:
+            row = self.db.execute(
+                "SELECT * FROM cierres_caja WHERE id=?", (cierre_id,)
+            ).fetchone()
+            return dict(row) if row else None
+        except Exception as e:
+            logger.warning("get_cierre_por_id: %s", e)
+            return None
+
+    # ── Arqueo ────────────────────────────────────────────────────────────────
+
+    def calcular_arqueo(self, turno_id: int, total_fisico: float) -> Dict:
+        """
+        Calcula diferencia entre efectivo físico contado y efectivo esperado del turno.
+        Solo cuenta ventas en EFECTIVO (no tarjeta ni transferencia).
+        """
+        try:
+            row_t = self.db.execute(
+                "SELECT fondo_inicial, fecha_apertura, sucursal_id, cajero FROM turnos_caja WHERE id=?",
+                (turno_id,),
+            ).fetchone()
+            if not row_t:
+                return {"error": "Turno no encontrado"}
+            fondo = float(row_t["fondo_inicial"] or 0)
+            fecha_apertura = row_t["fecha_apertura"]
+            sucursal_id = row_t["sucursal_id"]
+            cajero = row_t["cajero"]
+
+            ventas_ef = self._sum_ventas_efectivo(sucursal_id, cajero, fecha_apertura, turno_id)
+            row_m = self.db.execute(
+                """SELECT
+                     COALESCE(SUM(CASE WHEN tipo='INGRESO' THEN monto ELSE 0 END),0) AS ingresos,
+                     COALESCE(SUM(CASE WHEN tipo='RETIRO'  THEN monto ELSE 0 END),0) AS retiros
+                   FROM movimientos_caja WHERE turno_id=?""",
+                (turno_id,),
+            ).fetchone()
+            ingresos = float(row_m["ingresos"] or 0) if row_m else 0.0
+            retiros = float(row_m["retiros"] or 0) if row_m else 0.0
+
+            esperado = fondo + ventas_ef + ingresos - retiros
+            diferencia = total_fisico - esperado
+            return {
+                "fondo_inicial": fondo,
+                "ventas_efectivo": ventas_ef,
+                "ingresos": ingresos,
+                "retiros": retiros,
+                "esperado": esperado,
+                "total_fisico": total_fisico,
+                "diferencia": diferencia,
+            }
+        except Exception as e:
+            logger.warning("calcular_arqueo: %s", e)
+            return {"error": str(e)}
+
+    def _sum_ventas_efectivo(
+        self, sucursal_id: int, cajero: str, fecha_apertura: str, turno_id: int
+    ) -> float:
+        """Suma SOLO las ventas en efectivo del turno."""
+        formas = list(_EFECTIVO_FORMAS)
+        placeholders = ",".join("?" * len(formas))
+        try:
+            row = self.db.execute(
+                f"""SELECT COALESCE(SUM(total), 0)
+                    FROM ventas
+                    WHERE sucursal_id=? AND estado='completada'
+                      AND fecha >= ?
+                      AND COALESCE(forma_pago,'Efectivo') IN ({placeholders})""",
+                (sucursal_id, fecha_apertura) + tuple(formas),
+            ).fetchone()
+            return float(row[0] or 0) if row else 0.0
+        except Exception as e:
+            logger.debug("_sum_ventas_efectivo: %s", e)
+            return 0.0
+
+    def _sum_ventas_por_forma(
+        self, sucursal_id: int, fecha_apertura: str, turno_id: int
+    ) -> Dict:
+        """Retorna breakdown de ventas por forma de pago."""
+        result = {}
+        try:
+            rows = self.db.execute(
+                """SELECT COALESCE(forma_pago,'Efectivo') AS fp,
+                          COALESCE(SUM(total),0) AS total_fp,
+                          COUNT(*) AS num_ventas
+                   FROM ventas
+                   WHERE sucursal_id=? AND estado='completada'
+                     AND fecha >= (SELECT COALESCE(fecha_apertura, DATE('now'))
+                                   FROM turnos_caja WHERE id=?)
+                   GROUP BY fp
+                   ORDER BY total_fp DESC""",
+                (sucursal_id, turno_id),
+            ).fetchall()
+            for r in rows:
+                result[r[0]] = {"total": float(r[1] or 0), "count": int(r[2] or 0)}
+        except Exception as e:
+            logger.debug("_sum_ventas_por_forma: %s", e)
+        return result
+
+    # ── Corte Z ───────────────────────────────────────────────────────────────
+
+    def generar_corte_z(
+        self,
+        turno_id: int,
+        sucursal_id: int,
+        usuario: str,
+        efectivo_fisico: float,
+        observaciones: str = "",
+    ) -> Dict:
+        """
+        Ejecuta el cierre Z del turno.
+
+        Reglas de cálculo (CLAUDE.md §10):
+          efectivo_esperado = fondo_inicial
+                            + ventas_en_efectivo        (NO tarjeta ni transferencia)
+                            + ingresos_manuales
+                            - retiros
+          diferencia = efectivo_fisico - efectivo_esperado
+        """
+        # 1. Validar turno
+        row_t = self.db.execute(
+            "SELECT id, estado, sucursal_id, cajero, fondo_inicial, fecha_apertura FROM turnos_caja WHERE id=?",
+            (turno_id,),
+        ).fetchone()
+        if not row_t:
+            raise TurnoNoEncontradoError(f"Turno {turno_id} no encontrado.")
+        if row_t["estado"] != "abierto":
+            raise TurnoCerradoError(f"El turno {turno_id} ya fue cerrado.")
+
+        fondo = float(row_t["fondo_inicial"] or 0)
+        fecha_apertura = row_t["fecha_apertura"]
+        cajero = row_t["cajero"] or usuario
+
+        # 2. Calcular ventas por forma de pago
+        ventas_por_pago = self._sum_ventas_por_forma(sucursal_id, fecha_apertura, turno_id)
+        total_ventas = sum(v["total"] for v in ventas_por_pago.values())
+        num_ventas = sum(v["count"] for v in ventas_por_pago.values())
+
+        # 3. Ventas solo en efectivo
+        ventas_efectivo = sum(
+            v["total"] for fp, v in ventas_por_pago.items()
+            if fp in _EFECTIVO_FORMAS
+        )
+
+        # 4. Movimientos manuales
+        row_m = self.db.execute(
+            """SELECT
+                 COALESCE(SUM(CASE WHEN tipo='INGRESO' THEN monto ELSE 0 END),0) AS ingresos,
+                 COALESCE(SUM(CASE WHEN tipo='RETIRO'  THEN monto ELSE 0 END),0) AS retiros
+               FROM movimientos_caja WHERE turno_id=?""",
+            (turno_id,),
+        ).fetchone()
+        ingresos = float(row_m["ingresos"] or 0) if row_m else 0.0
+        retiros = float(row_m["retiros"] or 0) if row_m else 0.0
+
+        # 5. Totales por tipo de pago
+        total_efectivo = ventas_efectivo
+        total_tarjeta = sum(
+            v["total"] for fp, v in ventas_por_pago.items()
+            if "tarjeta" in fp.lower() or "card" in fp.lower()
+        )
+        total_transferencia = sum(
+            v["total"] for fp, v in ventas_por_pago.items()
+            if "transfer" in fp.lower()
+        )
+        total_otros = total_ventas - total_efectivo - total_tarjeta - total_transferencia
+
+        # 6. Cálculo correcto de efectivo esperado
+        esperado = round(fondo + ventas_efectivo + ingresos - retiros, 2)
+        diferencia = round(efectivo_fisico - esperado, 2)
+
+        cierre_uuid = str(uuid.uuid4())
+        fecha_cierre = datetime.now().isoformat()
+
+        # 7. Transacción atómica
+        sp = f"sp_corte_{uuid.uuid4().hex[:6]}"
+        try:
+            self.db.execute(f"SAVEPOINT {sp}")
+
+            # 7a. Insertar en cierres_caja
+            cur = self.db.execute(
+                """INSERT INTO cierres_caja
+                   (uuid, tipo, sucursal_id, usuario, turno,
+                    fecha_apertura, fecha_cierre,
+                    total_ventas, num_ventas,
+                    total_efectivo, total_tarjeta, total_transferencia, total_otros,
+                    efectivo_contado, fondo_inicial, diferencia, comentarios, estado)
+                   VALUES (?,?,?,?,?,?,datetime('now'),?,?,?,?,?,?,?,?,?,?,'cerrado')""",
+                (
+                    cierre_uuid, "Z", sucursal_id, usuario, cajero,
+                    fecha_apertura,
+                    round(total_ventas, 2), num_ventas,
+                    round(total_efectivo, 2), round(total_tarjeta, 2),
+                    round(total_transferencia, 2), round(max(total_otros, 0), 2),
+                    round(efectivo_fisico, 2), round(fondo, 2),
+                    diferencia, observaciones or "",
+                ),
+            )
+            cierre_id = cur.lastrowid
+
+            # 7b. Actualizar turnos_caja
+            self.db.execute(
+                """UPDATE turnos_caja SET
+                   estado='cerrado', fecha_cierre=datetime('now'),
+                   total_ventas=?, efectivo_esperado=?,
+                   efectivo_contado=?, diferencia=?
+                   WHERE id=?""",
+                (round(total_ventas, 2), esperado, efectivo_fisico, diferencia, turno_id),
+            )
+            self.db.execute(f"RELEASE SAVEPOINT {sp}")
+        except Exception:
+            try:
+                self.db.execute(f"ROLLBACK TO SAVEPOINT {sp}")
+            except Exception:
+                pass
+            raise
+
+        try:
+            self.db.commit()
+        except Exception:
+            pass
+
+        # 8. Asiento contable si hay diferencia
+        if abs(diferencia) >= 0.01 and self._finance and hasattr(self._finance, "registrar_asiento"):
+            try:
+                if diferencia > 0:
+                    debe, haber = "110-caja", "999-diferencias-caja"
+                else:
+                    debe, haber = "999-diferencias-caja", "110-caja"
+                self._finance.registrar_asiento(
+                    debe=debe, haber=haber,
+                    concepto=f"Diferencia Corte Z #{cierre_id} — cajero: {usuario}",
+                    monto=abs(diferencia),
+                    modulo="caja",
+                    referencia_id=cierre_id,
+                    sucursal_id=sucursal_id,
+                    evento="CORTE_Z",
+                    metadata={
+                        "efectivo_contado": efectivo_fisico,
+                        "efectivo_esperado": esperado,
+                        "cajero": usuario,
+                    },
+                )
+                try:
+                    self.db.commit()
+                except Exception:
+                    pass
+            except Exception as e:
+                logger.warning("Corte Z asiento diferencia: %s", e)
+
+        resultado = {
+            "cierre_id": cierre_id,
+            "turno_id": turno_id,
+            "fondo_inicial": fondo,
+            "total_ventas": round(total_ventas, 2),
+            "ventas_efectivo": round(ventas_efectivo, 2),
+            "otros_ingresos": round(ingresos, 2),
+            "retiros": round(retiros, 2),
+            "efectivo_esperado": esperado,
+            "efectivo_contado": efectivo_fisico,
+            "diferencia": diferencia,
+            "ventas_por_pago": ventas_por_pago,
+            # alias keys for UI compat
+            "esperado": esperado,
+            "contado": efectivo_fisico,
+            "ventas_totales": round(total_ventas, 2),
+        }
+
+        # 9. Publicar eventos de dominio
+        self._publish("CAJA_CORTE_Z_GENERADO", {
+            "cierre_id": cierre_id,
+            "turno_id": turno_id,
+            "sucursal_id": sucursal_id,
+            "usuario": usuario,
+            "total_ventas": resultado["total_ventas"],
+            "diferencia": diferencia,
+        })
+        if abs(diferencia) >= 0.01:
+            self._publish("CAJA_DIFERENCIA_DETECTADA", {
+                "cierre_id": cierre_id,
+                "turno_id": turno_id,
+                "sucursal_id": sucursal_id,
+                "usuario": usuario,
+                "diferencia": diferencia,
+                "esperado": esperado,
+                "contado": efectivo_fisico,
+            })
+        self._publish("CAJA_TURNO_CERRADO", {
+            "turno_id": turno_id,
+            "sucursal_id": sucursal_id,
+            "usuario": usuario,
+            "cierre_id": cierre_id,
+        })
+
+        logger.info(
+            "Corte Z generado #%d — ventas=%d total=%.2f diff=%.2f",
+            cierre_id, num_ventas, total_ventas, diferencia,
+        )
+        return resultado

--- a/pos_spj_v13.4/core/app_container.py
+++ b/pos_spj_v13.4/core/app_container.py
@@ -12,6 +12,7 @@ from repositories.recetas import RecetaRepository as RecipeRepository
 from repositories.finance_repository import FinanceRepository
 from repositories.sales_repository import SalesRepository
 from repositories.purchase_repository import PurchaseRepository
+from repositories.caja import CajaRepository
 # Si tienes estos, descoméntalos; si no, coméntalos para que no den error:
 from repositories.promotion_repository import PromotionRepository
 # [REFACTOR FASE 2] BIRepository eliminado - toda la lógica migrada a AnalyticsEngine
@@ -76,6 +77,7 @@ class AppContainer:
         self.finance_repo = FinanceRepository(self.db)
         self.sales_repo = SalesRepository(self.db)
         self.purchase_repo = PurchaseRepository(self.db)
+        self.caja_repo = CajaRepository(self.db)
 
         # Phase 3: repositorios documentales PR/PO
         try:
@@ -136,6 +138,29 @@ class AppContainer:
 
         self.finance_service = FinanceService(self.db) # Solo recibe 1 parámetro
         self.loyalty_service = LoyaltyService(self.db)  # module_config set below
+
+        # CajaApplicationService — fuente única de verdad para operaciones de caja
+        try:
+            from application.services.caja_application_service import CajaApplicationService
+            self.caja_service = CajaApplicationService(
+                db=self.db,
+                finance_service=self.finance_service,
+                caja_repo=self.caja_repo,
+            )
+        except Exception as _caja_svc_err:
+            self.caja_service = None
+            logger.warning("CajaApplicationService no cargado: %s", _caja_svc_err)
+
+        # CajaTicketService — impresión y PDF de cortes Z
+        try:
+            from core.services.caja_ticket_service import CajaTicketService
+            self.caja_ticket_service = CajaTicketService(
+                db=self.db,
+                hardware_service=None,  # wired later after hardware_service init
+            )
+        except Exception as _caja_tkt_err:
+            self.caja_ticket_service = None
+            logger.warning("CajaTicketService no cargado: %s", _caja_tkt_err)
 
         # CustomerCreditService — validación de crédito y CxC en ventas
         from application.services.customer_credit_service import CustomerCreditService
@@ -233,6 +258,10 @@ class AppContainer:
         # ── Servicios adicionales (v12) ───────────────────────────────────
         from core.services.hardware_service import HardwareService
         self.hardware_service = HardwareService(self.db)
+
+        # Wire hardware_service into CajaTicketService now that it's available
+        if self.caja_ticket_service is not None:
+            self.caja_ticket_service._hw = self.hardware_service
 
         # v13.4 Fase 1: ModuleConfig (toggles globales) — antes de otros servicios
         from core.module_config import ModuleConfig

--- a/pos_spj_v13.4/core/events/event_bus.py
+++ b/pos_spj_v13.4/core/events/event_bus.py
@@ -163,6 +163,13 @@ CUSTOMER_NOTIFICATION_REQUESTED = "CUSTOMER_NOTIFICATION_REQUESTED"  # order_id,
 DRIVER_SETTLEMENT_CREATED     = "DRIVER_SETTLEMENT_CREATED"       # cut_id, driver_id, driver_nombre, efectivo, diferencia, fecha
 PURCHASE_SUGGESTION_CREATED   = "PURCHASE_SUGGESTION_CREATED"     # producto_id, cantidad_sugerida, motivo, sucursal_id
 
+# Caja (módulo de caja registradora)
+CAJA_MOVIMIENTO           = "CAJA_MOVIMIENTO"
+CAJA_TURNO_ABIERTO        = "CAJA_TURNO_ABIERTO"
+CAJA_TURNO_CERRADO        = "CAJA_TURNO_CERRADO"
+CAJA_CORTE_Z_GENERADO     = "CAJA_CORTE_Z_GENERADO"
+CAJA_DIFERENCIA_DETECTADA = "CAJA_DIFERENCIA_DETECTADA"
+
 
 class EventBus:
     """Bus de eventos singleton thread-safe."""

--- a/pos_spj_v13.4/core/services/caja_ticket_service.py
+++ b/pos_spj_v13.4/core/services/caja_ticket_service.py
@@ -1,0 +1,254 @@
+# core/services/caja_ticket_service.py
+"""
+CajaTicketService — Impresión y generación de PDF para cortes Z.
+
+Extrae lógica de impresión de modulos/caja.py.
+La UI solo debe llamar:
+    container.caja_ticket_service.preview_or_print_corte(resultado, parent_widget)
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from typing import Dict, Optional
+
+logger = logging.getLogger("spj.caja.ticket")
+
+
+class CajaTicketService:
+    """Genera HTML, PDF y envía ESC/POS para comprobantes de corte Z."""
+
+    def __init__(self, db=None, hardware_service=None):
+        self.db = db
+        self._hw = hardware_service
+
+    def generar_html_corte(self, datos: Dict, cierre_id: int) -> str:
+        """Genera el HTML del ticket de corte Z."""
+        diferencia_texto = "Exacto ($0.00)"
+        dif = float(datos.get("diferencia", 0))
+        if dif < -0.01:
+            diferencia_texto = f"<span style='color:red;'>FALTANTE: ${abs(dif):.2f}</span>"
+        elif dif > 0.01:
+            diferencia_texto = f"SOBRANTE: ${dif:.2f}"
+
+        cajero = datos.get("cajero", "")
+        fecha = datos.get("fecha", datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+        ventas = float(datos.get("ventas_totales", datos.get("total_ventas", 0)))
+        retiros = float(datos.get("retiros", 0))
+        esperado = float(datos.get("esperado", datos.get("efectivo_esperado", 0)))
+        contado = float(datos.get("contado", datos.get("efectivo_contado", 0)))
+        fondo = float(datos.get("fondo_inicial", 0))
+
+        return f"""
+        <html>
+        <body style="font-family:monospace;text-align:center;width:300px;">
+            <h2>CORTE DE CAJA (Z)</h2>
+            <p>=============================</p>
+            <p><strong>Folio:</strong> {cierre_id}</p>
+            <p><strong>Fecha:</strong> {fecha}</p>
+            <p><strong>Cajero:</strong> {cajero}</p>
+            <p>=============================</p>
+            <div style="text-align:left;padding-left:20px;">
+                <p>Fondo inicial: ${fondo:.2f}</p>
+                <p>Ventas Totales: ${ventas:.2f}</p>
+                <p>Gastos/Retiros: ${retiros:.2f}</p>
+                <p>-------------------------</p>
+                <p><strong>EFECTIVO ESPERADO: ${esperado:.2f}</strong></p>
+                <p><strong>EFECTIVO CONTADO:  ${contado:.2f}</strong></p>
+                <p>-------------------------</p>
+                <h3>DIFERENCIA: {diferencia_texto}</h3>
+            </div>
+            <br><br>
+            <p>_________________________</p>
+            <p>Firma del Cajero</p>
+        </body>
+        </html>
+        """
+
+    def guardar_pdf(self, datos: Dict, cierre_id: int, carpeta: str = "CORTES_Z") -> str:
+        """Guarda PDF del corte en la carpeta indicada. Retorna la ruta del archivo."""
+        try:
+            from PyQt5.QtPrintSupport import QPrinter
+            from PyQt5.QtGui import QTextDocument
+            os.makedirs(carpeta, exist_ok=True)
+            fecha_str = datetime.now().strftime("%Y%m%d")
+            filename = os.path.join(carpeta, f"corte_z_{cierre_id}_{fecha_str}.pdf")
+            printer = QPrinter(QPrinter.HighResolution)
+            printer.setOutputFormat(QPrinter.PdfFormat)
+            printer.setOutputFileName(filename)
+            doc = QTextDocument()
+            doc.setHtml(self.generar_html_corte(datos, cierre_id))
+            doc.print_(printer)
+            logger.info("PDF corte Z guardado: %s", filename)
+            return filename
+        except Exception as e:
+            logger.warning("guardar_pdf: %s", e)
+            return ""
+
+    def enviar_escpos(self, datos: Dict, ancho: int = 48) -> bool:
+        """Envía ticket ESC/POS a impresora térmica via HardwareService."""
+        hw = self._hw
+        if not hw:
+            return False
+        try:
+            hw.load_configs()
+            cfg = hw._cache_config.get("ticket", {})
+            if not cfg:
+                return False
+            ubicacion = cfg.get("ubicacion", "")
+            ancho = 48 if "80" in cfg.get("ancho", "80") else 32
+            if not ubicacion:
+                return False
+
+            ESC = b"\x1b"
+            GS = b"\x1d"
+            data = bytearray()
+            data += ESC + b"@"
+            data += ESC + b"a\x01"
+            data += ESC + b"E\x01"
+            data += b"** CORTE Z **\n"
+            data += ESC + b"E\x00"
+            sep = b"-" * ancho + b"\n"
+            data += sep
+            data += f"Cajero: {datos.get('cajero','')}\n".encode()
+            data += f"Fecha:  {datos.get('fecha','')}\n".encode()
+            data += sep
+            data += ESC + b"a\x00"
+            ventas = float(datos.get("ventas_totales", datos.get("total_ventas", 0)))
+            retiros = float(datos.get("retiros", 0))
+            esperado = float(datos.get("esperado", datos.get("efectivo_esperado", 0)))
+            contado = float(datos.get("contado", datos.get("efectivo_contado", 0)))
+            dif = float(datos.get("diferencia", 0))
+            data += f"Ventas:   ${ventas:>10,.2f}\n".encode()
+            data += f"Retiros:  ${retiros:>10,.2f}\n".encode()
+            data += sep
+            data += ESC + b"E\x01"
+            data += f"Esperado: ${esperado:>10,.2f}\n".encode()
+            data += f"Contado:  ${contado:>10,.2f}\n".encode()
+            data += sep
+            dif_str = (
+                "CUADRADO        " if abs(dif) < 0.01
+                else (f"FALTANTE ${abs(dif):,.2f}" if dif < 0 else f"SOBRANTE ${dif:,.2f}")
+            )
+            data += f"DIFERENCIA: {dif_str}\n".encode()
+            data += ESC + b"E\x00"
+            data += b"\n\n\n"
+            data += GS + b"V\x42\x00"
+
+            tipo = cfg.get("tipo", "").lower()
+            if "red" in tipo or ":" in ubicacion:
+                import socket
+                ip, port = ubicacion.split(":") if ":" in ubicacion else (ubicacion, "9100")
+                s = socket.socket()
+                s.settimeout(5)
+                s.connect((ip.strip(), int(port)))
+                s.sendall(bytes(data))
+                s.close()
+            elif "serial" in tipo or "com" in ubicacion.upper():
+                import serial as _ser
+                with _ser.Serial(ubicacion, 9600, timeout=3) as s:
+                    s.write(bytes(data))
+            else:
+                try:
+                    with open(ubicacion, "wb") as f:
+                        f.write(bytes(data))
+                except Exception:
+                    return False
+            return True
+        except Exception as e:
+            logger.warning("ESC/POS: %s", e)
+            return False
+
+    def preview_or_print_corte(self, resultado: Dict, cajero: str, parent=None) -> None:
+        """
+        Muestra diálogo de vista previa con opciones: imprimir + guardar PDF.
+        Este es el único punto de entrada para impresión desde la UI.
+        """
+        datos = {
+            "fecha": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "cajero": cajero,
+            "ventas_totales": float(resultado.get("total_ventas", resultado.get("ventas_totales", 0))),
+            "retiros": float(resultado.get("retiros", 0)),
+            "esperado": float(resultado.get("efectivo_esperado", resultado.get("esperado", 0))),
+            "contado": float(resultado.get("efectivo_contado", resultado.get("contado", 0))),
+            "diferencia": float(resultado.get("diferencia", 0)),
+            "fondo_inicial": float(resultado.get("fondo_inicial", 0)),
+        }
+        cierre_id = int(resultado.get("cierre_id", resultado.get("turno_id", 0)))
+
+        # Auto-save PDF
+        try:
+            self.guardar_pdf(datos, cierre_id)
+        except Exception as e:
+            logger.warning("auto-save PDF: %s", e)
+
+        # Show dialog
+        try:
+            from PyQt5.QtWidgets import (
+                QDialog, QVBoxLayout, QHBoxLayout, QTextBrowser, QFileDialog,
+            )
+            from PyQt5.QtPrintSupport import QPrinter, QPrintDialog
+            from PyQt5.QtGui import QTextDocument
+
+            try:
+                from modulos.ui_components import (
+                    create_primary_button, create_success_button, create_secondary_button,
+                )
+                from modulos.ui_components import Toast
+            except Exception:
+                return
+
+            html = self.generar_html_corte(datos, cierre_id)
+            dlg = QDialog(parent)
+            dlg.setWindowTitle(f"Ticket Corte Z — {datos['cajero']}")
+            dlg.setMinimumSize(420, 500)
+            lay = QVBoxLayout(dlg)
+
+            browser = QTextBrowser()
+            browser.setHtml(html)
+            lay.addWidget(browser)
+
+            btn_row = QHBoxLayout()
+            btn_print = create_primary_button(dlg, "🖨️ Imprimir", "Imprimir comprobante")
+            btn_pdf = create_success_button(dlg, "💾 Guardar PDF", "Guardar como PDF")
+            btn_close = create_secondary_button(dlg, "Cerrar", "Cerrar vista previa")
+
+            def _do_print():
+                if self.enviar_escpos(datos):
+                    return
+                printer = QPrinter(QPrinter.HighResolution)
+                pdlg = QPrintDialog(printer, dlg)
+                if pdlg.exec_() == QPrintDialog.Accepted:
+                    doc = QTextDocument()
+                    doc.setHtml(html)
+                    doc.print_(printer)
+
+            def _save_pdf():
+                path, _ = QFileDialog.getSaveFileName(
+                    dlg, "Guardar Corte Z",
+                    f"CorteZ_{datos['cajero']}_{datos['fecha'][:10]}.pdf",
+                    "PDF (*.pdf)",
+                )
+                if path:
+                    printer = QPrinter(QPrinter.HighResolution)
+                    printer.setOutputFormat(QPrinter.PdfFormat)
+                    printer.setOutputFileName(path)
+                    doc = QTextDocument()
+                    doc.setHtml(html)
+                    doc.print_(printer)
+                    if parent:
+                        Toast.success(parent, "PDF guardado", path)
+
+            btn_print.clicked.connect(_do_print)
+            btn_pdf.clicked.connect(_save_pdf)
+            btn_close.clicked.connect(dlg.accept)
+
+            btn_row.addWidget(btn_print)
+            btn_row.addWidget(btn_pdf)
+            btn_row.addStretch()
+            btn_row.addWidget(btn_close)
+            lay.addLayout(btn_row)
+            dlg.exec_()
+        except Exception as e:
+            logger.warning("preview_or_print_corte: %s", e)

--- a/pos_spj_v13.4/modulos/caja.py
+++ b/pos_spj_v13.4/modulos/caja.py
@@ -12,14 +12,9 @@ from core.events.event_bus import VENTA_COMPLETADA
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit,
     QComboBox, QMessageBox, QFormLayout, QDoubleSpinBox, QGroupBox,
-    QTableWidget, QTableWidgetItem, QDialog, QDialogButtonBox, QHeaderView,
-    QAbstractItemView, QFrame, QSplitter, QGridLayout, QListWidget,
-    QListWidgetItem, QCompleter, QDateEdit, QTimeEdit, QTabWidget,
-    QRadioButton, QButtonGroup, QCheckBox, QSpinBox, QTextEdit, QMenu,
-    QAction, QToolBar, QStatusBar, QProgressBar, QSlider, QDial,
-    QCalendarWidget, QColorDialog, QFontDialog, QFileDialog, QInputDialog,
-    QErrorMessage, QProgressDialog, QSplashScreen, QSystemTrayIcon,
-    QStyleFactory, QApplication, QSizePolicy, QCompleter as QCompleterAlias
+    QTableWidget, QTableWidgetItem, QDialog, QHeaderView,
+    QAbstractItemView, QFrame, QGridLayout, QTabWidget,
+    QInputDialog, QStackedWidget,
 )
 from PyQt5.QtCore import Qt
 from datetime import datetime
@@ -52,7 +47,7 @@ class DialogoCorteZCiego(QDialog):
         self.container   = container
         self.sucursal_id = sucursal_id
         self.total_contado = 0.0
-        self.resultado     = None   # Se llena al confirmar
+        self.resultado     = None
 
         self.setWindowTitle("🔒 Corte Z — Conteo a Ciegas")
         self.setMinimumWidth(520)
@@ -62,7 +57,6 @@ class DialogoCorteZCiego(QDialog):
     def _build(self):
         root = QVBoxLayout(self)
 
-        # ── Header ───────────────────────────────────────────────────────────
         hdr = QLabel("CORTE Z — CONTEO FÍSICO DE EFECTIVO")
         hdr.setAlignment(Qt.AlignCenter)
         hdr.setObjectName("dialogHeader")
@@ -76,8 +70,6 @@ class DialogoCorteZCiego(QDialog):
         aviso.setObjectName("warningBox")
         root.addWidget(aviso)
 
-        # ── Stacked pages ─────────────────────────────────────────────────────
-        from PyQt5.QtWidgets import QStackedWidget
         self._stack = QStackedWidget()
         root.addWidget(self._stack, 1)
 
@@ -85,9 +77,9 @@ class DialogoCorteZCiego(QDialog):
         self._stack.addWidget(self._page_confirmar())
         self._stack.addWidget(self._page_resultado())
 
-        # ── Navigation buttons ────────────────────────────────────────────────
-        nav = QHBoxLayout()
-        
+        # Navigation buttons — stored as self._nav to be accessible from _ejecutar_corte
+        self._nav = QHBoxLayout()
+
         self._btn_cancel = create_secondary_button(self, "Cancelar", "Cancelar el corte de caja")
         self._btn_cancel.clicked.connect(self.reject)
 
@@ -98,11 +90,11 @@ class DialogoCorteZCiego(QDialog):
         self._btn_next = create_primary_button(self, "Siguiente ▶", "Continuar al siguiente paso del corte")
         self._btn_next.clicked.connect(self._next_page)
 
-        nav.addWidget(self._btn_cancel)
-        nav.addStretch()
-        nav.addWidget(self._btn_back)
-        nav.addWidget(self._btn_next)
-        root.addLayout(nav)
+        self._nav.addWidget(self._btn_cancel)
+        self._nav.addStretch()
+        self._nav.addWidget(self._btn_back)
+        self._nav.addWidget(self._btn_next)
+        root.addLayout(self._nav)
 
     # ── Page 1: Arqueo ────────────────────────────────────────────────────────
     def _page_arqueo(self) -> QWidget:
@@ -195,7 +187,7 @@ class DialogoCorteZCiego(QDialog):
         self.lbl_resultado = QLabel("Procesando...")
         self.lbl_resultado.setWordWrap(True)
         self.lbl_resultado.setAlignment(Qt.AlignCenter)
-        self.lbl_resultado.setObjectName("resultadoCard")  # Nombre único para evitar conflicto con QFrame card
+        self.lbl_resultado.setObjectName("resultadoCard")
         lay.addWidget(self.lbl_resultado, 1)
         return w
 
@@ -204,7 +196,6 @@ class DialogoCorteZCiego(QDialog):
         cur = self._stack.currentIndex()
 
         if cur == 0:
-            # Paso 1 → 2: sync arqueo total to spin
             self.spin_total_fisico.setValue(self.total_contado)
             self._stack.setCurrentIndex(1)
             self._btn_back.setEnabled(True)
@@ -212,7 +203,6 @@ class DialogoCorteZCiego(QDialog):
             self._btn_next.setToolTip("Confirmar el corte de caja y revelar resultados")
 
         elif cur == 1:
-            # Paso 2 → 3: execute corte and reveal result
             if not confirm_action(
                 self,
                 "Confirmar Corte Z",
@@ -232,32 +222,38 @@ class DialogoCorteZCiego(QDialog):
             self._btn_next.setToolTip("Continuar al siguiente paso")
 
     def _ejecutar_corte(self):
-        """Llama al servicio, luego revela el resultado."""
+        """Llama al servicio canónico, luego revela el resultado."""
         efectivo = self.spin_total_fisico.value()
         obs = self.txt_observaciones.text().strip()
 
         try:
-            resultado = self.container.finance_service.generar_corte_z(
-                self.turno_id, self.sucursal_id,
-                self.cajero, efectivo
-            )
+            # Usar CajaApplicationService (fuente única de verdad)
+            svc = getattr(self.container, 'caja_service', None)
+            if svc is None:
+                # Fallback para compatibilidad: usar finance_service
+                svc = self.container.finance_service
+                resultado = svc.generar_corte_z(
+                    self.turno_id, self.sucursal_id, self.cajero, efectivo
+                )
+            else:
+                resultado = svc.generar_corte_z(
+                    self.turno_id, self.sucursal_id, self.cajero, efectivo, obs
+                )
             self.resultado = resultado
 
             dif = resultado.get("diferencia", 0)
-            esperado = resultado.get("esperado",
-                       resultado.get("efectivo_esperado", 0))
+            esperado = resultado.get("efectivo_esperado", resultado.get("esperado", 0))
 
             if abs(dif) < 0.01:
-                dif_txt  = "✅  CAJA CUADRADA"
+                dif_txt   = "✅  CAJA CUADRADA"
                 dif_color = Colors.SUCCESS_BASE
             elif dif < 0:
-                dif_txt  = f"⚠️  FALTANTE  ${abs(dif):,.2f}"
+                dif_txt   = f"⚠️  FALTANTE  ${abs(dif):,.2f}"
                 dif_color = Colors.DANGER_HOVER
             else:
-                dif_txt  = f"ℹ️  SOBRANTE  ${dif:,.2f}"
+                dif_txt   = f"ℹ️  SOBRANTE  ${dif:,.2f}"
                 dif_color = Colors.WARNING_BASE
 
-            # Build forma_pago breakdown rows
             breakdown_rows = ""
             ventas_por_pago = resultado.get("ventas_por_pago", {})
             if ventas_por_pago:
@@ -274,7 +270,7 @@ class DialogoCorteZCiego(QDialog):
                 f"<table width='100%' cellspacing='6' "
                 f"style='font-size:13px;text-align:left;'>"
                 f"<tr><td>Ventas del turno:</td>"
-                f"<td align='right'><b>${resultado.get('total_ventas',resultado.get('ventas_totales',0)):,.2f}</b></td></tr>"
+                f"<td align='right'><b>${resultado.get('total_ventas', resultado.get('ventas_totales',0)):,.2f}</b></td></tr>"
                 f"{breakdown_rows}"
                 f"<tr><td>Retiros / gastos:</td>"
                 f"<td align='right'>${resultado.get('retiros',0):,.2f}</td></tr>"
@@ -294,19 +290,22 @@ class DialogoCorteZCiego(QDialog):
             self.lbl_resultado.setText(html)
             self._stack.setCurrentIndex(2)
             self._btn_back.setEnabled(False)
-            # Reemplazar botón de imprimir
-            idx = nav.indexOf(self._btn_next)
+
+            # Reemplazar botón Siguiente por Cerrar e Imprimir usando self._nav
+            idx = self._nav.indexOf(self._btn_next)
             if idx != -1:
-                nav.removeWidget(self._btn_next)
+                self._nav.removeWidget(self._btn_next)
                 self._btn_next.deleteLater()
-            
+
             self._btn_next = create_primary_button(self, "🖨️ Cerrar e Imprimir", "Cerrar el corte e imprimir comprobante")
             self._btn_next.clicked.connect(self.accept)
-            nav.insertWidget(idx, self._btn_next)
+            self._nav.insertWidget(idx, self._btn_next)
             self._btn_cancel.setEnabled(False)
 
         except Exception as e:
-            QMessageBox.critical(self, "Error", str(e))
+            import logging
+            logging.getLogger(__name__).error("_ejecutar_corte: %s", e)
+            QMessageBox.critical(self, "Error al ejecutar corte", str(e))
 
     def get_resultado(self):
         return self.resultado
@@ -320,163 +319,164 @@ class ModuloCaja(QWidget, RefreshMixin):
         super().__init__(parent)
         try: self._init_refresh(container, ["VENTA_COMPLETADA"])
         except Exception: pass
-        self.container = container # 🧠 Inyección del Cerebro
+        self.container = container
         self.sucursal_id = 1
         self.usuario_actual = ""
-        self.turno_actual = None # Almacenará el ID del turno si está abierto
-        self.layout_estado = None  # Referencia al layout de estado
-        
+        self.rol_actual = "cajero"
+        self.turno_actual = None
+        self.layout_estado = None
+
         self.init_ui()
 
-        # ── Atajos de teclado (F1-F10) ───────────────────────────────────
         from PyQt5.QtWidgets import QShortcut
         from PyQt5.QtGui import QKeySequence
         try:
             QShortcut(QKeySequence("F1"), self).activated.connect(self.abrir_caja)
             QShortcut(QKeySequence("F2"), self).activated.connect(self.registrar_movimiento)
             QShortcut(QKeySequence("F3"), self).activated.connect(
-                lambda: self.cerrar_caja() if hasattr(self,'cerrar_caja') else None)
-            QShortcut(QKeySequence("F10"), self).activated.connect(
-                lambda: self._generar_corte_z() if hasattr(self,'_generar_corte_z') else self.cerrar_caja())
+                lambda: self.cerrar_caja() if hasattr(self, 'cerrar_caja') else None)
+            QShortcut(QKeySequence("F10"), self).activated.connect(self.cerrar_caja)
         except Exception:
             pass
+
+    # ── Helpers de servicio ───────────────────────────────────────────────────
+
+    @property
+    def _caja_svc(self):
+        """Retorna CajaApplicationService si disponible, o None."""
+        return getattr(self.container, 'caja_service', None)
 
     def set_sucursal(self, sucursal_id: int, nombre_sucursal: str):
         self.sucursal_id = sucursal_id
         self.verificar_estado_caja()
 
-    def _crear_caja_kpi_bar(self) -> 'QFrame':
-        """Barra de KPIs: saldo fondo, ventas del turno, movimientos, cortes del día."""
-        from PyQt5.QtWidgets import QFrame as _F, QHBoxLayout as _H, QVBoxLayout as _V, QLabel as _L
-        from modulos.design_tokens import Colors as _C
-        bar = _F(); bar.setObjectName("cajaKpiBar")
+    def _crear_caja_kpi_bar(self) -> QFrame:
+        """Barra de KPIs: fondo, ventas del turno, movimientos, cortes del día."""
+        bar = QFrame()
+        bar.setObjectName("cajaKpiBar")
         bar.setFixedHeight(64)
         bar.setStyleSheet(
-            "QFrame#cajaKpiBar { background:#1E293B; border-radius:8px;"
-            " border:1px solid #334155; margin-bottom:4px; }"
+            f"QFrame#cajaKpiBar {{ background:{Colors.SURFACE_DARK if hasattr(Colors,'SURFACE_DARK') else '#1E293B'};"
+            f" border-radius:8px; border:1px solid #334155; margin-bottom:4px; }}"
         )
-        lay = _H(bar); lay.setContentsMargins(20,8,20,8); lay.setSpacing(0)
+        lay = QHBoxLayout(bar)
+        lay.setContentsMargins(20, 8, 20, 8)
+        lay.setSpacing(0)
 
-        kpis = [("Fondo inicial","—",_C.PRIMARY_BASE),("Ventas turno","—",_C.SUCCESS_BASE),
-                ("Movimientos","—",_C.WARNING_BASE),("Cortes hoy","—",_C.INFO_BASE)]
+        kpis = [
+            ("Fondo inicial",  "—", Colors.PRIMARY_BASE),
+            ("Ventas turno",   "—", Colors.SUCCESS_BASE),
+            ("Movimientos",    "—", Colors.WARNING_BASE),
+            ("Cortes hoy",     "—", Colors.INFO_BASE),
+        ]
+
+        # Obtener datos desde caja_service (sin SQL directo)
         try:
-            db = getattr(self, 'conexion', None) or getattr(self, 'db', None)
-            if db:
-                r = db.execute(
-                    "SELECT COALESCE(monto_apertura,0), COALESCE(total_ventas,0) "
-                    "FROM turnos_caja WHERE estado='abierto' "
-                    "ORDER BY fecha_apertura DESC LIMIT 1"
-                ).fetchone()
-                if r:
-                    kpis[0] = ("Fondo inicial", f"${float(r[0]):,.0f}", _C.PRIMARY_BASE)
-                    kpis[1] = ("Ventas turno",  f"${float(r[1]):,.0f}", _C.SUCCESS_BASE)
-                r2 = db.execute(
-                    "SELECT COUNT(*) FROM movimientos_caja "
-                    "WHERE DATE(fecha)=DATE('now')"
-                ).fetchone()
-                kpis[2] = ("Movimientos", str(r2[0] or 0), _C.WARNING_BASE)
-                r3 = db.execute(
-                    "SELECT COUNT(*) FROM cortes_z WHERE DATE(fecha)=DATE('now')"
-                ).fetchone()
-                kpis[3] = ("Cortes hoy", str(r3[0] or 0), _C.INFO_BASE)
-        except Exception: pass
+            svc = self._caja_svc
+            if svc and self.usuario_actual:
+                kpi_data = svc.get_caja_kpis(self.sucursal_id, self.usuario_actual)
+                fondo = kpi_data.get("fondo_inicial", 0)
+                ventas = kpi_data.get("total_ventas_turno", 0)
+                movs = kpi_data.get("num_movimientos_hoy", 0)
+                cortes = kpi_data.get("num_cortes_hoy", 0)
+                kpis[0] = ("Fondo inicial", f"${fondo:,.0f}", Colors.PRIMARY_BASE)
+                kpis[1] = ("Ventas turno",  f"${ventas:,.0f}", Colors.SUCCESS_BASE)
+                kpis[2] = ("Movimientos", str(movs), Colors.WARNING_BASE)
+                kpis[3] = ("Cortes hoy", str(cortes), Colors.INFO_BASE)
+        except Exception:
+            pass
 
         self._caja_kpi_labels = {}
         for i, (lbl, val, col) in enumerate(kpis):
             if i > 0:
-                s = _F(); s.setFrameShape(_F.VLine); s.setFixedWidth(1)
+                s = QFrame()
+                s.setFrameShape(QFrame.VLine)
+                s.setFixedWidth(1)
                 s.setStyleSheet("background:#334155; border:none;")
-                lay.addWidget(s); lay.addSpacing(20)
-            c = _V(); c.setSpacing(1)
-            v = _L(val); v.setStyleSheet(f"color:{col};font-size:18px;font-weight:700;background:transparent;")
-            l = _L(lbl.upper()); l.setStyleSheet("color:#64748B;font-size:9px;font-weight:700;letter-spacing:0.5px;background:transparent;")
-            c.addWidget(v); c.addWidget(l); lay.addLayout(c)
+                lay.addWidget(s)
+                lay.addSpacing(20)
+            c = QVBoxLayout()
+            c.setSpacing(1)
+            v = QLabel(val)
+            v.setStyleSheet(f"color:{col};font-size:18px;font-weight:700;background:transparent;")
+            l = QLabel(lbl.upper())
+            l.setStyleSheet("color:#64748B;font-size:9px;font-weight:700;letter-spacing:0.5px;background:transparent;")
+            c.addWidget(v)
+            c.addWidget(l)
+            lay.addLayout(c)
             self._caja_kpi_labels[lbl] = v
-            if i < 3: lay.addSpacing(20)
+            if i < 3:
+                lay.addSpacing(20)
         lay.addStretch()
         return bar
-        # Build additional tabs (historial + arqueo)
-        try:
-            self._build_tab_historial()
-            self._build_tab_arqueo()
-        except Exception:
-            pass
 
     def set_usuario_actual(self, usuario: str, rol: str):
         self.usuario_actual = usuario
-        self.rol_actual     = rol or "cajero"
+        self.rol_actual = rol or "cajero"
         self.verificar_estado_caja()
 
     def init_ui(self):
         layout_principal = QVBoxLayout(self)
-        
+
         self.lbl_titulo = QLabel("💵 Gestión de Caja Registradora")
         self.lbl_titulo.setObjectName("heading")
         layout_principal.addWidget(self.lbl_titulo)
 
-        # ── Barra de KPIs de caja ─────────────────────────────────────────────
-        self._caja_kpi_bar = self._crear_caja_kpi_bar()
-        layout_principal.addWidget(self._caja_kpi_bar)
+        self._caja_kpi_bar_widget = self._crear_caja_kpi_bar()
+        layout_principal.addWidget(self._caja_kpi_bar_widget)
 
-        # --- PANEL DE ESTADO ---
         self.panel_estado = QGroupBox("Estado Actual")
         self.panel_estado.setObjectName("styledGroup")
         self.layout_estado = QVBoxLayout(self.panel_estado)
-        
+
         self.lbl_status = QLabel("Buscando estado del turno...")
         self.lbl_status.setAlignment(Qt.AlignCenter)
         self.lbl_status.setObjectName("statusLabel")
         self.layout_estado.addWidget(self.lbl_status)
-        
-        # Botón dinámico (Abrir o Cerrar Turno)
+
         self.btn_accion_turno = create_primary_button(self, "Acción de Turno", "Abrir o cerrar turno de caja según estado")
         self.btn_accion_turno.clicked.connect(self.gestionar_turno)
         self.layout_estado.addWidget(self.btn_accion_turno)
-        
+
         layout_principal.addWidget(self.panel_estado)
-        
-        # --- PANEL DE MOVIMIENTOS (RETIROS / INGRESOS) ---
+
         self.panel_movimientos = QGroupBox("💸 Registrar Movimiento de Efectivo")
         self.panel_movimientos.setObjectName("styledGroup")
         layout_mov = QFormLayout(self.panel_movimientos)
-        
+
         self.cmb_tipo_movimiento = QComboBox()
         self.cmb_tipo_movimiento.addItems(["RETIRO (Salida de dinero)", "INGRESO (Entrada extra)"])
         self.cmb_tipo_movimiento.setObjectName("inputField")
-        
+
         self.txt_monto_mov = QDoubleSpinBox()
         self.txt_monto_mov.setRange(0.1, 999999.0)
         self.txt_monto_mov.setPrefix("$ ")
         self.txt_monto_mov.setObjectName("inputField")
-        
+
         self.txt_concepto = QLineEdit()
         self.txt_concepto.setPlaceholderText("Ej. Pago a proveedor de refrescos, Cambio extra...")
         self.txt_concepto.setObjectName("inputField")
-        
+
         self.btn_guardar_mov = create_success_button(self, "Guardar Movimiento", "Registrar movimiento de efectivo en el turno")
         self.btn_guardar_mov.clicked.connect(self.registrar_movimiento)
-        
+
         layout_mov.addRow("Tipo:", self.cmb_tipo_movimiento)
         layout_mov.addRow("Monto:", self.txt_monto_mov)
         layout_mov.addRow("Concepto:", self.txt_concepto)
         layout_mov.addRow("", self.btn_guardar_mov)
-        
+
         layout_principal.addWidget(self.panel_movimientos)
 
-        # ── Pestañas: Turno | Movimientos | Historial Cortes | Arqueo ─────────
         self._tabs_caja = QTabWidget()
         layout_principal.addWidget(self._tabs_caja, 1)
 
-        # Tab 0: Movimientos del turno actual
         self._tab_movs = QWidget()
         self._tabs_caja.addTab(self._tab_movs, "📋 Movimientos del Turno")
         self._build_tab_movimientos()
 
-        # Tab 1: Historial de cortes
         self._tab_hist = QWidget()
         self._tabs_caja.addTab(self._tab_hist, "📜 Historial de Cortes")
 
-        # Tab 2: Arqueo de caja
         self._tab_arqueo = QWidget()
         self._tabs_caja.addTab(self._tab_arqueo, "🔢 Arqueo")
 
@@ -495,26 +495,29 @@ class ModuloCaja(QWidget, RefreshMixin):
             pass
 
     def verificar_estado_caja(self):
-        """Consulta al servicio financiero si el usuario ya abrió su caja hoy."""
-        if not self.usuario_actual: return
-        
+        """Consulta al servicio de caja si el usuario ya abrió su caja hoy."""
+        if not self.usuario_actual:
+            return
+
         try:
-            # 🚀 LLAMADA ENTERPRISE: El servicio revisa la BD
-            turno = self.container.finance_service.get_estado_turno(self.sucursal_id, self.usuario_actual)
-            
+            svc = self._caja_svc
+            if svc:
+                turno = svc.get_estado_turno(self.sucursal_id, self.usuario_actual)
+            else:
+                turno = self.container.finance_service.get_estado_turno(self.sucursal_id, self.usuario_actual)
+
             if turno:
                 self.turno_actual = turno['id']
                 self.lbl_status.setText(f"✅ TURNO ABIERTO\nFondo Inicial: ${turno['fondo_inicial']:.2f}")
                 self.lbl_status.setProperty("class", "status-success")
                 self.lbl_status.style().unpolish(self.lbl_status)
                 self.lbl_status.style().polish(self.lbl_status)
-                
-                # Reemplazar botón por uno de peligro
+
                 idx = self.layout_estado.indexOf(self.btn_accion_turno)
                 if idx != -1:
                     self.layout_estado.removeWidget(self.btn_accion_turno)
                     self.btn_accion_turno.deleteLater()
-                
+
                 self.btn_accion_turno = create_danger_button(self, "🔒 CERRAR CAJA (CORTE Z)", "Cerrar turno y realizar corte Z")
                 self.btn_accion_turno.clicked.connect(self.gestionar_turno)
                 self.layout_estado.insertWidget(idx, self.btn_accion_turno)
@@ -525,92 +528,101 @@ class ModuloCaja(QWidget, RefreshMixin):
                 self.lbl_status.setProperty("class", "status-neutral")
                 self.lbl_status.style().unpolish(self.lbl_status)
                 self.lbl_status.style().polish(self.lbl_status)
-                
-                # Reemplazar botón por uno primario
+
                 idx = self.layout_estado.indexOf(self.btn_accion_turno)
                 if idx != -1:
                     self.layout_estado.removeWidget(self.btn_accion_turno)
                     self.btn_accion_turno.deleteLater()
-                
+
                 self.btn_accion_turno = create_primary_button(self, "🔓 ABRIR TURNO DE CAJA", "Iniciar nuevo turno de caja con fondo inicial")
                 self.btn_accion_turno.clicked.connect(self.gestionar_turno)
                 self.layout_estado.insertWidget(idx, self.btn_accion_turno)
-                self.panel_movimientos.setEnabled(False) # No se puede retirar dinero si la caja está cerrada
-                
+                self.panel_movimientos.setEnabled(False)
+
         except Exception as e:
             self.lbl_status.setText("Error leyendo estado de caja.")
-            print(f"Error en caja: {e}")
+            import logging
+            logging.getLogger(__name__).error("verificar_estado_caja: %s", e)
 
     def gestionar_turno(self):
-        """Decide si abre o cierra la caja dependiendo del estado actual."""
         if self.turno_actual is None:
             self.abrir_caja()
         else:
             self.cerrar_caja()
 
     def abrir_caja(self):
-        # v13.30: Verificar permiso
         try:
             from core.permissions import verificar_permiso
             if not verificar_permiso(self.container, "caja.abrir", self):
                 return
-        except Exception: pass
+        except Exception:
+            pass
+
         fondo, ok = QInputDialog.getDouble(
-            self, "Abrir Turno", 
+            self, "Abrir Turno",
             "¿Con cuánto dinero en efectivo inicias el turno en el cajón?",
             value=0.0, min=0.0, max=99999.0, decimals=2
         )
-        
+
         if ok:
             try:
-                # 🚀 LLAMADA ENTERPRISE: Abrir turno
-                self.container.finance_service.abrir_turno(self.sucursal_id, self.usuario_actual, fondo)
+                svc = self._caja_svc
+                if svc:
+                    svc.abrir_turno(self.sucursal_id, self.usuario_actual, fondo)
+                else:
+                    self.container.finance_service.abrir_turno(self.sucursal_id, self.usuario_actual, fondo)
+
                 Toast.success(self, "Turno abierto", f"Fondo inicial: ${fondo:.2f}")
-                
-                # Intentamos abrir el cajón físico para que guarden el fondo
+
                 if hasattr(self.container, 'hardware_service'):
                     self.container.hardware_service.open_cash_drawer()
-                    
+
                 self.verificar_estado_caja()
             except Exception as e:
                 QMessageBox.critical(self, "Error", str(e))
 
     def registrar_movimiento(self):
-        # v13.30: Verificar permiso
         try:
             from core.permissions import verificar_permiso
             if not verificar_permiso(self.container, "caja.movimientos", self):
                 return
-        except Exception: pass
+        except Exception:
+            pass
+
         if not self.turno_actual:
             return
-            
+
         monto = self.txt_monto_mov.value()
         concepto = self.txt_concepto.text().strip()
         tipo = "RETIRO" if "RETIRO" in self.cmb_tipo_movimiento.currentText() else "INGRESO"
-        
+
         if not concepto:
             QMessageBox.warning(self, "Aviso", "Debe ingresar un concepto para justificar el movimiento.")
             return
-            
+
         try:
-            # 🚀 LLAMADA ENTERPRISE: Registrar retiro/ingreso
-            self.container.finance_service.registrar_movimiento_manual(
-                self.turno_actual, self.sucursal_id, self.usuario_actual, tipo, monto, concepto
-            )
-            
+            svc = self._caja_svc
+            if svc:
+                svc.registrar_movimiento_manual(
+                    self.turno_actual, self.sucursal_id, self.usuario_actual, tipo, monto, concepto
+                )
+            else:
+                self.container.finance_service.registrar_movimiento_manual(
+                    self.turno_actual, self.sucursal_id, self.usuario_actual, tipo, monto, concepto
+                )
+
             Toast.success(self, "Movimiento registrado", f"{tipo} registrado correctamente.")
-            # Refresh movimientos tab
-            try: self._cargar_movimientos_turno()
-            except Exception: pass
-            
-            # Abrir cajón para sacar/meter el billete
+            try:
+                self._cargar_movimientos_turno()
+            except Exception:
+                pass
+
             if hasattr(self.container, 'hardware_service'):
                 self.container.hardware_service.open_cash_drawer()
-                
+
             self.txt_monto_mov.setValue(0.1)
             self.txt_concepto.clear()
-            
+
         except Exception as e:
             QMessageBox.critical(self, "Error", str(e))
 
@@ -620,12 +632,13 @@ class ModuloCaja(QWidget, RefreshMixin):
         El cajero NO ve los totales del sistema antes de contar el efectivo.
         Solo después de ingresar su conteo se revela la diferencia.
         """
-        # v13.30: Verificar permiso
         try:
             from core.permissions import verificar_permiso
             if not verificar_permiso(self.container, "caja.cerrar", self):
                 return
-        except Exception: pass
+        except Exception:
+            pass
+
         dlg = DialogoCorteZCiego(
             turno_id    = self.turno_actual,
             cajero      = self.usuario_actual,
@@ -640,14 +653,13 @@ class ModuloCaja(QWidget, RefreshMixin):
         if not resultado:
             return
 
-        # Notificaciones y PDF
         try:
             notif = getattr(self.container, 'notification_service', None)
             if notif:
                 notif.notificar_corte_z(
                     folio        = str(resultado.get('cierre_id', '?')),
-                    total_ventas = float(resultado.get('ventas_totales', 0)),
-                    total_caja   = float(resultado.get('contado', 0)),
+                    total_ventas = float(resultado.get('total_ventas', resultado.get('ventas_totales', 0))),
+                    total_caja   = float(resultado.get('efectivo_contado', resultado.get('contado', 0))),
                     diferencia   = float(resultado.get('diferencia', 0)),
                     cajero       = self.usuario_actual,
                     sucursal_id  = self.sucursal_id,
@@ -656,232 +668,97 @@ class ModuloCaja(QWidget, RefreshMixin):
             import logging
             logging.getLogger(__name__).debug("notif corte_z: %s", _e)
 
+        # Impresión via CajaTicketService (sin lógica de impresión en UI)
         try:
-            self.imprimir_ticket_corte(resultado)
+            ticket_svc = getattr(self.container, 'caja_ticket_service', None)
+            if ticket_svc:
+                ticket_svc.preview_or_print_corte(resultado, self.usuario_actual, parent=self)
+            else:
+                self._fallback_imprimir(resultado)
+        except Exception as _e:
+            import logging
+            logging.getLogger(__name__).warning("imprimir corte: %s", _e)
+
+        self.verificar_estado_caja()
+        try:
+            self._cargar_movimientos_turno()
         except Exception:
             pass
 
-        self.verificar_estado_caja()
-        try: self._cargar_movimientos_turno()
-        except Exception: pass
-
-    # =========================================================
-    # NUEVAS FUNCIONES PARA IMPRIMIR EL TICKET DEL CORTE Z
-    # =========================================================
-    def imprimir_ticket_corte(self, resultado_corte: dict):
-        """
-        Muestra el ticket de corte Z en un diálogo y ofrece imprimir/guardar PDF.
-        Acepta tanto las claves del finance_service como las normalizadas.
-        """
-        # Normalize key names — generar_corte_z uses efectivo_esperado/contado
-        datos = {
-            'fecha':         datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-            'cajero':        self.usuario_actual,
-            'ventas_totales': float(resultado_corte.get('total_ventas',
-                                   resultado_corte.get('ventas_totales', 0))),
-            'retiros':       float(resultado_corte.get('retiros', 0)),
-            'esperado':      float(resultado_corte.get('efectivo_esperado',
-                                   resultado_corte.get('esperado', 0))),
-            'contado':       float(resultado_corte.get('efectivo_contado',
-                                   resultado_corte.get('contado', 0))),
-            'diferencia':    float(resultado_corte.get('diferencia', 0)),
-            'fondo_inicial': float(resultado_corte.get('fondo_inicial', 0)),
-        }
-        cierre_id = resultado_corte.get('cierre_id',
-                    resultado_corte.get('turno_id', 0))
-
+    def _fallback_imprimir(self, resultado: dict):
+        """Impresión básica cuando CajaTicketService no está disponible."""
         try:
-            # 1. Save PDF audit copy silently
-            self.guardar_corte_pdf(datos, cierre_id)
-        except Exception as e:
-            import logging; logging.getLogger(__name__).warning("PDF corte: %s", e)
-
-        # 2. Show print dialog
-        try:
-            html = self._generar_html_corte(datos, cierre_id)
-            from PyQt5.QtWidgets import QDialog, QVBoxLayout, QTextBrowser, QHBoxLayout
+            from PyQt5.QtWidgets import QDialog as _D, QVBoxLayout as _V, QTextBrowser as _TB
             from PyQt5.QtPrintSupport import QPrinter, QPrintDialog
             from PyQt5.QtGui import QTextDocument
-
-            dlg = QDialog(self)
-            dlg.setWindowTitle(f"Ticket Corte Z — {datos['cajero']}")
-            dlg.setMinimumSize(420, 500)
-            lay = QVBoxLayout(dlg)
-
-            browser = QTextBrowser()
+            datos = {
+                'fecha': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                'cajero': self.usuario_actual,
+                'ventas_totales': float(resultado.get('total_ventas', resultado.get('ventas_totales', 0))),
+                'retiros': float(resultado.get('retiros', 0)),
+                'esperado': float(resultado.get('efectivo_esperado', resultado.get('esperado', 0))),
+                'contado': float(resultado.get('efectivo_contado', resultado.get('contado', 0))),
+                'diferencia': float(resultado.get('diferencia', 0)),
+                'fondo_inicial': float(resultado.get('fondo_inicial', 0)),
+            }
+            cierre_id = resultado.get('cierre_id', resultado.get('turno_id', 0))
+            html = self._generar_html_corte_simple(datos, cierre_id)
+            dlg = _D(self)
+            dlg.setWindowTitle("Ticket Corte Z")
+            dlg.setMinimumSize(420, 400)
+            lay = _V(dlg)
+            browser = _TB()
             browser.setHtml(html)
             lay.addWidget(browser)
-
             btn_row = QHBoxLayout()
-            btn_print = create_primary_button(dlg, "🖨️ Imprimir", "Imprimir comprobante de corte en impresora térmica o sistema")
-            btn_pdf = create_success_button(dlg, "💾 Guardar PDF", "Guardar comprobante de corte como archivo PDF")
-            btn_close = create_secondary_button(dlg, "Cerrar", "Cerrar ventana de vista previa")
-
-            def _do_print():
-                # Try ESC/POS thermal printer first (from HardwareService config)
-                hw = getattr(self.container, 'hardware_service', None)
-                if hw and _try_thermal_print(hw, datos):
-                    return
-                # Fallback: system print dialog
-                from PyQt5.QtPrintSupport import QPrinter, QPrintDialog
-                from PyQt5.QtGui import QTextDocument
-                printer = QPrinter(QPrinter.HighResolution)
-                pdlg = QPrintDialog(printer, dlg)
-                if pdlg.exec_() == QPrintDialog.Accepted:
-                    doc = QTextDocument(); doc.setHtml(html)
-                    doc.print_(printer)
-
-            def _try_thermal_print(hw, d: dict) -> bool:
-                """Send ESC/POS formatted corte Z to thermal printer."""
-                try:
-                    hw.load_configs()  # Refresh config from DB
-                    cfg = hw._cache_config.get('ticket', {})
-                    if not cfg:
-                        return False
-                    ubicacion = cfg.get('ubicacion', '')
-                    ancho = 48 if '80' in cfg.get('ancho', '80') else 32
-                    if not ubicacion:
-                        return False
-
-                    # Build ESC/POS bytes
-                    ESC = b'\x1b'; GS = b'\x1d'
-                    data = bytearray()
-                    data += ESC + b'@'                    # Init
-                    data += ESC + b'a\x01'               # Center align
-                    data += ESC + b'E\x01'               # Bold ON
-                    data += b'** CORTE Z **\n'
-                    data += ESC + b'E\x00'               # Bold OFF
-                    sep = b'-' * ancho + b'\n'
-                    data += sep
-                    data += f"Cajero: {d['cajero']}\n".encode()
-                    data += f"Fecha:  {d['fecha']}\n".encode()
-                    data += sep
-                    data += ESC + b'a\x00'               # Left align
-                    data += f"Ventas:   ${d['ventas_totales']:>10,.2f}\n".encode()
-                    data += f"Retiros:  ${d['retiros']:>10,.2f}\n".encode()
-                    data += sep
-                    data += ESC + b'E\x01'
-                    data += f"Esperado: ${d['esperado']:>10,.2f}\n".encode()
-                    data += f"Contado:  ${d['contado']:>10,.2f}\n".encode()
-                    data += sep
-                    dif = d['diferencia']
-                    dif_str = f"CUADRADO        " if abs(dif) < 0.01 else (
-                              f"FALTANTE ${abs(dif):,.2f}" if dif < 0 else
-                              f"SOBRANTE ${dif:,.2f}")
-                    data += f"DIFERENCIA: {dif_str}\n".encode()
-                    data += ESC + b'E\x00'
-                    data += b'\n\n\n'
-                    data += GS + b'V\x42\x00'           # Full cut
-
-                    tipo = cfg.get('tipo', '').lower()
-                    if 'red' in tipo or ':' in ubicacion:
-                        import socket
-                        ip, port = ubicacion.split(':') if ':' in ubicacion else (ubicacion, '9100')
-                        s = socket.socket(); s.settimeout(5)
-                        s.connect((ip.strip(), int(port))); s.sendall(bytes(data)); s.close()
-                    elif 'serial' in tipo or 'com' in ubicacion.upper():
-                        import serial as _ser
-                        with _ser.Serial(ubicacion, 9600, timeout=3) as s:
-                            s.write(bytes(data))
-                    else:
-                        # USB / raw file
-                        try:
-                            with open(ubicacion, 'wb') as f: f.write(bytes(data))
-                        except Exception:
-                            return False
-                    return True
-                except Exception as _e:
-                    import logging; logging.getLogger(__name__).warning("ESC/POS: %s", _e)
-                    return False
-
-            def _save_pdf():
-                from PyQt5.QtWidgets import QFileDialog
-                path, _ = QFileDialog.getSaveFileName(
-                    dlg, "Guardar Corte Z",
-                    f"CorteZ_{datos['cajero']}_{datos['fecha'][:10]}.pdf",
-                    "PDF (*.pdf)")
-                if path:
-                    printer = QPrinter(QPrinter.HighResolution)
-                    printer.setOutputFormat(QPrinter.PdfFormat)
-                    printer.setOutputFileName(path)
-                    doc = QTextDocument(); doc.setHtml(html)
-                    doc.print_(printer)
-                    Toast.success(self, "PDF guardado", path)
-
-            btn_print.clicked.connect(_do_print)
-            btn_pdf.clicked.connect(_save_pdf)
-            btn_close.clicked.connect(dlg.accept)
-
-            btn_row.addWidget(btn_print)
-            btn_row.addWidget(btn_pdf)
-            btn_row.addStretch()
-            btn_row.addWidget(btn_close)
+            btn_p = create_primary_button(dlg, "🖨️ Imprimir", "Imprimir")
+            btn_c = create_secondary_button(dlg, "Cerrar", "Cerrar")
+            def _print():
+                p = QPrinter(QPrinter.HighResolution)
+                pd = QPrintDialog(p, dlg)
+                if pd.exec_() == QPrintDialog.Accepted:
+                    doc = QTextDocument(); doc.setHtml(html); doc.print_(p)
+            btn_p.clicked.connect(_print)
+            btn_c.clicked.connect(dlg.accept)
+            btn_row.addWidget(btn_p); btn_row.addStretch(); btn_row.addWidget(btn_c)
             lay.addLayout(btn_row)
             dlg.exec_()
-        except Exception as e:
-            import logging; logging.getLogger(__name__).warning("imprimir_ticket_corte: %s", e)
+        except Exception:
+            pass
 
-    def guardar_corte_pdf(self, datos: dict, cierre_id: int):
-        """Genera un archivo PDF con el resumen del cierre."""
-        import os
-        from PyQt5.QtPrintSupport import QPrinter
-        from PyQt5.QtGui import QTextDocument
-
-        carpeta_cortes = "CORTES_Z"
-        os.makedirs(carpeta_cortes, exist_ok=True)
-
-        try:
-            printer = QPrinter(QPrinter.HighResolution)
-            printer.setOutputFormat(QPrinter.PdfFormat)
-            filename = os.path.join(carpeta_cortes, f"corte_z_{cierre_id}_{datetime.now().strftime('%Y%m%d')}.pdf")
-            printer.setOutputFileName(filename)
-            
-            doc = QTextDocument()
-            html = self._generar_html_corte(datos, cierre_id)
-            doc.setHtml(html)
-            doc.print_(printer)
-        except Exception as e:
-            print(f"Error guardando PDF de corte: {e}")
-
-    def _generar_html_corte(self, datos: dict, cierre_id: int) -> str:
-        """Diseño del ticket en formato HTML."""
-        
-        diferencia_texto = f"Exacto ($0.00)"
-        if datos['diferencia'] < 0:
-            diferencia_texto = f"<span style='color: red;'>FALTANTE: ${abs(datos['diferencia']):.2f}</span>"
-        elif datos['diferencia'] > 0:
-            diferencia_texto = f"SOBRANTE: ${datos['diferencia']:.2f}"
-
+    def _generar_html_corte_simple(self, datos: dict, cierre_id: int) -> str:
+        dif = float(datos.get('diferencia', 0))
+        if dif < -0.01:
+            dif_txt = f"<span style='color:red;'>FALTANTE: ${abs(dif):.2f}</span>"
+        elif dif > 0.01:
+            dif_txt = f"SOBRANTE: ${dif:.2f}"
+        else:
+            dif_txt = "Exacto ($0.00)"
         return f"""
-        <html>
-        <body style="font-family: monospace; text-align: center; width: 300px;">
-            <h2>CORTE DE CAJA (Z)</h2>
-            <p>=============================</p>
+        <html><body style="font-family:monospace;text-align:center;width:300px;">
+            <h2>CORTE DE CAJA (Z)</h2><p>=============================</p>
             <p><strong>Folio:</strong> {cierre_id}</p>
-            <p><strong>Fecha:</strong> {datos['fecha']}</p>
-            <p><strong>Cajero:</strong> {datos['cajero']}</p>
+            <p><strong>Fecha:</strong> {datos.get('fecha','')}</p>
+            <p><strong>Cajero:</strong> {datos.get('cajero','')}</p>
             <p>=============================</p>
-            <div style="text-align: left; padding-left: 20px;">
-                <p>Ventas Totales: ${datos['ventas_totales']:.2f}</p>
-                <p>Gastos/Retiros: ${datos['retiros']:.2f}</p>
+            <div style="text-align:left;padding-left:20px;">
+                <p>Ventas Totales: ${float(datos.get('ventas_totales',0)):.2f}</p>
+                <p>Gastos/Retiros: ${float(datos.get('retiros',0)):.2f}</p>
                 <p>-------------------------</p>
-                <p><strong>EFECTIVO ESPERADO: ${datos['esperado']:.2f}</strong></p>
-                <p><strong>EFECTIVO CONTADO:  ${datos['contado']:.2f}</strong></p>
+                <p><strong>EFECTIVO ESPERADO: ${float(datos.get('esperado',0)):.2f}</strong></p>
+                <p><strong>EFECTIVO CONTADO:  ${float(datos.get('contado',0)):.2f}</strong></p>
                 <p>-------------------------</p>
-                <h3>DIFERENCIA: {diferencia_texto}</h3>
+                <h3>DIFERENCIA: {dif_txt}</h3>
             </div>
-            <br><br><br>
-            <p>_________________________</p>
-            <p>Firma del Cajero</p>
-        </body>
-        </html>
-        """
+            <br><br><p>_________________________</p><p>Firma del Cajero</p>
+        </body></html>"""
+
+    # ── Tabs ──────────────────────────────────────────────────────────────────
+
     def _build_tab_movimientos(self) -> None:
-        """Tab de movimientos del turno activo con quién hizo qué."""
         lay = QVBoxLayout(self._tab_movs)
         lay.setContentsMargins(8, 8, 8, 8)
 
-        # Header
         hdr = QHBoxLayout()
         lbl = QLabel("Movimientos de efectivo del turno activo")
         lbl.setObjectName("subheading")
@@ -892,7 +769,6 @@ class ModuloCaja(QWidget, RefreshMixin):
         hdr.addWidget(btn_ref)
         lay.addLayout(hdr)
 
-        # Table
         self._tbl_movs = create_table_with_columns(
             self,
             columns=["Hora", "Tipo", "Concepto", "Monto", "Usuario", "ID Turno"],
@@ -905,12 +781,11 @@ class ModuloCaja(QWidget, RefreshMixin):
             hh.setSectionResizeMode(c, QHeaderView.ResizeToContents)
         lay.addWidget(self._tbl_movs)
 
-        # Totals bar
         tot_row = QHBoxLayout()
-        self.lbl_mov_ingresos  = QLabel("Ingresos: $0.00")
-        self.lbl_mov_retiros   = QLabel("Retiros: $0.00")
-        self.lbl_mov_ventas    = QLabel("Ventas: $0.00")
-        self.lbl_mov_neto      = QLabel("Neto en caja: $0.00")
+        self.lbl_mov_ingresos = QLabel("Ingresos: $0.00")
+        self.lbl_mov_retiros  = QLabel("Retiros: $0.00")
+        self.lbl_mov_ventas   = QLabel("Ventas: $0.00")
+        self.lbl_mov_neto     = QLabel("Neto en caja: $0.00")
         for lbl in (self.lbl_mov_ingresos, self.lbl_mov_retiros,
                     self.lbl_mov_ventas, self.lbl_mov_neto):
             lbl.setObjectName("badge")
@@ -923,66 +798,64 @@ class ModuloCaja(QWidget, RefreshMixin):
         lay.addLayout(tot_row)
 
     def _cargar_movimientos_turno(self) -> None:
-        """Carga todos los movimientos del turno activo en la tabla."""
         self._tbl_movs.setRowCount(0)
         if not self.turno_actual:
             return
+
+        svc = self._caja_svc
         try:
-            rows = self.container.db.execute("""
-                SELECT fecha, tipo, COALESCE(concepto, descripcion,'') as concepto,
-                       monto, COALESCE(usuario,'Sistema') as usuario, turno_id
-                FROM movimientos_caja
-                WHERE turno_id=?
-                ORDER BY fecha DESC
-            """, (self.turno_actual,)).fetchall()
-        except Exception as e:
-            rows = []
+            if svc:
+                rows_raw = svc.get_movimientos_turno(self.turno_actual, self.rol_actual)
+            else:
+                rows_raw = self.container.finance_service.get_movimientos_turno(self.turno_actual)
+        except Exception:
+            rows_raw = []
 
         ingresos = retiros = ventas = 0.0
 
-        for ri, r in enumerate(rows):
+        from PyQt5.QtGui import QColor
+        for ri, r in enumerate(rows_raw):
             self._tbl_movs.insertRow(ri)
-            fecha_str = str(r[0] or "")[:16]
-            tipo      = str(r[1] or "")
-            concepto  = str(r[2] or "")
-            monto     = float(r[3] or 0)
-            usuario   = str(r[4] or "Sistema")
-            turno_id  = str(r[5] or "")
+            fecha_str = str(r.get('fecha', r[0] if isinstance(r, (list, tuple)) else '') or "")[:16]
+            tipo      = str(r.get('tipo', r[1] if isinstance(r, (list, tuple)) else '') or "")
+            concepto  = str(r.get('concepto', r[2] if isinstance(r, (list, tuple)) else '') or "")
+            monto     = float(r.get('monto', r[3] if isinstance(r, (list, tuple)) else 0) or 0)
+            usuario   = str(r.get('usuario', r[4] if isinstance(r, (list, tuple)) else 'Sistema') or "Sistema")
+            turno_id  = str(r.get('turno_id', r[5] if isinstance(r, (list, tuple)) else '') or "")
 
-            # Hide monto for non-admin roles (blind corte principle)
             rol = getattr(self, 'rol_actual', 'cajero').lower()
             monto_display = (f"${monto:,.2f}"
-                             if rol in ('admin','administrador','gerente')
+                             if rol in ('admin', 'administrador', 'gerente')
                              else "***")
-            vals = [fecha_str, tipo, concepto,
-                    monto_display, usuario, turno_id]
+            vals = [fecha_str, tipo, concepto, monto_display, usuario, turno_id]
             for ci, val in enumerate(vals):
                 it = QTableWidgetItem(val)
                 it.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
-                # Color by type
                 if tipo == "VENTA":
-                    it.setForeground(__import__('PyQt5.QtGui', fromlist=['QColor']).QColor('#27ae60'))
+                    it.setForeground(QColor('#27ae60'))
                 elif tipo in ("RETIRO", "GASTO"):
-                    it.setForeground(__import__('PyQt5.QtGui', fromlist=['QColor']).QColor('#e74c3c'))
+                    it.setForeground(QColor('#e74c3c'))
                 self._tbl_movs.setItem(ri, ci, it)
 
-            # Accumulate
-            if tipo == "VENTA":       ventas   += monto
-            elif tipo == "INGRESO":   ingresos += monto
-            elif tipo in ("RETIRO","GASTO"): retiros += monto
+            if tipo == "VENTA":      ventas   += monto
+            elif tipo == "INGRESO":  ingresos += monto
+            elif tipo in ("RETIRO", "GASTO"): retiros += monto
 
-        # Update totals bar
+        # Fondo inicial via servicio
         fondo = 0.0
         try:
-            row = self.container.db.execute(
-                "SELECT fondo_inicial FROM turnos_caja WHERE id=?",
-                (self.turno_actual,)).fetchone()
-            if row: fondo = float(row[0] or 0)
-        except Exception: pass
+            if svc:
+                turno = svc.get_estado_turno(self.sucursal_id, self.usuario_actual)
+                if turno:
+                    fondo = float(turno.get('fondo_inicial', 0) or 0)
+            else:
+                row = self.container.finance_service.get_estado_turno(self.sucursal_id, self.usuario_actual)
+                if row:
+                    fondo = float(row.get('fondo_inicial', 0) or 0)
+        except Exception:
+            pass
 
         neto = fondo + ventas + ingresos - retiros
-        # Solo mostrar totales financieros al gerente/admin
-        # El cajero solo ve cantidad de movimientos, no importes totales
         rol = getattr(self, 'rol_actual', 'cajero').lower()
         es_gerente = rol in ('admin', 'administrador', 'gerente')
 
@@ -992,15 +865,13 @@ class ModuloCaja(QWidget, RefreshMixin):
             self.lbl_mov_ventas.setText(f"Ventas: ${ventas:,.2f}")
             self.lbl_mov_neto.setText(f"Neto en caja: ${neto:,.2f}")
         else:
-            # Cajero ve solo contadores, sin importes
-            self.lbl_mov_ingresos.setText(
-                f"Entradas: {sum(1 for r in rows if str(r[1] or '') == 'INGRESO')} mov.")
-            self.lbl_mov_retiros.setText(
-                f"Retiros: {sum(1 for r in rows if str(r[1] or '') in ('RETIRO','GASTO'))} mov.")
-            self.lbl_mov_ventas.setText(
-                f"Ventas: {sum(1 for r in rows if str(r[1] or '') == 'VENTA')} registradas")
+            num_ingresos = sum(1 for r in rows_raw if str(r.get('tipo', '') if isinstance(r, dict) else r[1]) == 'INGRESO')
+            num_retiros  = sum(1 for r in rows_raw if str(r.get('tipo', '') if isinstance(r, dict) else r[1]) in ('RETIRO','GASTO'))
+            num_ventas   = sum(1 for r in rows_raw if str(r.get('tipo', '') if isinstance(r, dict) else r[1]) == 'VENTA')
+            self.lbl_mov_ingresos.setText(f"Entradas: {num_ingresos} mov.")
+            self.lbl_mov_retiros.setText(f"Retiros: {num_retiros} mov.")
+            self.lbl_mov_ventas.setText(f"Ventas: {num_ventas} registradas")
             self.lbl_mov_neto.setText("Corte al cerrar turno")
-            # Also hide monto column for cajero
             self.lbl_mov_neto.setObjectName("badge-neutral")
 
     def _on_tab_change(self, idx: int) -> None:
@@ -1012,16 +883,12 @@ class ModuloCaja(QWidget, RefreshMixin):
             self._init_arqueo()
 
     def _build_tab_historial(self) -> None:
-        from PyQt5.QtWidgets import (QVBoxLayout, QHBoxLayout, QTableWidget,
-                                      QTableWidgetItem, QHeaderView,
-                                      QAbstractItemView, QPushButton, QLabel)
-        from PyQt5.QtCore import Qt
         lay = QVBoxLayout(self._tab_hist)
         lay.addWidget(create_subheading(self, "Historial de cortes Z y X de esta sucursal"))
         self._tbl_hist = QTableWidget()
         self._tbl_hist.setColumnCount(6)
         self._tbl_hist.setHorizontalHeaderLabels(
-            ["Tipo","Fecha","Cajero","Ventas","Efectivo","Acciones"])
+            ["Tipo", "Fecha", "Cajero", "Ventas", "Efectivo", "Acciones"])
         hh = self._tbl_hist.horizontalHeader()
         hh.setSectionResizeMode(2, QHeaderView.Stretch)
         self._tbl_hist.setEditTriggers(QAbstractItemView.NoEditTriggers)
@@ -1030,61 +897,76 @@ class ModuloCaja(QWidget, RefreshMixin):
         lay.addWidget(self._tbl_hist)
 
     def _cargar_historial_cortes(self) -> None:
-        from PyQt5.QtWidgets import QTableWidgetItem, QPushButton, QWidget, QHBoxLayout
-        from PyQt5.QtCore import Qt
+        from PyQt5.QtWidgets import QWidget as _W, QHBoxLayout as _H
+        svc = self._caja_svc
         try:
-            rows = self.container.db.execute("""
-                SELECT tipo, fecha_cierre, usuario, total_ventas,
-                       total_efectivo, id
-                FROM cierres_caja
-                WHERE sucursal_id=?
-                ORDER BY fecha_cierre DESC LIMIT 100
-            """, (self.sucursal_id,)).fetchall()
-        except Exception as e:
+            if svc:
+                rows = svc.get_historial_cortes(self.sucursal_id, limit=100)
+            else:
+                rows = []
+        except Exception:
             rows = []
+
         self._tbl_hist.setRowCount(len(rows))
         for ri, r in enumerate(rows):
-            vals = [r[0] or "Z", str(r[1] or "")[:16], r[2] or "",
-                    f"${float(r[3] or 0):,.2f}", f"${float(r[4] or 0):,.2f}"]
+            if isinstance(r, dict):
+                vals = [
+                    r.get('tipo', 'Z'),
+                    str(r.get('fecha_cierre', ''))[:16],
+                    r.get('usuario', ''),
+                    f"${float(r.get('total_ventas', 0) or 0):,.2f}",
+                    f"${float(r.get('total_efectivo', r.get('efectivo_contado', 0)) or 0):,.2f}",
+                ]
+                cierre_id = r.get('id', 0)
+            else:
+                vals = [r[0] or "Z", str(r[1] or "")[:16], r[2] or "",
+                        f"${float(r[3] or 0):,.2f}", f"${float(r[4] or 0):,.2f}"]
+                cierre_id = r[5]
+
             for ci, v in enumerate(vals):
                 it = QTableWidgetItem(v)
                 it.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
                 self._tbl_hist.setItem(ri, ci, it)
-            cierre_id = r[5]
-            btn_w = QWidget(); btn_lay = QHBoxLayout(btn_w)
-            btn_lay.setContentsMargins(2,2,2,2)
+
+            btn_w = _W()
+            btn_lay = _H(btn_w)
+            btn_lay.setContentsMargins(2, 2, 2, 2)
             btn_r = create_secondary_button(self, "🖨️ Reimprimir", "Volver a imprimir comprobante de corte")
-            btn_r.clicked.connect(
-                lambda _, cid=cierre_id: self._reimprimir_corte(cid))
+            btn_r.clicked.connect(lambda _, cid=cierre_id: self._reimprimir_corte(cid))
             btn_lay.addWidget(btn_r)
             self._tbl_hist.setCellWidget(ri, 5, btn_w)
 
     def _reimprimir_corte(self, cierre_id: int) -> None:
+        svc = self._caja_svc
         try:
-            row = self.container.db.execute(
-                "SELECT * FROM cierres_caja WHERE id=?", (cierre_id,)
-            ).fetchone()
-            if not row:
-        # [spj-dedup removed local QMessageBox import]
-                QMessageBox.warning(self, "No encontrado",
-                    "No se encontró el corte."); return
-            d = dict(row)
-            cierre_id_r = d.get('id', 0)
-            # Normalize key names
+            if svc:
+                d = svc.get_cierre_por_id(cierre_id)
+            else:
+                d = None
+
+            if not d:
+                QMessageBox.warning(self, "No encontrado", "No se encontró el corte.")
+                return
+
             datos_r = {
                 'fecha': str(d.get('fecha_cierre', d.get('fecha', ''))),
                 'cajero': d.get('usuario', '?'),
-                'ventas_totales': float(d.get('total_ventas', d.get('ventas_totales', 0))),
-                'retiros': float(d.get('retiros', d.get('total_retiros', 0))),
-                'esperado': float(d.get('efectivo_esperado', d.get('esperado', 0))),
-                'contado':  float(d.get('efectivo_contado', d.get('contado', d.get('total_efectivo', 0)))),
-                'diferencia': float(d.get('diferencia', 0)),
-                'fondo_inicial': float(d.get('fondo_inicial', 0)),
+                'ventas_totales': float(d.get('total_ventas', d.get('ventas_totales', 0)) or 0),
+                'retiros': float(d.get('retiros', d.get('total_retiros', 0)) or 0),
+                'esperado': float(d.get('efectivo_esperado', d.get('esperado', 0)) or 0),
+                'contado': float(d.get('efectivo_contado', d.get('contado', d.get('total_efectivo', 0))) or 0),
+                'diferencia': float(d.get('diferencia', 0) or 0),
+                'fondo_inicial': float(d.get('fondo_inicial', 0) or 0),
             }
-            html = self._generar_html_corte(datos_r, cierre_id_r)
+
+            ticket_svc = getattr(self.container, 'caja_ticket_service', None)
+            if ticket_svc:
+                html = ticket_svc.generar_html_corte(datos_r, cierre_id)
+            else:
+                html = self._generar_html_corte_simple(datos_r, cierre_id)
+
             self._imprimir_html(html)
         except Exception as e:
-        # [spj-dedup removed local QMessageBox import]
             QMessageBox.critical(self, "Error", str(e))
 
     def _imprimir_html(self, html: str) -> None:
@@ -1092,14 +974,13 @@ class ModuloCaja(QWidget, RefreshMixin):
         from PyQt5.QtGui import QTextDocument
         printer = QPrinter(QPrinter.HighResolution)
         dlg = QPrintDialog(printer, self)
-        if dlg.exec_() != QPrintDialog.Accepted: return
-        doc = QTextDocument(); doc.setHtml(html)
+        if dlg.exec_() != QPrintDialog.Accepted:
+            return
+        doc = QTextDocument()
+        doc.setHtml(html)
         doc.print_(printer)
 
     def _build_tab_arqueo(self) -> None:
-        from PyQt5.QtWidgets import (QVBoxLayout, QHBoxLayout, QFormLayout,
-                                      QGroupBox, QLabel, QDoubleSpinBox,
-                                      QPushButton, QGridLayout)
         lay = QVBoxLayout(self._tab_arqueo)
 
         info = create_label(self, "Cuenta los billetes y monedas del cajón para verificar el cierre.", "caption")
@@ -1114,6 +995,7 @@ class ModuloCaja(QWidget, RefreshMixin):
             ("$2", 2), ("$1", 1), ("$0.50", 0.5),
         ]
         self._arqueo_spins = {}
+        self._arqueo_sub_labels = {}
         for i, (label, valor) in enumerate(DENOMINACIONES):
             col = (i % 2) * 3
             row_idx = i // 2
@@ -1121,16 +1003,19 @@ class ModuloCaja(QWidget, RefreshMixin):
             lbl_den.setObjectName("subheading")
             grid.addWidget(lbl_den, row_idx, col)
             spin = QDoubleSpinBox()
-            spin.setRange(0, 9999); spin.setDecimals(0)
-            spin.setSuffix(" pzas"); spin.setFixedWidth(100)
+            spin.setRange(0, 9999)
+            spin.setDecimals(0)
+            spin.setSuffix(" pzas")
+            spin.setFixedWidth(100)
             spin.setObjectName("inputField")
             spin.valueChanged.connect(self._calcular_arqueo)
             self._arqueo_spins[valor] = spin
-            grid.addWidget(spin, row_idx, col+1)
+            grid.addWidget(spin, row_idx, col + 1)
+            # Keep the specific name for lookup; do NOT overwrite with a generic one
             lbl_subtotal = QLabel("$0.00")
             lbl_subtotal.setObjectName(f"lbl_arq_{valor}")
-            lbl_subtotal.setObjectName("badge")
-            grid.addWidget(lbl_subtotal, row_idx, col+2)
+            self._arqueo_sub_labels[valor] = lbl_subtotal  # Direct reference — no findChild needed
+            grid.addWidget(lbl_subtotal, row_idx, col + 2)
 
         lay.addWidget(grp)
 
@@ -1146,7 +1031,7 @@ class ModuloCaja(QWidget, RefreshMixin):
 
         btn_limpiar = create_secondary_button(self, "🔄 Limpiar", "Limpiar conteo de arqueo")
         btn_limpiar.clicked.connect(self._limpiar_arqueo)
-        lay.addWidget(btn_limpiar, 0, __import__('PyQt5.QtCore', fromlist=['Qt']).Qt.AlignLeft)
+        lay.addWidget(btn_limpiar, 0, Qt.AlignLeft)
         lay.addStretch()
 
     def _init_arqueo(self) -> None:
@@ -1158,27 +1043,26 @@ class ModuloCaja(QWidget, RefreshMixin):
             for valor, spin in self._arqueo_spins.items():
                 subtotal = float(valor) * spin.value()
                 total += subtotal
-                lbl = self._tab_arqueo.findChild(
-                    __import__('PyQt5.QtWidgets', fromlist=['QLabel']).QLabel,
-                    f"lbl_arq_{valor}")
+                lbl = self._arqueo_sub_labels.get(valor)
                 if lbl:
                     lbl.setText(f"${subtotal:,.2f}")
             self.lbl_total_arqueo.setText(f"Total contado: ${total:,.2f}")
-            # Compare with system total
-            try:
-                row = self.container.db.execute(
-                    "SELECT total_efectivo FROM turno_actual WHERE sucursal_id=? AND abierto=1",
-                    (self.sucursal_id,)
-                ).fetchone()
-                if row:
-                    sistema = float(row[0] or 0)
-                    diff = total - sistema
-                    color = Colors.SUCCESS_BASE if abs(diff) < 0.01 else Colors.DANGER_HOVER
-                    self.lbl_diferencia_arqueo.setText(
-                        f"Sistema: ${sistema:,.2f} | Diferencia: "
-                        f"<span style='color:{color}'>${diff:+.2f}</span>")
-            except Exception:
-                pass
+
+            # Compare with system via caja_service (no direct DB access)
+            if self.turno_actual:
+                try:
+                    svc = self._caja_svc
+                    if svc:
+                        arqueo = svc.calcular_arqueo(self.turno_actual, total)
+                        if 'error' not in arqueo:
+                            sistema = arqueo.get('esperado', 0)
+                            diff = total - sistema
+                            color = Colors.SUCCESS_BASE if abs(diff) < 0.01 else Colors.DANGER_HOVER
+                            self.lbl_diferencia_arqueo.setText(
+                                f"Sistema (esperado): ${sistema:,.2f} | Diferencia: "
+                                f"<span style='color:{color}'>${diff:+.2f}</span>")
+                except Exception:
+                    pass
         except Exception:
             pass
 

--- a/pos_spj_v13.4/tests/test_caja.py
+++ b/pos_spj_v13.4/tests/test_caja.py
@@ -1,0 +1,396 @@
+# tests/test_caja.py
+"""
+Tests de regresión para el módulo de caja.
+Cubre: turno, movimientos, corte Z, eventos, historial.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import os
+import pytest
+
+# Asegurar que el path del proyecto esté disponible
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ── Fixture: BD en memoria ─────────────────────────────────────────────────────
+
+@pytest.fixture
+def db():
+    """Crea una BD SQLite en memoria con el esquema mínimo para pruebas de caja."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS turnos_caja (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            sucursal_id    INTEGER DEFAULT 1,
+            usuario        TEXT,
+            cajero         TEXT,
+            fondo_inicial  REAL DEFAULT 0,
+            total_ventas   REAL DEFAULT 0,
+            total_efectivo REAL DEFAULT 0,
+            retiros        REAL DEFAULT 0,
+            estado         TEXT DEFAULT 'abierto',
+            fecha_apertura DATETIME DEFAULT (datetime('now')),
+            fecha_cierre   DATETIME,
+            efectivo_esperado REAL DEFAULT 0,
+            efectivo_contado  REAL DEFAULT 0,
+            diferencia        REAL DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS movimientos_caja (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            turno_id    INTEGER,
+            sucursal_id INTEGER DEFAULT 1,
+            tipo        TEXT,
+            monto       REAL DEFAULT 0,
+            concepto    TEXT,
+            descripcion TEXT,
+            usuario     TEXT,
+            fecha       DATETIME DEFAULT (datetime('now'))
+        );
+        CREATE TABLE IF NOT EXISTS cierres_caja (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            uuid                TEXT UNIQUE,
+            tipo                TEXT DEFAULT 'Z',
+            sucursal_id         INTEGER DEFAULT 1,
+            usuario             TEXT,
+            turno               TEXT,
+            fecha_apertura      DATETIME,
+            fecha_cierre        DATETIME DEFAULT (datetime('now')),
+            total_ventas        REAL DEFAULT 0,
+            num_ventas          INTEGER DEFAULT 0,
+            total_efectivo      REAL DEFAULT 0,
+            total_tarjeta       REAL DEFAULT 0,
+            total_transferencia REAL DEFAULT 0,
+            total_otros         REAL DEFAULT 0,
+            total_anulaciones   REAL DEFAULT 0,
+            num_anulaciones     INTEGER DEFAULT 0,
+            efectivo_contado    REAL DEFAULT 0,
+            fondo_inicial       REAL DEFAULT 0,
+            diferencia          REAL DEFAULT 0,
+            comentarios         TEXT,
+            estado              TEXT DEFAULT 'cerrado'
+        );
+        CREATE TABLE IF NOT EXISTS ventas (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            sucursal_id INTEGER DEFAULT 1,
+            cajero      TEXT,
+            usuario     TEXT,
+            total       REAL DEFAULT 0,
+            forma_pago  TEXT DEFAULT 'Efectivo',
+            estado      TEXT DEFAULT 'completada',
+            fecha       DATETIME DEFAULT (datetime('now'))
+        );
+        CREATE TABLE IF NOT EXISTS financial_event_log (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            evento       TEXT,
+            modulo       TEXT,
+            referencia_id INTEGER,
+            monto        REAL,
+            cuenta_debe  TEXT,
+            cuenta_haber TEXT,
+            usuario_id   INTEGER,
+            sucursal_id  INTEGER,
+            metadata     TEXT,
+            created_at   DATETIME DEFAULT (datetime('now'))
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+@pytest.fixture
+def svc(db):
+    """Instancia CajaApplicationService con BD en memoria."""
+    from application.services.caja_application_service import CajaApplicationService
+    return CajaApplicationService(db=db, finance_service=None, caja_repo=None)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _insertar_venta(db, sucursal_id=1, cajero="test_cajero", total=100.0,
+                    forma_pago="Efectivo", estado="completada"):
+    db.execute(
+        "INSERT INTO ventas (sucursal_id, cajero, usuario, total, forma_pago, estado, fecha) "
+        "VALUES (?,?,?,?,?,?,datetime('now'))",
+        (sucursal_id, cajero, cajero, total, forma_pago, estado)
+    )
+    db.commit()
+
+
+# ── Tests: abrir turno ────────────────────────────────────────────────────────
+
+def test_abrir_turno_exitoso(svc):
+    turno_id = svc.abrir_turno(1, "cajero1", 500.0)
+    assert turno_id > 0
+
+
+def test_abrir_turno_retorna_id(svc):
+    tid = svc.abrir_turno(1, "cajero_x", 200.0)
+    assert isinstance(tid, int)
+
+
+def test_no_permitir_doble_turno_abierto(svc):
+    from application.services.caja_application_service import TurnoYaAbiertroError
+    svc.abrir_turno(1, "cajero2", 300.0)
+    with pytest.raises(TurnoYaAbiertroError):
+        svc.abrir_turno(1, "cajero2", 100.0)
+
+
+def test_dos_cajeros_diferentes_pueden_abrir(svc):
+    """Cajeros distintos pueden tener turnos abiertos simultáneos."""
+    svc.abrir_turno(1, "cajeroA", 100.0)
+    # Cajero B en misma sucursal es independiente
+    tid_b = svc.abrir_turno(1, "cajeroB", 200.0)
+    assert tid_b > 0
+
+
+def test_get_estado_turno_abierto(svc):
+    svc.abrir_turno(1, "cajero3", 150.0)
+    estado = svc.get_estado_turno(1, "cajero3")
+    assert estado is not None
+    assert float(estado['fondo_inicial']) == 150.0
+
+
+def test_get_estado_turno_cerrado(svc):
+    estado = svc.get_estado_turno(1, "cajero_sin_turno")
+    assert estado is None
+
+
+# ── Tests: registrar movimiento ───────────────────────────────────────────────
+
+def test_registrar_ingreso(svc):
+    tid = svc.abrir_turno(1, "cajero4", 100.0)
+    svc.registrar_movimiento_manual(tid, 1, "cajero4", "INGRESO", 50.0, "Cambio extra")
+    movs = svc.get_movimientos_turno(tid)
+    assert any(m.get('tipo') == 'INGRESO' for m in movs)
+
+
+def test_registrar_retiro(svc):
+    tid = svc.abrir_turno(1, "cajero5", 300.0)
+    svc.registrar_movimiento_manual(tid, 1, "cajero5", "RETIRO", 80.0, "Pago proveedor")
+    movs = svc.get_movimientos_turno(tid)
+    assert any(m.get('tipo') == 'RETIRO' for m in movs)
+
+
+def test_movimiento_monto_invalido(svc):
+    tid = svc.abrir_turno(1, "cajero6", 100.0)
+    with pytest.raises(ValueError):
+        svc.registrar_movimiento_manual(tid, 1, "cajero6", "INGRESO", 0.0, "Sin monto")
+
+
+def test_movimiento_tipo_invalido(svc):
+    tid = svc.abrir_turno(1, "cajero7", 100.0)
+    with pytest.raises(ValueError):
+        svc.registrar_movimiento_manual(tid, 1, "cajero7", "VENTA", 50.0, "Tipo no permitido")
+
+
+# ── Tests: corte Z ────────────────────────────────────────────────────────────
+
+def test_corte_z_solo_efectivo_en_esperado(svc, db):
+    """Tarjeta y transferencia NO incrementan el efectivo esperado."""
+    tid = svc.abrir_turno(1, "cajero8", 100.0)
+    _insertar_venta(db, cajero="cajero8", total=200.0, forma_pago="Efectivo")
+    _insertar_venta(db, cajero="cajero8", total=500.0, forma_pago="Tarjeta")
+    _insertar_venta(db, cajero="cajero8", total=300.0, forma_pago="Transferencia")
+
+    # Esperado = 100 (fondo) + 200 (efectivo) + 0 (ingresos) - 0 (retiros) = 300
+    resultado = svc.generar_corte_z(tid, 1, "cajero8", 300.0)
+    assert abs(resultado['efectivo_esperado'] - 300.0) < 0.01
+
+
+def test_tarjeta_no_incrementa_efectivo_esperado(svc, db):
+    tid = svc.abrir_turno(1, "cajero_t1", 0.0)
+    _insertar_venta(db, cajero="cajero_t1", total=1000.0, forma_pago="Tarjeta")
+    resultado = svc.generar_corte_z(tid, 1, "cajero_t1", 0.0)
+    # Solo fondo (0) en efectivo esperado, tarjeta no cuenta
+    assert abs(resultado['efectivo_esperado'] - 0.0) < 0.01
+
+
+def test_transferencia_no_incrementa_efectivo_esperado(svc, db):
+    tid = svc.abrir_turno(1, "cajero_t2", 50.0)
+    _insertar_venta(db, cajero="cajero_t2", total=800.0, forma_pago="Transferencia")
+    resultado = svc.generar_corte_z(tid, 1, "cajero_t2", 50.0)
+    # Esperado = 50 (fondo solamente)
+    assert abs(resultado['efectivo_esperado'] - 50.0) < 0.01
+
+
+def test_corte_z_inserta_en_cierres_caja(svc, db):
+    """Corte Z DEBE insertar registro en cierres_caja (historial)."""
+    tid = svc.abrir_turno(1, "cajero9", 200.0)
+    svc.generar_corte_z(tid, 1, "cajero9", 200.0)
+    row = db.execute("SELECT COUNT(*) FROM cierres_caja").fetchone()
+    assert row[0] >= 1
+
+
+def test_corte_z_cierra_turno(svc, db):
+    tid = svc.abrir_turno(1, "cajero10", 100.0)
+    svc.generar_corte_z(tid, 1, "cajero10", 100.0)
+    row = db.execute("SELECT estado FROM turnos_caja WHERE id=?", (tid,)).fetchone()
+    assert row['estado'] == 'cerrado'
+
+
+def test_corte_z_calcula_diferencia_faltante(svc, db):
+    tid = svc.abrir_turno(1, "cajero11", 100.0)
+    _insertar_venta(db, cajero="cajero11", total=200.0, forma_pago="Efectivo")
+    # Esperado = 300, contado = 250 → diferencia = -50
+    resultado = svc.generar_corte_z(tid, 1, "cajero11", 250.0)
+    assert abs(resultado['diferencia'] - (-50.0)) < 0.01
+
+
+def test_corte_z_calcula_diferencia_sobrante(svc, db):
+    tid = svc.abrir_turno(1, "cajero12", 100.0)
+    _insertar_venta(db, cajero="cajero12", total=200.0, forma_pago="Efectivo")
+    # Esperado = 300, contado = 350 → diferencia = +50
+    resultado = svc.generar_corte_z(tid, 1, "cajero12", 350.0)
+    assert abs(resultado['diferencia'] - 50.0) < 0.01
+
+
+def test_corte_z_turno_no_existe(svc):
+    from application.services.caja_application_service import TurnoNoEncontradoError
+    with pytest.raises(TurnoNoEncontradoError):
+        svc.generar_corte_z(99999, 1, "nadie", 0.0)
+
+
+def test_corte_z_turno_ya_cerrado(svc, db):
+    from application.services.caja_application_service import TurnoCerradoError
+    tid = svc.abrir_turno(1, "cajero13", 100.0)
+    svc.generar_corte_z(tid, 1, "cajero13", 100.0)
+    with pytest.raises(TurnoCerradoError):
+        svc.generar_corte_z(tid, 1, "cajero13", 100.0)
+
+
+def test_corte_z_retorna_cierre_id(svc, db):
+    tid = svc.abrir_turno(1, "cajero14", 100.0)
+    resultado = svc.generar_corte_z(tid, 1, "cajero14", 100.0)
+    assert 'cierre_id' in resultado
+    assert resultado['cierre_id'] > 0
+
+
+def test_corte_z_considera_ingresos_manuales(svc, db):
+    """Ingresos manuales SÍ incrementan efectivo esperado."""
+    tid = svc.abrir_turno(1, "cajero15", 100.0)
+    svc.registrar_movimiento_manual(tid, 1, "cajero15", "INGRESO", 200.0, "Cambio extra")
+    resultado = svc.generar_corte_z(tid, 1, "cajero15", 300.0)
+    # Esperado = 100 + 0 (ventas ef) + 200 (ingreso) = 300
+    assert abs(resultado['efectivo_esperado'] - 300.0) < 0.01
+
+
+def test_corte_z_descuenta_retiros(svc, db):
+    """Retiros reducen efectivo esperado."""
+    tid = svc.abrir_turno(1, "cajero16", 500.0)
+    svc.registrar_movimiento_manual(tid, 1, "cajero16", "RETIRO", 100.0, "Pago a proveedor")
+    resultado = svc.generar_corte_z(tid, 1, "cajero16", 400.0)
+    # Esperado = 500 - 100 = 400
+    assert abs(resultado['efectivo_esperado'] - 400.0) < 0.01
+
+
+# ── Tests: historial ─────────────────────────────────────────────────────────
+
+def test_historial_devuelve_cierre_recien_creado(svc, db):
+    tid = svc.abrir_turno(1, "cajero17", 100.0)
+    resultado = svc.generar_corte_z(tid, 1, "cajero17", 100.0)
+    historial = svc.get_historial_cortes(1)
+    ids = [h.get('id') for h in historial]
+    assert resultado['cierre_id'] in ids
+
+
+def test_historial_vacio_sin_cortes(svc):
+    historial = svc.get_historial_cortes(99)  # sucursal inexistente
+    assert historial == []
+
+
+# ── Tests: eventos ────────────────────────────────────────────────────────────
+
+def test_evento_corte_z_generado(svc, db):
+    """CAJA_CORTE_Z_GENERADO debe publicarse al ejecutar corte."""
+    eventos_capturados = []
+
+    try:
+        from core.events.event_bus import get_bus, CAJA_CORTE_Z_GENERADO
+        get_bus().subscribe(
+            CAJA_CORTE_Z_GENERADO,
+            lambda p: eventos_capturados.append(p),
+            label="test_corte_z"
+        )
+    except Exception:
+        pytest.skip("EventBus no disponible")
+
+    tid = svc.abrir_turno(1, "cajero18", 100.0)
+    svc.generar_corte_z(tid, 1, "cajero18", 100.0)
+
+    assert len(eventos_capturados) >= 1
+    assert eventos_capturados[0].get('turno_id') == tid
+
+
+def test_evento_diferencia_detectada_cuando_hay_diferencia(svc, db):
+    """CAJA_DIFERENCIA_DETECTADA debe publicarse cuando diferencia != 0."""
+    eventos_capturados = []
+
+    try:
+        from core.events.event_bus import get_bus, CAJA_DIFERENCIA_DETECTADA
+        get_bus().subscribe(
+            CAJA_DIFERENCIA_DETECTADA,
+            lambda p: eventos_capturados.append(p),
+            label="test_dif"
+        )
+    except Exception:
+        pytest.skip("EventBus no disponible")
+
+    tid = svc.abrir_turno(1, "cajero19", 100.0)
+    _insertar_venta(db, cajero="cajero19", total=200.0, forma_pago="Efectivo")
+    svc.generar_corte_z(tid, 1, "cajero19", 250.0)  # diferencia = -50
+
+    assert len(eventos_capturados) >= 1
+    assert abs(eventos_capturados[0].get('diferencia', 0) + 50.0) < 0.01
+
+
+def test_no_evento_diferencia_cuando_cuadrado(svc, db):
+    """CAJA_DIFERENCIA_DETECTADA NO debe publicarse cuando caja cuadra."""
+    eventos_capturados = []
+
+    try:
+        from core.events.event_bus import get_bus, CAJA_DIFERENCIA_DETECTADA
+        get_bus().subscribe(
+            CAJA_DIFERENCIA_DETECTADA,
+            lambda p: eventos_capturados.append(p),
+            label="test_no_dif"
+        )
+    except Exception:
+        pytest.skip("EventBus no disponible")
+
+    tid = svc.abrir_turno(1, "cajero20", 100.0)
+    svc.generar_corte_z(tid, 1, "cajero20", 100.0)  # cuadrado
+
+    assert len(eventos_capturados) == 0
+
+
+# ── Tests: UI no contiene self.container.db.execute ──────────────────────────
+
+def test_ui_no_contiene_db_execute_directo():
+    """Verifica que modulos/caja.py no tenga SQL directo."""
+    import ast
+    caja_path = os.path.join(os.path.dirname(__file__), "..", "modulos", "caja.py")
+    with open(caja_path, "r") as f:
+        source = f.read()
+
+    # Buscar patrones de acceso directo a DB en la UI
+    patrones_prohibidos = [
+        "self.container.db.execute",
+        "container.db.execute(",
+    ]
+    for patron in patrones_prohibidos:
+        assert patron not in source, (
+            f"modulos/caja.py contiene SQL directo: '{patron}'. "
+            "Debe delegarse a caja_service."
+        )
+
+
+def test_caja_py_sintaxis_valida():
+    """modulos/caja.py debe tener sintaxis Python válida."""
+    import ast
+    caja_path = os.path.join(os.path.dirname(__file__), "..", "modulos", "caja.py")
+    with open(caja_path, "r") as f:
+        source = f.read()
+    ast.parse(source)  # raises SyntaxError si hay problema


### PR DESCRIPTION
## Summary

Refactors the caja (cash register) module to follow clean architecture principles by extracting business logic from the PyQt5 UI layer into a dedicated `CajaApplicationService`. This addresses critical bugs in the corte Z (cash closing) workflow and establishes a canonical service layer for all cash operations.

## Key Changes

### New Files
- **`application/services/caja_application_service.py`** (521 lines)
  - Canonical service for all caja operations: turno (shift) management, manual movements, corte Z
  - Implements proper separation of concerns: UI → Application → Infrastructure
  - Publishes domain events (CAJA_TURNO_ABIERTO, CAJA_MOVIMIENTO, CAJA_CORTE_Z_GENERADO)
  - Fixes critical bug: corte Z now only counts EFECTIVO (cash) sales, not tarjeta/transferencia
  - Inserts corte results into `cierres_caja` table for audit trail (was missing)
  - Includes proper error handling and logging

- **`core/services/caja_ticket_service.py`** (254 lines)
  - Extracts ticket/PDF generation logic from UI
  - Generates HTML and ESC/POS for thermal printer
  - Saves PDF cortes to disk with proper naming

- **`tests/test_caja.py`** (396 lines)
  - Comprehensive regression test suite covering:
    - Turno (shift) opening/closing
    - Manual movements (INGRESO/RETIRO)
    - Corte Z calculations with only cash sales
    - Event publishing
    - Historial (audit trail)

- **`docs/refactor/caja_auditoria_real.md`** (207 lines)
  - Detailed audit of current caja implementation
  - Maps all duplicated services (finance_service vs cierre_caja_service)
  - Documents 5 critical bugs in current corte Z flow
  - Provides migration path to canonical service

### Modified Files

#### `modulos/caja.py` (1,188 lines)
- **Removed unused imports:** Eliminated 15+ unused PyQt5 widgets (QDialogButtonBox, QListWidget, QCompleter, QMenu, QAction, QToolBar, QStatusBar, QProgressBar, QSlider, QDial, QCalendarWidget, QColorDialog, QFontDialog, QFileDialog, QErrorMessage, QProgressDialog, QSplashScreen, QSystemTrayIcon, QStyleFactory, QSizePolicy)
- **Fixed scope bug in DialogoCorteZCiego._ejecutar_corte():**
  - Variable `nav` was undefined (line 298) → now uses `self._nav` stored in `_build()`
  - Allows dynamic button replacement after corte execution
- **Improved service integration:**
  - Added fallback logic to use `caja_service` (new) or `finance_service` (legacy)
  - Passes observations (`obs`) to new service
  - Corrected field mapping: `efectivo_esperado` vs `esperado`
- **Fixed corte Z calculation:**
  - Now correctly retrieves only cash sales (not tarjeta/transferencia)
  - Proper field ordering in result dictionary
- **Refactored KPI bar (_crear_caja_kpi_bar):**
  - Replaced hardcoded SQL with `caja_service.get_caja_kpis()` call
  - Removed direct database access from UI
  - Cleaner variable naming (removed single-letter aliases)
- **Code cleanup:**
  - Removed decorative ASCII comments
  - Improved error logging with structured logging
  - Better spacing and formatting

#### `core/app_container.py`
- Added import and registration of `CajaRepository`
- Prepares container for dependency injection of caja services

#### `core/events/event_bus.py`
- Added new domain events:
  - `CAJA_TURNO_ABIERTO` — shift opened
  - `CAJA_MOVIMIENTO` — manual

https://claude.ai/code/session_011F9BSNv3RgvYVNyLKNgeh9