### PR TITLE
Inventario y productos: KPIs, nuevas pestañas, mejoras en recetas y mensajes de error

### DIFF
--- a/pos_spj_v13.4/core/services/inventory_query_service.py
+++ b/pos_spj_v13.4/core/services/inventory_query_service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+
+def get_recent_movements(db, branch_id: int, limit: int = 200):
+    try:
+        rows = db.execute(
+            "SELECT im.created_at, p.nombre, im.movement_type, im.quantity, im.branch_id, "
+            "COALESCE(im.reference,''), COALESCE(im.usuario,''), COALESCE(im.origin,'') "
+            "FROM inventory_movements im JOIN productos p ON p.id=im.product_id "
+            "WHERE im.branch_id=? ORDER BY im.created_at DESC LIMIT ?",
+            [branch_id, int(limit)]
+        ).fetchall()
+        return rows
+    except Exception:
+        return []
+
+
+def get_inventory_operational_kpis(db, branch_id: int, prod_data: list[dict]) -> dict:
+    stock_bajo = sum(1 for p in prod_data if p.get("health") == "BAJO MÍN.")
+    sin_stock = sum(1 for p in prod_data if p.get("health") == "SIN STOCK")
+    virtual_disponible = 0  # fallback seguro hasta backend de virtual
+    reservados = 0          # fallback seguro hasta backend de reservas
+    mov_hoy = 0
+    try:
+        r = db.execute(
+            "SELECT COUNT(*) FROM inventory_movements WHERE branch_id=? AND DATE(created_at)=DATE('now')",
+            [branch_id]
+        ).fetchone()
+        mov_hoy = int((r[0] if r else 0) or 0)
+    except Exception:
+        mov_hoy = 0
+    return {
+        "stock_bajo": stock_bajo,
+        "sin_stock_fisico": sin_stock,
+        "virtual_disponible": virtual_disponible,
+        "reservados": reservados,
+        "mov_hoy": mov_hoy,
+    }

--- a/pos_spj_v13.4/core/services/product_catalog_query_service.py
+++ b/pos_spj_v13.4/core/services/product_catalog_query_service.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Set
+
+
+def _scalar(db, query: str, params=()) -> int:
+    row = db.execute(query, params).fetchone()
+    if not row:
+        return 0
+    return int(row[0] or 0)
+
+
+def get_product_configuration_kpis(db) -> Dict[str, int]:
+    """KPIs de configuración de catálogo (sin métricas de inventario)."""
+    activos = _scalar(db, "SELECT COUNT(*) FROM productos WHERE COALESCE(activo,1)=1")
+    sin_tipo = _scalar(
+        db,
+        "SELECT COUNT(*) FROM productos WHERE COALESCE(activo,1)=1 "
+        "AND (tipo_producto IS NULL OR TRIM(tipo_producto)='')"
+    )
+    receta_pendiente = _scalar(
+        db,
+        "SELECT COUNT(*) FROM productos p "
+        "WHERE COALESCE(p.activo,1)=1 "
+        "AND LOWER(COALESCE(p.tipo_producto,'')) IN ('compuesto','procesable','producido') "
+        "AND NOT EXISTS (SELECT 1 FROM product_recipes r WHERE r.base_product_id=p.id AND COALESCE(r.is_active,1)=1)"
+    )
+    sin_costo = _scalar(
+        db,
+        "SELECT COUNT(*) FROM productos WHERE COALESCE(activo,1)=1 "
+        "AND COALESCE(precio_compra,0)<=0"
+    )
+    inactivos = _scalar(db, "SELECT COUNT(*) FROM productos WHERE COALESCE(activo,1)=0")
+    return {
+        "activos": activos,
+        "sin_tipo": sin_tipo,
+        "receta_pendiente": receta_pendiente,
+        "sin_costo": sin_costo,
+        "inactivos": inactivos,
+    }
+
+
+def get_catalog_filter_ids(db, filter_key: str) -> Set[int]:
+    queries = {
+        "sin_tipo": (
+            "SELECT id FROM productos WHERE COALESCE(activo,1)=1 "
+            "AND (tipo_producto IS NULL OR TRIM(tipo_producto)='')"
+        ),
+        "receta_pendiente": (
+            "SELECT p.id FROM productos p "
+            "WHERE COALESCE(p.activo,1)=1 "
+            "AND LOWER(COALESCE(p.tipo_producto,'')) IN ('compuesto','procesable','producido') "
+            "AND NOT EXISTS (SELECT 1 FROM product_recipes r WHERE r.base_product_id=p.id AND COALESCE(r.is_active,1)=1)"
+        ),
+        "sin_costo": (
+            "SELECT id FROM productos WHERE COALESCE(activo,1)=1 "
+            "AND COALESCE(precio_compra,0)<=0"
+        ),
+    }
+    q = queries.get(filter_key)
+    if not q:
+        return set()
+    rows = db.execute(q).fetchall()
+    out: Set[int] = set()
+    for r in rows:
+        out.add(int((r["id"] if hasattr(r, "keys") else r[0]) or 0))
+    return out

--- a/pos_spj_v13.4/modulos/dialogs/receta_dialog.py
+++ b/pos_spj_v13.4/modulos/dialogs/receta_dialog.py
@@ -369,13 +369,34 @@ class DialogoReceta(QDialog):
             QMessageBox.warning(self, "Auto-referencia",
                                 "Un componente no puede ser el mismo producto base.")
         except RecetaPercentageError as exc:
-            QMessageBox.warning(self, "Error de Porcentaje", str(exc))
+            QMessageBox.warning(self, "Validación de receta", self._to_business_recipe_error(exc))
         except RecetaDuplicadaError:
             QMessageBox.warning(self, "Receta Duplicada",
                                 "Ya existe una receta activa para este producto base.\n"
                                 "Cierre este diálogo y use el botón «Editar» sobre la receta existente.")
         except RecetaError as exc:
-            QMessageBox.warning(self, "Error en Receta", str(exc))
+            QMessageBox.warning(self, "Error en receta", self._to_business_recipe_error(exc))
         except Exception as exc:
             logger.exception("guardar_receta")
-            QMessageBox.critical(self, "Error Inesperado", str(exc))
+            QMessageBox.critical(
+                self, "Error inesperado",
+                "No se pudo guardar la receta en este momento. Intente nuevamente."
+            )
+    @staticmethod
+    def _to_business_recipe_error(exc: Exception) -> str:
+        raw = str(exc or "").upper()
+        if "TIPO_RECETA" in raw and "COMPUESTO" in raw:
+            return "Este producto debe ser COMPUESTO para tener receta de combinación."
+        if "TIPO_RECETA" in raw and "PROCESABLE" in raw:
+            return "Este producto debe ser PROCESABLE para tener receta de despiece."
+        if "TIPO_RECETA" in raw and "PRODUCIDO" in raw:
+            return "Este producto debe ser PRODUCIDO para tener receta de producción."
+        if "COMPONENT_PRODUCT_ID" in raw or "COMPONENT_NOT_FOUND" in raw:
+            return "Falta seleccionar un componente válido para la receta."
+        if "CANTIDAD_DEBE_SER_POSITIVA" in raw:
+            return "La cantidad del componente debe ser mayor a cero."
+        if "TOTAL_RENDIMIENTO_MUST_BE_100" in raw:
+            return "En recetas de despiece, rendimiento + merma debe sumar 100%."
+        if "TOTAL_RENDIMIENTO_EXCEEDS_100" in raw or "COMPONENT_EXCEEDS_100" in raw:
+            return "Los porcentajes de rendimiento y merma no pueden superar 100%."
+        return "No se pudo guardar la receta. Revise los datos ingresados."

--- a/pos_spj_v13.4/modulos/inventario_local.py
+++ b/pos_spj_v13.4/modulos/inventario_local.py
@@ -20,7 +20,7 @@ from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QFrame,
     QTableWidget, QTableWidgetItem, QHeaderView, QAbstractItemView,
     QMessageBox, QDialog, QDialogButtonBox, QComboBox, QDoubleSpinBox,
-    QTextEdit, QLineEdit, QScrollArea, QSizePolicy, QFileDialog, QSplitter,
+    QTextEdit, QLineEdit, QScrollArea, QSizePolicy, QFileDialog, QSplitter, QTabWidget,
 )
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QColor
@@ -31,12 +31,23 @@ from modulos.ui_components import (
 )
 from modulos.spj_refresh_mixin import RefreshMixin
 from modulos.kpi_card import KPICard
+from core.services.inventory_query_service import get_recent_movements, get_inventory_operational_kpis
 from core.events.event_bus import (
     VENTA_COMPLETADA, PRODUCTO_ACTUALIZADO, PRODUCTO_CREADO,
     AJUSTE_INVENTARIO, COMPRA_REGISTRADA,
 )
 
 logger = logging.getLogger("spj.inventario")
+
+
+def _to_business_inventory_error(exc: Exception) -> str:
+    msg = str(exc or "")
+    up = msg.upper()
+    if "INSUFICIENTE" in up or "STOCK" in up:
+        return "No hay stock suficiente para completar la operación."
+    if "PERMISO" in up or "DENIED" in up:
+        return "No tiene permisos para ejecutar esta acción en inventario."
+    return "No se pudo completar la operación de inventario. Verifique los datos e intente de nuevo."
 
 # ── Semantic stock health ─────────────────────────────────────────────────────
 
@@ -717,14 +728,14 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
         self._loading.hide()
         body_lyt.addWidget(self._loading)
 
-        # Workspace: table + insights
+        # Workspace: tabs + insights
         workspace = QHBoxLayout()
         workspace.setSpacing(Spacing.MD)
 
-        # Left: table
+        # Left: tabs
         table_col = QVBoxLayout()
         table_col.setSpacing(Spacing.SM)
-        table_col.addWidget(self._build_table())
+        table_col.addWidget(self._build_inventory_tabs())
         self._empty_state = EmptyStateWidget(
             "Sin productos",
             "No se encontraron productos para los filtros aplicados.",
@@ -754,17 +765,126 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
         lyt.setContentsMargins(0, 0, 0, 0)
         lyt.setSpacing(Spacing.MD)
 
-        self._kpi_total   = _InvKPICard("Total productos",    "—", "📦", "primary")
-        self._kpi_valor   = _InvKPICard("Valor en stock",     "—", "💰", "success")
-        self._kpi_critico = _InvKPICard("Sin stock",          "—", "🚨", "danger")
-        self._kpi_bajo    = _InvKPICard("Bajo mínimo",        "—", "⚠️",  "warning")
-        self._kpi_ajustes = _InvKPICard("Ajustes hoy",        "—", "⚖️",  "info")
-
-        for card in (self._kpi_total, self._kpi_valor, self._kpi_critico,
-                     self._kpi_bajo, self._kpi_ajustes):
-            lyt.addWidget(card)
+        self._kpi_click_mode = "none"
+        self._kpi_bajo    = _InvKPICard("Stock bajo",             "—", "⚠️", "warning")
+        self._kpi_sin     = _InvKPICard("Sin stock físico",       "—", "🚨", "danger")
+        self._kpi_virtual = _InvKPICard("Virtual disponible",     "—", "🧩", "info")
+        self._kpi_res     = _InvKPICard("Reservados",             "—", "🔒", "primary")
+        self._kpi_mov     = _InvKPICard("Movimientos hoy",        "—", "📋", "success")
+        for key, card in (
+            ("stock_bajo", self._kpi_bajo),
+            ("sin_stock_fisico", self._kpi_sin),
+            ("virtual_disponible", self._kpi_virtual),
+            ("reservados", self._kpi_res),
+            ("mov_hoy", self._kpi_mov),
+        ):
+            btn = QPushButton()
+            btn.setFlat(True)
+            btn.clicked.connect(lambda _, k=key: self._on_kpi_click(k))
+            bl = QHBoxLayout(btn); bl.setContentsMargins(0, 0, 0, 0); bl.addWidget(card)
+            lyt.addWidget(btn)
 
         return container
+
+    def _build_inventory_tabs(self) -> QTabWidget:
+        self._tabs_inv = QTabWidget(self)
+        self._tab_exist = QWidget()
+        self._tab_disp = QWidget()
+        self._tab_virtual = QWidget()
+        self._tab_mov = QWidget()
+        self._tab_res = QWidget()
+        self._tab_aj = QWidget()
+        self._tab_aud = QWidget()
+
+        self._tabs_inv.addTab(self._tab_exist, "Existencias")
+        self._tabs_inv.addTab(self._tab_disp, "Disponibilidad")
+        self._tabs_inv.addTab(self._tab_virtual, "Stock virtual")
+        self._tabs_inv.addTab(self._tab_mov, "Movimientos")
+        self._tabs_inv.addTab(self._tab_res, "Reservas")
+        self._tabs_inv.addTab(self._tab_aj, "Ajustes")
+        self._tabs_inv.addTab(self._tab_aud, "Auditoría")
+
+        le = QVBoxLayout(self._tab_exist)
+        le.setContentsMargins(0, 0, 0, 0)
+        le.addWidget(self._build_table())
+
+        ld = QVBoxLayout(self._tab_disp)
+        ld.setContentsMargins(0, 0, 0, 0)
+        ld.addWidget(self._build_disponibilidad_table())
+
+        lv = QVBoxLayout(self._tab_virtual)
+        lv.setContentsMargins(0, 0, 0, 0)
+        lv.addWidget(self._build_virtual_table())
+
+        lm = QVBoxLayout(self._tab_mov)
+        lm.setContentsMargins(0, 0, 0, 0)
+        lm.addWidget(self._build_movimientos_table())
+
+        lr = QVBoxLayout(self._tab_res)
+        lbl_res = QLabel("Reservas: vista en preparación (sin mezclar físico y virtual).")
+        lbl_res.setObjectName("caption")
+        lr.addWidget(lbl_res)
+
+        la = QVBoxLayout(self._tab_aj)
+        lbl_aj = QLabel("Ajustes: use el botón ⚖ Ajuste para registrar movimientos auditados.")
+        lbl_aj.setObjectName("caption")
+        la.addWidget(lbl_aj)
+
+        lau = QVBoxLayout(self._tab_aud)
+        lbl_aud = QLabel("Auditoría: use 📋 Historial para revisar trazabilidad por producto.")
+        lbl_aud.setObjectName("caption")
+        lau.addWidget(lbl_aud)
+
+        return self._tabs_inv
+
+    def _build_disponibilidad_table(self) -> QTableWidget:
+        self.tabla_disponibilidad = QTableWidget(self)
+        self.tabla_disponibilidad.setColumnCount(7)
+        self.tabla_disponibilidad.setHorizontalHeaderLabels([
+            "Producto", "Stock físico", "Reservado", "Disponible físico",
+            "Disponible virtual", "Disponible venta", "Modo"
+        ])
+        self.tabla_disponibilidad.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.tabla_disponibilidad.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.tabla_disponibilidad.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.tabla_disponibilidad.verticalHeader().setVisible(False)
+        self.tabla_disponibilidad.setObjectName("tableView")
+        return self.tabla_disponibilidad
+
+    def _build_virtual_table(self) -> QTableWidget:
+        self.tabla_virtual = QTableWidget(self)
+        self.tabla_virtual.setColumnCount(8)
+        self.tabla_virtual.setHorizontalHeaderLabels([
+            "Producto vendible", "Stock físico", "Disponible virtual", "Receta usada",
+            "Componentes requeridos", "Máx vendible", "Componente limitante", "Sucursal"
+        ])
+        self.tabla_virtual.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.tabla_virtual.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.tabla_virtual.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.tabla_virtual.verticalHeader().setVisible(False)
+        self.tabla_virtual.setObjectName("tableView")
+        return self.tabla_virtual
+
+    def _build_movimientos_table(self) -> QTableWidget:
+        self.tabla_movimientos = QTableWidget(self)
+        self.tabla_movimientos.setColumnCount(8)
+        self.tabla_movimientos.setHorizontalHeaderLabels([
+            "Fecha", "Producto", "Tipo movimiento", "Cantidad", "Sucursal", "Referencia", "Usuario", "Origen"
+        ])
+        hh = self.tabla_movimientos.horizontalHeader()
+        hh.setSectionResizeMode(0, QHeaderView.ResizeToContents)
+        hh.setSectionResizeMode(1, QHeaderView.Stretch)
+        hh.setSectionResizeMode(2, QHeaderView.ResizeToContents)
+        hh.setSectionResizeMode(3, QHeaderView.ResizeToContents)
+        hh.setSectionResizeMode(4, QHeaderView.ResizeToContents)
+        hh.setSectionResizeMode(5, QHeaderView.ResizeToContents)
+        hh.setSectionResizeMode(6, QHeaderView.ResizeToContents)
+        hh.setSectionResizeMode(7, QHeaderView.ResizeToContents)
+        self.tabla_movimientos.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.tabla_movimientos.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.tabla_movimientos.verticalHeader().setVisible(False)
+        self.tabla_movimientos.setObjectName("tableView")
+        return self.tabla_movimientos
 
     def _build_action_bar(self) -> QWidget:
         bar = QFrame(self)
@@ -922,6 +1042,8 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
             pass
 
         self.tabla.setRowCount(0)
+        self.tabla_disponibilidad.setRowCount(0)
+        self.tabla_virtual.setRowCount(0)
 
         for i, r in enumerate(rows):
             prod_id  = int(r[0])
@@ -975,6 +1097,18 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
 
             # Col 6: Último movimiento
             self.tabla.setItem(i, 6, QTableWidgetItem(last_mov))
+            reservado = 0.0
+            disp_fis = stock - reservado
+            modo = "DIRECTO" if disp_fis > 0 else "NO DISPONIBLE"
+            self.tabla_disponibilidad.insertRow(i)
+            for j, v in enumerate([nombre, f"{stock:.3f}", f"{reservado:.3f}", f"{disp_fis:.3f}", "0.000", f"{disp_fis:.3f}", modo]):
+                self.tabla_disponibilidad.setItem(i, j, QTableWidgetItem(v))
+
+        self.tabla_virtual.setRowCount(1)
+        self.tabla_virtual.setItem(0, 0, QTableWidgetItem("Stock virtual no calculado todavía."))
+        for c in range(1, 8):
+            self.tabla_virtual.setItem(0, c, QTableWidgetItem("—"))
+        self._cargar_movimientos_tab()
 
         count = len(rows)
         self.lbl_total.setText(
@@ -995,45 +1129,32 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
             except Exception:
                 pass
 
+    def _cargar_movimientos_tab(self) -> None:
+        self.tabla_movimientos.setRowCount(0)
+        rows = get_recent_movements(self.container.db, self.sucursal_id, limit=200)
+        for i, r in enumerate(rows):
+            self.tabla_movimientos.insertRow(i)
+            for j, v in enumerate(r):
+                self.tabla_movimientos.setItem(i, j, QTableWidgetItem(str(v or "")))
+
     def _refresh_kpis(self, db) -> None:
-        try:
-            r = db.execute(
-                "SELECT COUNT(*), COUNT(DISTINCT categoria) FROM productos WHERE activo=1"
-            ).fetchone()
-            self._kpi_total.set_valor(str(r[0] or 0))
-        except Exception:
-            pass
+        data = get_inventory_operational_kpis(db, self.sucursal_id, self._prod_data)
+        self._kpi_bajo.set_valor(str(data.get("stock_bajo", 0)))
+        self._kpi_sin.set_valor(str(data.get("sin_stock_fisico", 0)))
+        self._kpi_virtual.set_valor(str(data.get("virtual_disponible", 0)))
+        self._kpi_res.set_valor(str(data.get("reservados", 0)))
+        self._kpi_mov.set_valor(str(data.get("mov_hoy", 0)))
 
-        try:
-            r2 = db.execute(
-                "SELECT COALESCE(SUM(existencia*precio),0) FROM productos WHERE activo=1"
-            ).fetchone()
-            val = float(r2[0] or 0)
-            self._kpi_valor.set_valor(f"${val:,.0f}")
-        except Exception:
-            pass
-
-        self._kpi_critico.set_valor(
-            str(sum(1 for p in self._prod_data if p["health"] == _HEALTH_CRITICAL))
-        )
-        self._kpi_bajo.set_valor(
-            str(sum(1 for p in self._prod_data if p["health"] == _HEALTH_LOW))
-        )
-
-        try:
-            r4 = db.execute(
-                "SELECT COUNT(*) FROM ajustes_inventario WHERE DATE(created_at)=DATE('now')"
-            ).fetchone()
-            self._kpi_ajustes.set_valor(str(r4[0] or 0))
-        except Exception:
-            try:
-                r4b = db.execute(
-                    "SELECT COUNT(*) FROM inventory_movements "
-                    "WHERE movement_type='AJUSTE' AND DATE(created_at)=DATE('now')"
-                ).fetchone()
-                self._kpi_ajustes.set_valor(str(r4b[0] or 0))
-            except Exception:
-                pass
+    def _on_kpi_click(self, key: str) -> None:
+        self._kpi_click_mode = key
+        if key == "virtual_disponible":
+            self._tabs_inv.setCurrentWidget(self._tab_virtual)
+            return
+        if key == "mov_hoy":
+            self._tabs_inv.setCurrentWidget(self._tab_mov)
+            return
+        self._tabs_inv.setCurrentWidget(self._tab_exist)
+        self._apply_filters()
 
     def _populate_categories(self) -> None:
         current = self._cmb_cat.currentText()
@@ -1073,7 +1194,12 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
             match_c = (cat_sel == "Todas las categorías") or (cat == cat_sel.lower())
             match_e = (health_filter is None) or (estado == health_filter)
 
-            self.tabla.setRowHidden(row, not (match_q and match_c and match_e))
+            match_kpi = True
+            if getattr(self, "_kpi_click_mode", "none") == "stock_bajo":
+                match_kpi = (estado == _HEALTH_LOW)
+            elif getattr(self, "_kpi_click_mode", "none") == "sin_stock_fisico":
+                match_kpi = (estado == _HEALTH_CRITICAL)
+            self.tabla.setRowHidden(row, not (match_q and match_c and match_e and match_kpi))
 
     # ── Operational actions ───────────────────────────────────────────────────
 
@@ -1129,7 +1255,8 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
             )
             self.cargar_datos()
         except Exception as e:
-            QMessageBox.critical(self, "Error en entrada", str(e))
+            logger.exception("inventario.entrada")
+            QMessageBox.critical(self, "Error en entrada", _to_business_inventory_error(e))
 
     def _accion_ajuste(self) -> None:
         """Audited inventory adjustment — requires reason + observation."""
@@ -1174,7 +1301,8 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
             )
             self.cargar_datos()
         except Exception as e:
-            QMessageBox.critical(self, "Error en ajuste", str(e))
+            logger.exception("inventario.ajuste")
+            QMessageBox.critical(self, "Error en ajuste", _to_business_inventory_error(e))
 
     def _accion_historial(self) -> None:
         """Open read-only movement audit trail for selected product."""

--- a/pos_spj_v13.4/modulos/produccion.py
+++ b/pos_spj_v13.4/modulos/produccion.py
@@ -20,6 +20,7 @@ from modulos.ui_components import (
     create_primary_button, create_success_button, create_danger_button,
     FilterBar, LoadingIndicator, EmptyStateWidget
 )
+from modulos.kpi_card import KPICard
 
 import logging
 from typing import Dict, List, Optional
@@ -193,74 +194,26 @@ class ModuloProduccion(ModuloBase):
         Sigue el estándar visual de finanzas_unificadas._crear_fin_kpi_bar.
         Sin hardcodeo: usa Colors.NEUTRAL tokens.
         """
-        from PyQt5.QtWidgets import QFrame as _F, QHBoxLayout as _H, QVBoxLayout as _V, QLabel as _L
-
-        N = Colors.NEUTRAL
-        bar = _F()
-        bar.setObjectName("prodStatsBar")
-        bar.setFixedHeight(68)
-        bar.setStyleSheet(
-            f"QFrame#prodStatsBar {{ "
-            f"background:{N.DARK_CARD}; "
-            f"border-radius:8px; "
-            f"border:1px solid {N.DARK_BORDER}; }}"
-        )
-
-        lay = _H(bar)
-        lay.setContentsMargins(Spacing.LG, Spacing.SM, Spacing.LG, Spacing.SM)
-        lay.setSpacing(0)
-
-        # Definición inicial de KPIs (valores placeholder)
-        kpis = [
-            ("producciones_hoy", "Producciones hoy", "—",    Colors.PRIMARY_BASE),
-            ("kg_procesados",    "Kg procesados",    "—",    Colors.SUCCESS_BASE),
-            ("merma_dia",        "Merma del día",    "—",    Colors.WARNING_BASE),
-            ("rendimiento",      "Rendimiento",      "—",    Colors.SUCCESS_BASE),
-            ("lotes_activos",    "Lotes activos",    "—",    Colors.INFO_BASE),
-        ]
-
-        # Guardar referencias a los QLabel de valor para actualizaciones en vivo
-        self._stats_lbl_vals: dict = {}
-
-        for i, (key, label, valor, color) in enumerate(kpis):
-            if i > 0:
-                sep = _F()
-                sep.setFrameShape(_F.VLine)
-                sep.setFixedWidth(1)
-                sep.setStyleSheet(f"background:{N.SLATE_700}; border:none;")
-                lay.addWidget(sep)
-                lay.addSpacing(Spacing.LG)
-
-            col = _V()
-            col.setSpacing(2)
-
-            lbl_v = _L(valor)
-            lbl_v.setStyleSheet(
-                f"color:{color}; font-size:18px; font-weight:700; background:transparent;"
-            )
-            lbl_l = _L(label.upper())
-            lbl_l.setStyleSheet(
-                f"color:{N.SLATE_500}; font-size:9px; font-weight:700; "
-                f"letter-spacing:0.5px; background:transparent;"
-            )
-
-            self._stats_lbl_vals[key] = (lbl_v, color)  # (label_widget, color_ok)
-            col.addWidget(lbl_v)
-            col.addWidget(lbl_l)
-            lay.addLayout(col)
-
-            if i < len(kpis) - 1:
-                lay.addSpacing(Spacing.LG)
-
-        lay.addStretch()
-
-        # Cargar valores reales en diferido para no bloquear arranque
+        from PyQt5.QtWidgets import QWidget, QHBoxLayout
+        bar = QWidget()
+        lay = QHBoxLayout(bar)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.setSpacing(Spacing.MD)
+        self._stats_cards = {
+            "producciones_hoy": KPICard("Producciones hoy", "—", "🏭", "primary"),
+            "kg_procesados": KPICard("Kg procesados", "—", "⚖️", "success"),
+            "merma_dia": KPICard("Merma del día", "—", "🧪", "warning"),
+            "rendimiento": KPICard("Rendimiento", "—", "📈", "success"),
+            "lotes_activos": KPICard("Lotes activos", "—", "🧾", "info"),
+        }
+        for card in self._stats_cards.values():
+            lay.addWidget(card)
         QTimer.singleShot(50, self._actualizar_stats_bar)
         return bar
 
     def _actualizar_stats_bar(self) -> None:
         """Actualiza los QLabels de la stats bar con datos del servicio de query."""
-        if not hasattr(self, '_stats_lbl_vals'):
+        if not hasattr(self, '_stats_cards'):
             return
 
         db = self.conexion
@@ -274,36 +227,11 @@ class ModuloProduccion(ModuloBase):
         merma = vals.get("merma_dia", 0)
         rend  = vals.get("rendimiento", 0.0)
 
-        formatos = {
-            "producciones_hoy": (
-                str(vals.get("producciones_hoy", 0)),
-                Colors.PRIMARY_BASE,
-            ),
-            "kg_procesados": (
-                f"{kg_p:.1f} kg",
-                Colors.SUCCESS_BASE,
-            ),
-            "merma_dia": (
-                f"{merma:.1f} kg",
-                Colors.DANGER_BASE if merma > 0 else Colors.SUCCESS_BASE,
-            ),
-            "rendimiento": (
-                f"{rend:.1f}%",
-                Colors.SUCCESS_BASE if rend >= 90 else Colors.WARNING_BASE,
-            ),
-            "lotes_activos": (
-                str(vals.get("lotes_activos", 0)),
-                Colors.INFO_BASE,
-            ),
-        }
-
-        for key, (lbl_w, _default_color) in self._stats_lbl_vals.items():
-            if key in formatos:
-                texto, color = formatos[key]
-                lbl_w.setText(texto)
-                lbl_w.setStyleSheet(
-                    f"color:{color}; font-size:18px; font-weight:700; background:transparent;"
-                )
+        self._stats_cards["producciones_hoy"].set_valor(str(vals.get("producciones_hoy", 0)))
+        self._stats_cards["kg_procesados"].set_valor(f"{kg_p:.1f} kg")
+        self._stats_cards["merma_dia"].set_valor(f"{merma:.1f} kg")
+        self._stats_cards["rendimiento"].set_valor(f"{rend:.1f}%")
+        self._stats_cards["lotes_activos"].set_valor(str(vals.get("lotes_activos", 0)))
 
     # ── TAB: Ejecutar Producción ──────────────────────────────────────────────
 
@@ -324,6 +252,9 @@ class ModuloProduccion(ModuloBase):
         self._combo_receta = QComboBox()
         self._combo_receta.currentIndexChanged.connect(self._on_receta_changed)
         fl.addWidget(self._combo_receta)
+        lbl_migracion = QLabel("Las recetas ahora se administran desde Productos > Receta.")
+        lbl_migracion.setObjectName("caption")
+        fl.addWidget(lbl_migracion)
 
         # Info receta
         self._lbl_tipo = QLabel()

--- a/pos_spj_v13.4/modulos/productos.py
+++ b/pos_spj_v13.4/modulos/productos.py
@@ -29,6 +29,8 @@ from PyQt5.QtGui import QFont, QPixmap
 import logging
 from modulos.dialogs.receta_dialog import DialogoReceta
 from core.services.recipes.recipe_service import RecipeService
+from modulos.kpi_card import KPICard
+from core.services.product_catalog_query_service import get_product_configuration_kpis, get_catalog_filter_ids
 
 logger = logging.getLogger(__name__)
 
@@ -70,22 +72,24 @@ class DialogoProducto(QDialog):
     def init_ui(self):
         layout_principal = QVBoxLayout(self)
         
-        # --- TABS DEL FORMULARIO ---
+        # --- TABS DEL FORMULARIO (FASE 1: producto como configuración) ---
         tabs = QTabWidget()
         tab_general = QWidget()
-        self.tab_compuesto = QWidget() # Se oculta/muestra según el tipo
-        
-        tabs.addTab(tab_general, "Datos Generales")
-        tabs.addTab(self.tab_compuesto, "Componentes (Si es Compuesto)")
-        
-        # ================= TAB GENERAL =================
-        layout_general = QHBoxLayout(tab_general)
-        
-        # Columna Izquierda: Formulario
-        form_layout = QFormLayout()
+        tab_config = QWidget()
+        tab_precios = QWidget()
+        tab_receta = QWidget()
+        tab_referencias = QWidget()
+
+        tabs.addTab(tab_general, "General")
+        tabs.addTab(tab_config, "Configuración")
+        tabs.addTab(tab_precios, "Precios / Costos base")
+        tabs.addTab(tab_receta, "Receta")
+        tabs.addTab(tab_referencias, "Referencias")
+
+        # ================= CAMPOS BASE =================
         
         self.cmb_tipo = QComboBox()
-        self.cmb_tipo.addItems(["Simple", "Compuesto", "Subproducto"])
+        self.cmb_tipo.addItems(["Simple", "Compuesto", "Procesable", "Subproducto", "Producido", "Insumo", "Servicio"])
         self.cmb_tipo.currentTextChanged.connect(self.al_cambiar_tipo)
         
         self.txt_nombre = QLineEdit()
@@ -96,6 +100,13 @@ class DialogoProducto(QDialog):
         self.cmb_categoria.setEditable(True)
         self.cargar_categorias()
         
+        self.cmb_estado = QComboBox()
+        self.cmb_estado.addItems(["Activo", "Inactivo"])
+
+        self.cmb_unidad_venta = QComboBox()
+        self.cmb_unidad_venta.addItems(["kg", "pza", "litro", "paquete", "caja"])
+        self.cmb_unidad_compra = QComboBox()
+        self.cmb_unidad_compra.addItems(["kg", "pza", "litro", "paquete", "caja"])
         self.txt_precio = QDoubleSpinBox()
         self.txt_precio.setRange(0.0, 999999.0)
         self.txt_precio.setPrefix("$ ")
@@ -104,19 +115,11 @@ class DialogoProducto(QDialog):
         self.txt_costo.setRange(0.0, 999999.0)
         self.txt_costo.setPrefix("$ ")
         
-        self.cmb_unidad = QComboBox()
+        self.cmb_unidad = QComboBox()  # unidad base / inventario
         self.cmb_unidad.addItems(["kg", "pza", "litro", "paquete", "caja"])
         
         self.txt_stock_minimo = QDoubleSpinBox()
         self.txt_stock_minimo.setRange(0.0, 99999.0)
-        
-        form_layout.addRow("Tipo de Producto:", self.cmb_tipo)
-        form_layout.addRow("Nombre:*", self.txt_nombre)
-        form_layout.addRow("Código Interno:", self.txt_codigo)
-        form_layout.addRow("Código de Barras:", self.txt_codigo_barras)
-        form_layout.addRow("Categoría:", self.cmb_categoria)
-        form_layout.addRow("Precio de Venta:*", self.txt_precio)
-        form_layout.addRow("Costo de Compra:", self.txt_costo)
 
         # Precio mínimo (protección financiera)
         self.txt_precio_minimo = QDoubleSpinBox()
@@ -124,11 +127,20 @@ class DialogoProducto(QDialog):
         self.txt_precio_minimo.setDecimals(2)
         self.txt_precio_minimo.setPrefix("$")
         self.txt_precio_minimo.setToolTip("Precio mínimo de venta. Por debajo de este precio el sistema bloquea el descuento.")
-        form_layout.addRow("Precio mínimo:", self.txt_precio_minimo)
-        form_layout.addRow("Unidad de Medida:", self.cmb_unidad)
-        form_layout.addRow("Stock Mínimo:", self.txt_stock_minimo)
-        
-        # Columna Derecha: Imagen
+
+        # ================= TAB GENERAL =================
+        layout_general = QHBoxLayout(tab_general)
+        form_general = QFormLayout()
+        form_general.addRow("Nombre:*", self.txt_nombre)
+        form_general.addRow("SKU / Código:", self.txt_codigo)
+        form_general.addRow("Código de Barras:", self.txt_codigo_barras)
+        form_general.addRow("Categoría:", self.cmb_categoria)
+        form_general.addRow("Unidad de venta:", self.cmb_unidad_venta)
+        form_general.addRow("Unidad de compra:", self.cmb_unidad_compra)
+        form_general.addRow("Unidad base / inventario:", self.cmb_unidad)
+        form_general.addRow("Estado:", self.cmb_estado)
+
+        # Columna Derecha: Imagen + descripción
         panel_imagen = QVBoxLayout()
         self.lbl_imagen = QLabel("Sin Imagen")
         self.lbl_imagen.setAlignment(Qt.AlignCenter)
@@ -147,17 +159,69 @@ class DialogoProducto(QDialog):
         panel_imagen.addWidget(btn_quitar_img)
         panel_imagen.addStretch()
         
-        layout_general.addLayout(form_layout, 2)
+        layout_general.addLayout(form_general, 2)
         layout_general.addLayout(panel_imagen, 1)
-        
-        # ================= TAB COMPUESTOS =================
-        layout_compuesto = QVBoxLayout(self.tab_compuesto)
-        layout_compuesto.addWidget(QLabel("<i>Agregue los productos que conforman este paquete/combo.</i>"))
-        # Aquí iría un QTableWidget para agregar componentes si el usuario elige "Compuesto"
-        self.tabla_componentes = QTableWidget()
-        self.tabla_componentes.setColumnCount(3)
-        self.tabla_componentes.setHorizontalHeaderLabels(["ID Prod.", "Nombre", "Cantidad"])
-        layout_compuesto.addWidget(self.tabla_componentes)
+
+        # ================= TAB CONFIGURACIÓN =================
+        layout_config = QVBoxLayout(tab_config)
+        form_config = QFormLayout()
+        form_config.addRow("Tipo de Producto:", self.cmb_tipo)
+        self.chk_se_vende = QCheckBox("Se vende")
+        self.chk_es_inventariable = QCheckBox("Es inventariable")
+        self.chk_permite_receta = QCheckBox("Permite receta")
+        self.chk_permite_stock_virtual = QCheckBox("Permite stock virtual")
+        self.chk_descuenta_componentes = QCheckBox("Descuenta componentes en venta")
+        for chk in (
+            self.chk_se_vende, self.chk_es_inventariable, self.chk_permite_receta,
+            self.chk_permite_stock_virtual, self.chk_descuenta_componentes
+        ):
+            chk.setEnabled(False)  # fallback seguro: solo mostrar comportamiento
+            layout_config.addWidget(chk)
+        layout_config.addLayout(form_config)
+        self.lbl_tipo_help = create_caption(self, "")
+        layout_config.addWidget(self.lbl_tipo_help)
+        self._actualizar_hint_tipo(self.cmb_tipo.currentText())
+
+        # ================= TAB PRECIOS / COSTOS BASE =================
+        layout_precios = QVBoxLayout(tab_precios)
+        form_precios = QFormLayout()
+        form_precios.addRow("Precio venta:", self.txt_precio)
+        form_precios.addRow("Precio compra base:", self.txt_costo)
+        form_precios.addRow("Precio mínimo:", self.txt_precio_minimo)
+        self.lbl_costo_std = create_caption(self, "Costo estándar: —")
+        self.lbl_margen = create_caption(self, "Margen esperado: —")
+        layout_precios.addLayout(form_precios)
+        layout_precios.addWidget(self.lbl_costo_std)
+        layout_precios.addWidget(self.lbl_margen)
+
+        # ================= TAB RECETA =================
+        lay_receta = QVBoxLayout(tab_receta)
+        lay_receta.addWidget(create_caption(
+            self,
+            "La receta del producto se administra desde Productos > pestaña Receta del módulo."
+        ))
+        lay_receta.addWidget(create_caption(
+            self,
+            "SIMPLE y SERVICIO no usan receta. COMPUESTO/PROCESABLE/PRODUCIDO sí permiten receta."
+        ))
+        lay_receta.addStretch()
+
+        # ================= TAB REFERENCIAS =================
+        lay_ref = QVBoxLayout(tab_referencias)
+        self.lbl_stock_fisico = create_caption(self, "Stock físico actual: —")
+        self.lbl_disponible_venta = create_caption(self, "Disponible venta: —")
+        lay_ref.addWidget(self.lbl_stock_fisico)
+        lay_ref.addWidget(self.lbl_disponible_venta)
+        lay_ref.addWidget(create_caption(self, "Stock y disponibilidad se administran en Inventario."))
+        btn_ver_inv = create_secondary_button(self, "📦 Ver en Inventario", "Abrir módulo Inventario para gestión de existencias")
+        btn_ver_inv.clicked.connect(lambda: QMessageBox.information(
+            self, "Inventario",
+            "La gestión de existencias se realiza en el módulo Inventario."
+        ))
+        lay_ref.addWidget(btn_ver_inv)
+        lay_ref.addWidget(QLabel("Stock mínimo de referencia:"))
+        lay_ref.addWidget(self.txt_stock_minimo)
+        lay_ref.addStretch()
         
         # --- BOTONES DE ACCIÓN ---
         layout_principal.addWidget(tabs)
@@ -179,8 +243,20 @@ class DialogoProducto(QDialog):
         layout_principal.addWidget(btn_box)
 
     def al_cambiar_tipo(self, tipo):
-        """Habilita o deshabilita la pestaña de compuestos."""
-        self.tab_compuesto.setEnabled(tipo == "Compuesto")
+        self._actualizar_hint_tipo(tipo)
+
+    def _actualizar_hint_tipo(self, tipo: str):
+        hints = {
+            "Simple": "Producto que se compra y vende directamente.",
+            "Compuesto": "Producto vendido como paquete/combo. Puede descontar componentes al venderse.",
+            "Procesable": "Producto que puede transformarse en subproductos. Ejemplo: pollo entero.",
+            "Subproducto": "Producto generado por un despiece o usado como componente de otros productos.",
+            "Producido": "Producto elaborado a partir de insumos o subproductos.",
+            "Insumo": "Producto usado como ingrediente/material.",
+            "Servicio": "No controla inventario físico.",
+        }
+        if hasattr(self, "lbl_tipo_help"):
+            self.lbl_tipo_help.setText(hints.get(tipo, ""))
 
     def cargar_categorias(self):
         """Carga las categorías únicas existentes."""
@@ -231,12 +307,20 @@ class DialogoProducto(QDialog):
                 self.txt_precio.setValue(p.get('precio', 0.0))
                 self.txt_costo.setValue(p.get('precio_compra', 0.0) or p.get('costo', 0.0))
                 self.cmb_unidad.setCurrentText(p.get('unidad', 'pza'))
+                self.cmb_unidad_venta.setCurrentText(p.get('unidad_venta', p.get('unidad', 'pza')))
+                self.cmb_unidad_compra.setCurrentText(p.get('unidad_compra', p.get('unidad', 'pza')))
+                self.cmb_estado.setCurrentText("Activo" if int(p.get('activo', 1) or 1) == 1 else "Inactivo")
                 self.txt_stock_minimo.setValue(p.get('stock_minimo', 0.0))
                 
                 tipo = p.get('tipo_producto', 'simple')
                 if p.get('es_compuesto'): tipo = "Compuesto"
                 if p.get('es_subproducto'): tipo = "Subproducto"
                 self.cmb_tipo.setCurrentText(tipo.capitalize())
+                self._actualizar_hint_tipo(self.cmb_tipo.currentText())
+
+                existencia = p.get('existencia', 0.0) or 0.0
+                self.lbl_stock_fisico.setText(f"Stock físico actual: {existencia:.3f} {self.cmb_unidad.currentText()}")
+                self.lbl_disponible_venta.setText(f"Disponible venta: {existencia:.3f} {self.cmb_unidad.currentText()}")
                 
                 self.ruta_imagen_actual = p.get('imagen_path')
                 self.mostrar_imagen_previa(self.ruta_imagen_actual)
@@ -274,9 +358,9 @@ class DialogoProducto(QDialog):
             return
             
         tipo = self.cmb_tipo.currentText()
-        es_compuesto = 1 if tipo == "Compuesto" else 0
-        es_subproducto = 1 if tipo == "Subproducto" else 0
-        tipo_str = "compuesto" if es_compuesto else "subproducto" if es_subproducto else "simple"
+        tipo_str = (tipo or "Simple").strip().lower()
+        es_compuesto = 1 if tipo_str == "compuesto" else 0
+        es_subproducto = 1 if tipo_str == "subproducto" else 0
 
         # codigo_val must be defined before the if/else so both branches can use it
         codigo_val = self.txt_codigo.text().strip() or None
@@ -303,14 +387,14 @@ class DialogoProducto(QDialog):
                 query = """
                     UPDATE productos SET 
                         nombre=?, codigo=?, codigo_barras=?, categoria=?, precio=?, precio_compra=?, precio_minimo_venta=?, 
-                        unidad=?, stock_minimo=?, tipo_producto=?, es_compuesto=?, es_subproducto=?, 
+                        unidad=?, stock_minimo=?, tipo_producto=?, es_compuesto=?, es_subproducto=?, activo=?,
                         imagen_path=?, ultima_actualizacion=datetime('now')
                     WHERE id=?
                 """
                 cursor.execute(query, (
                     nombre, codigo_val, self.txt_codigo_barras.text(), self.cmb_categoria.currentText(),
                     precio, self.txt_costo.value(), getattr(self, "txt_precio_minimo", type("x", (), {"value": lambda s: 0})()).value(), self.cmb_unidad.currentText(), self.txt_stock_minimo.value(),
-                    tipo_str, es_compuesto, es_subproducto, self.ruta_imagen_actual, self.producto_id
+                    tipo_str, es_compuesto, es_subproducto, (1 if self.cmb_estado.currentText() == "Activo" else 0), self.ruta_imagen_actual, self.producto_id
                 ))
             else:
                 # INSERT
@@ -370,7 +454,7 @@ class DialogoProducto(QDialog):
                             self, "Receta pendiente",
                             "El producto fue guardado como compuesto.\n\n"
                             "⚠️  Aún no tiene una receta activa.\n"
-                            "Ve al módulo Recetas y crea la receta para este producto "
+                            "Administra la receta desde Productos > Receta "
                             "antes de procesarlo en ventas o producción.")
 
             self.container.db.commit()
@@ -414,7 +498,11 @@ class DialogoProducto(QDialog):
     
         except Exception as e:
             self.container.db.rollback()
-            QMessageBox.critical(self, "Error BD", f"No se pudo guardar: {e}")
+            logger.exception("productos.guardar")
+            QMessageBox.critical(
+                self, "No se pudo guardar",
+                "No fue posible guardar el producto. Revise la información e intente nuevamente."
+            )
 
 # ==============================================================================
 # MODULO PRINCIPAL (Centro de Productos y Producción)
@@ -455,44 +543,52 @@ class ModuloProductos(QWidget, RefreshMixin):
         self.usuario_actual = usuario
 
     def _crear_stats_productos(self) -> 'QFrame':
-        """Barra de KPIs rápidos: total productos, activos, stock bajo, categorías."""
-        from PyQt5.QtWidgets import QFrame as _F, QHBoxLayout as _H, QVBoxLayout as _V, QLabel as _L
-        bar = _F(); bar.setObjectName("statsBar")
-        bar.setFixedHeight(64)
-        bar.setStyleSheet(
-            f"QFrame#statsBar {{ background:{Colors.NEUTRAL.DARK_CARD if hasattr(Colors.NEUTRAL,'DARK_CARD') else '#1E293B'};"
-            f" border-radius:8px; border:1px solid {Colors.NEUTRAL.SLATE_700 if hasattr(Colors.NEUTRAL,'SLATE_700') else '#334155'}; }}"
-        )
-        lay = _H(bar); lay.setContentsMargins(20,8,20,8); lay.setSpacing(0)
-
-        kpis = [("Total Productos","—",Colors.PRIMARY_BASE),("Activos","—",Colors.SUCCESS_BASE),
-                ("Stock bajo","—",Colors.WARNING_BASE),("Categorías","—",Colors.INFO_BASE)]
-        self._stats_prod_labels = {}
-        try:
-            db = self.conexion
-            r = db.execute("SELECT COUNT(*), SUM(CASE WHEN activo=1 THEN 1 ELSE 0 END) FROM productos").fetchone()
-            kpis[0] = ("Total Productos", str(r[0] or 0), Colors.PRIMARY_BASE)
-            kpis[1] = ("Activos", str(r[1] or 0), Colors.SUCCESS_BASE)
-            r2 = db.execute("SELECT COUNT(*) FROM productos WHERE existencia<=COALESCE(stock_minimo,5) AND activo=1").fetchone()
-            kpis[2] = ("Stock bajo", str(r2[0] or 0), Colors.WARNING_BASE)
-            r3 = db.execute("SELECT COUNT(DISTINCT categoria) FROM productos WHERE activo=1").fetchone()
-            kpis[3] = ("Categorías", str(r3[0] or 0), Colors.INFO_BASE)
-        except Exception: pass
-
-        for i, (lbl, val, col) in enumerate(kpis):
-            if i > 0:
-                s = _F(); s.setFrameShape(_F.VLine); s.setFixedWidth(1)
-                s.setStyleSheet(f"background:{Colors.NEUTRAL.SLATE_700 if hasattr(Colors.NEUTRAL,'SLATE_700') else '#334155'}; border:none;")
-                lay.addWidget(s); lay.addSpacing(20)
-            c = _V(); c.setSpacing(1)
-            v = _L(val); v.setStyleSheet(f"color:{col};font-size:18px;font-weight:700;background:transparent;")
-            l = _L(lbl.upper()); l.setStyleSheet(f"color:{Colors.NEUTRAL.SLATE_500};font-size:9px;font-weight:700;letter-spacing:0.5px;background:transparent;")
-            c.addWidget(v); c.addWidget(l)
-            self._stats_prod_labels[lbl] = v
-            lay.addLayout(c)
-            if i < 3: lay.addSpacing(20)
-        lay.addStretch()
+        from PyQt5.QtWidgets import QFrame, QHBoxLayout, QPushButton
+        bar = QFrame()
+        lay = QHBoxLayout(bar)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.setSpacing(Spacing.SM)
+        self._kpi_filter_mode = "all"
+        self._kpi_cards = {}
+        defs = [
+            ("activos", "Productos activos", "📦", "success"),
+            ("sin_tipo", "Sin tipo_producto", "🏷️", "warning"),
+            ("receta_pendiente", "Receta pendiente", "🧪", "info"),
+            ("sin_costo", "Sin costo base", "💲", "danger"),
+            ("inactivos", "Inactivos", "⏸", "primary"),
+        ]
+        for key, title, icon, variant in defs:
+            btn = QPushButton()
+            btn.setFlat(True)
+            btn.clicked.connect(lambda _, k=key: self._on_kpi_click(k))
+            card = KPICard(title, "—", icon, variant, parent=btn)
+            self._kpi_cards[key] = card
+            h = QHBoxLayout(btn)
+            h.setContentsMargins(0, 0, 0, 0)
+            h.addWidget(card)
+            lay.addWidget(btn)
         return bar
+
+    def _refresh_kpi_productos(self):
+        try:
+            db = self.container.db if hasattr(self.container, 'db') else self.conexion
+            data = get_product_configuration_kpis(db)
+            for key, card in self._kpi_cards.items():
+                card.set_valor(str(data.get(key, 0)))
+        except Exception:
+            pass
+
+    def _on_kpi_click(self, key: str):
+        self._kpi_filter_mode = key
+        if key == "inactivos":
+            self.cmb_filtro_estado.setCurrentIndex(1)
+            return
+        if key == "activos":
+            self.cmb_filtro_estado.setCurrentIndex(0)
+            return
+        self.cmb_filtro_estado.setCurrentIndex(2)
+        self.tabs.setCurrentWidget(self.tab_catalogo)
+        self.cargar_catalogo()
 
     def init_ui(self):
         layout_principal = QVBoxLayout(self)
@@ -616,13 +712,50 @@ class ModuloProductos(QWidget, RefreshMixin):
 
     def setup_tab_receta_producto(self):
         lay = QVBoxLayout(self.tab_receta)
+        self._loading_receta = LoadingIndicator("Cargando información de receta…", self)
+        self._loading_receta.hide()
         self._lbl_receta_estado = create_subheading(self, "Seleccione un producto en Catálogo.")
         self._lbl_receta_hint = create_caption(self, "La receta permitida depende de tipo_producto.")
         self._btn_receta_abrir = create_primary_button(self, "🛠 Gestionar receta", "Crear o editar receta del producto seleccionado")
         self._btn_receta_abrir.clicked.connect(self._abrir_receta_producto)
+        self._btn_receta_desactivar = create_secondary_button(self, "⏸ Desactivar receta", "Desactivar receta activa del producto")
+        self._btn_receta_desactivar.clicked.connect(self._desactivar_receta_producto)
+        self._btn_receta_simular = create_secondary_button(self, "🧮 Simular", "Vista previa informativa según tipo de producto")
+        self._btn_receta_simular.clicked.connect(self._simular_receta_producto)
+        self._btn_receta_inv = create_secondary_button(self, "📦 Ver en Inventario", "Consultar disponibilidad/stock en Inventario")
+        self._btn_receta_inv.clicked.connect(
+            lambda: QMessageBox.information(self, "Inventario", "La disponibilidad y stock se consultan en Inventario.")
+        )
+        self._tbl_receta_componentes = QTableWidget()
+        self._tbl_receta_componentes.setColumnCount(5)
+        self._tbl_receta_componentes.setHorizontalHeaderLabels(
+            ["Componente/Insumo", "Cantidad", "Unidad", "Rendimiento %", "Merma %"]
+        )
+        self._tbl_receta_componentes.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self._tbl_receta_componentes.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._tbl_receta_componentes.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._lbl_receta_resumen = create_caption(self, "Resumen contextual: —")
+        self._lbl_receta_preview = create_caption(self, "")
+        self._empty_receta = EmptyStateWidget(
+            "Sin contexto de receta",
+            "Seleccione un producto en Catálogo para ver o gestionar su receta.",
+            "🧪",
+            self,
+        )
         lay.addWidget(self._lbl_receta_estado)
         lay.addWidget(self._lbl_receta_hint)
+        lay.addWidget(self._loading_receta)
         lay.addWidget(self._btn_receta_abrir)
+        row_btn = QHBoxLayout()
+        row_btn.addWidget(self._btn_receta_simular)
+        row_btn.addWidget(self._btn_receta_desactivar)
+        row_btn.addWidget(self._btn_receta_inv)
+        row_btn.addStretch()
+        lay.addLayout(row_btn)
+        lay.addWidget(self._tbl_receta_componentes)
+        lay.addWidget(self._lbl_receta_resumen)
+        lay.addWidget(self._lbl_receta_preview)
+        lay.addWidget(self._empty_receta)
         lay.addStretch()
         self._refresh_tab_receta_producto()
 
@@ -642,22 +775,90 @@ class ModuloProductos(QWidget, RefreshMixin):
 
     def _refresh_tab_receta_producto(self):
         p = self._producto_seleccionado_catalogo()
+        self._tbl_receta_componentes.setRowCount(0)
+        self._lbl_receta_resumen.setText("Resumen contextual: —")
+        self._lbl_receta_preview.setText("")
         if not p:
             self._lbl_receta_estado.setText("Seleccione un producto en Catálogo.")
             self._lbl_receta_hint.setText("SIMPLE: sin receta. COMPUESTO/PROCESABLE/PRODUCIDO: con receta.")
             self._btn_receta_abrir.setEnabled(False)
+            self._btn_receta_desactivar.setEnabled(False)
+            self._btn_receta_simular.setEnabled(False)
+            self._empty_receta.show()
             return
+        self._empty_receta.hide()
         tipo = (p.get("tipo_producto") or "simple").lower()
-        self._btn_receta_abrir.setEnabled(tipo != "simple")
+        self._btn_receta_abrir.setEnabled(tipo != "simple" and tipo != "servicio")
+        self._btn_receta_simular.setEnabled(tipo in {"compuesto", "procesable", "producido"})
+        self._btn_receta_desactivar.setEnabled(tipo in {"compuesto", "procesable", "producido", "subproducto"})
         rules = {
-            "simple": "No permite receta.",
-            "compuesto": "Permite receta COMBINACION.",
-            "procesable": "Permite receta SUBPRODUCTO (despiece).",
-            "producido": "Permite receta PRODUCCION.",
-            "subproducto": "Muestra origen/usos; gestión de receta permitida según configuración.",
+            "simple": "Este producto no usa receta.",
+            "compuesto": "Receta de combinación: al vender 1 unidad se descuentan componentes.",
+            "procesable": "Receta de despiece: al procesar se generan subproductos.",
+            "producido": "Receta de producción: se elabora consumiendo insumos/subproductos.",
+            "subproducto": "Este producto es generado por despiece o usado como componente.",
+            "insumo": "Este producto se usa como insumo.",
+            "servicio": "Los servicios no controlan inventario ni receta.",
         }
         self._lbl_receta_estado.setText(f"Producto: {p['nombre']} ({tipo.upper()})")
         self._lbl_receta_hint.setText(rules.get(tipo, "Revise configuración de receta para este tipo."))
+        self._cargar_detalle_receta_producto(p, tipo)
+
+    def _cargar_detalle_receta_producto(self, producto: dict, tipo: str) -> None:
+        db = self.container.db if hasattr(self.container, 'db') else self.conexion
+        svc = RecipeService(db)
+        self._loading_receta.show()
+        receta = svc.get_recipe_for_product(producto["id"])
+        if not receta:
+            if tipo == "simple":
+                self._lbl_receta_resumen.setText("Resumen contextual: producto simple (sin receta).")
+                self._lbl_receta_preview.setText("Este producto no usa receta. Los productos simples se compran y venden directamente.")
+            elif tipo == "servicio":
+                self._lbl_receta_resumen.setText("Resumen contextual: servicio (sin receta).")
+                self._lbl_receta_preview.setText("Los servicios no controlan inventario ni receta.")
+            else:
+                self._lbl_receta_resumen.setText("Resumen contextual: receta pendiente.")
+                self._lbl_receta_preview.setText("No hay receta activa para este producto.")
+            self._loading_receta.hide()
+            return
+        componentes = svc.get_recipe_components(receta["id"])
+        self._tbl_receta_componentes.setRowCount(len(componentes))
+        for i, c in enumerate(componentes):
+            vals = [
+                str(c.get("component_nombre") or ""),
+                f"{float(c.get('cantidad') or 0):.3f}",
+                str(c.get("unidad") or ""),
+                f"{float(c.get('rendimiento_pct') or 0):.3f}",
+                f"{float(c.get('merma_pct') or 0):.3f}",
+            ]
+            for j, v in enumerate(vals):
+                self._tbl_receta_componentes.setItem(i, j, QTableWidgetItem(v))
+        if tipo == "compuesto":
+            self._lbl_receta_resumen.setText(f"Resumen: Componentes {len(componentes)} · Disponible por componentes: — · Componente limitante: —")
+            self._lbl_receta_preview.setText("Preview: Al vender 1 unidad se descontará la lista de componentes.")
+        elif tipo == "procesable":
+            total_r = sum(float(c.get('rendimiento_pct') or 0) for c in componentes)
+            total_m = sum(float(c.get('merma_pct') or 0) for c in componentes)
+            self._lbl_receta_resumen.setText(
+                f"Resumen: Subproductos {len(componentes)} · Total generado {total_r:.1f}% · Merma {total_m:.1f}% · Total receta {(total_r+total_m):.1f}%"
+            )
+            self._lbl_receta_preview.setText("Preview: Si procesas X kg se generarán subproductos según rendimiento y merma.")
+        elif tipo == "producido":
+            self._lbl_receta_resumen.setText(f"Resumen: Insumos {len(componentes)} · Costo estimado: — · Rendimiento esperado: —")
+            self._lbl_receta_preview.setText("Preview: Si produces X se consumirán insumos según cantidades de la receta.")
+        elif tipo == "subproducto":
+            usados = self._buscar_usos_subproducto(svc, producto["id"])
+            self._lbl_receta_resumen.setText(f"Resumen: Recetas origen: {(1 if receta else 0)} · Usado en: {len(usados)} · Último costo: —")
+            self._lbl_receta_preview.setText(f"Usado en {len(usados)} receta(s): {', '.join(usados[:5])}" if usados else "Sin usos detectados en recetas activas.")
+        self._loading_receta.hide()
+
+    def _buscar_usos_subproducto(self, svc: RecipeService, producto_id: int):
+        usos = []
+        for rec in svc.get_all_recipes(include_inactive=False):
+            comps = svc.get_recipe_components(rec["id"])
+            if any(int(c.get("component_product_id") or 0) == int(producto_id) for c in comps):
+                usos.append(str(rec.get("nombre_receta") or f"Receta {rec.get('id')}"))
+        return usos
 
     def _abrir_receta_producto(self):
         p = self._producto_seleccionado_catalogo()
@@ -667,6 +868,9 @@ class ModuloProductos(QWidget, RefreshMixin):
         tipo = (p.get("tipo_producto") or "simple").lower()
         if tipo == "simple":
             QMessageBox.information(self, "Receta no permitida", "La UI no permite crear receta para producto SIMPLE.")
+            return
+        if tipo == "servicio":
+            QMessageBox.information(self, "Receta no permitida", "Los servicios no usan receta.")
             return
         db = self.container.db if hasattr(self.container, 'db') else self.conexion
         svc = RecipeService(db)
@@ -688,6 +892,33 @@ class ModuloProductos(QWidget, RefreshMixin):
         dlg._combo_base.setEnabled(False)
         if dlg.exec_() == QDialog.Accepted:
             self._refresh_tab_receta_producto()
+
+    def _desactivar_receta_producto(self):
+        p = self._producto_seleccionado_catalogo()
+        if not p:
+            return
+        db = self.container.db if hasattr(self.container, 'db') else self.conexion
+        svc = RecipeService(db)
+        receta = svc.get_recipe_for_product(p["id"])
+        if not receta:
+            QMessageBox.information(self, "Receta", "No hay receta activa para desactivar.")
+            return
+        if QMessageBox.question(self, "Desactivar receta", "¿Desea desactivar la receta activa de este producto?") != QMessageBox.Yes:
+            return
+        svc.deactivate_recipe(receta["id"], getattr(self, "usuario_actual", "Sistema"))
+        self._refresh_tab_receta_producto()
+
+    def _simular_receta_producto(self):
+        p = self._producto_seleccionado_catalogo()
+        if not p:
+            return
+        tipo = (p.get("tipo_producto") or "simple").lower()
+        if tipo == "compuesto":
+            QMessageBox.information(self, "Simulación", "Al vender 1 unidad se descontarán los componentes mostrados.")
+        elif tipo == "procesable":
+            QMessageBox.information(self, "Simulación", "Si procesas X kg se generarán subproductos conforme a rendimiento/merma.")
+        elif tipo == "producido":
+            QMessageBox.information(self, "Simulación", "Si produces X se consumirán insumos según la receta.")
 
     def _on_refresh(self, event_type: str, data: dict) -> None:
         """Auto-refresh catalog on product or purchase events."""
@@ -745,6 +976,11 @@ class ModuloProductos(QWidget, RefreshMixin):
 
             cursor = self.container.db.cursor() if hasattr(self.container, 'db') else self.conexion.cursor()
             rows = cursor.execute(query, params).fetchall()
+            db = self.container.db if hasattr(self.container, 'db') else self.conexion
+            kpi_mode = getattr(self, "_kpi_filter_mode", "all")
+            if kpi_mode in {"sin_tipo", "receta_pendiente", "sin_costo"}:
+                ids = get_catalog_filter_ids(db, kpi_mode)
+                rows = [r for r in rows if int(r['id']) in ids]
 
             self.tabla_productos.setRowCount(0)
             from PyQt5.QtGui import QColor as _QC
@@ -824,6 +1060,7 @@ class ModuloProductos(QWidget, RefreshMixin):
                     f"Mostrando {total} productos ({activos} activos, {total - activos} eliminados)")
             if hasattr(self, "_empty_catalogo"):
                 self._empty_catalogo.setVisible(len(rows) == 0)
+            self._refresh_kpi_productos()
 
         except Exception as e:
             logger.error(f"Error cargando catálogo: {e}")

--- a/pos_spj_v13.4/modulos/ventas.py
+++ b/pos_spj_v13.4/modulos/ventas.py
@@ -3188,6 +3188,25 @@ class ModuloVentas(ModuloBase):
             self.limpiar_seleccion_producto()
 
     def agregar_producto_directo(self, producto: Dict[str, Any], cantidad: float):
+        def _stock_msg(prod: Dict[str, Any]) -> str:
+            missing = prod.get("missing_components") or []
+            if missing:
+                lines = [f"No se puede vender {prod.get('nombre','este producto')}.\n", "Faltantes:"]
+                for m in missing[:6]:
+                    comp = m.get("component_name") or m.get("nombre") or "Componente"
+                    req = m.get("required_qty")
+                    ava = m.get("available_qty")
+                    und = m.get("unit") or prod.get("unidad") or ""
+                    lines.append(f"- {comp}: necesitas {req} {und}, disponible {ava} {und}")
+                mx = prod.get("max_sellable")
+                if mx is not None:
+                    lines.append(f"\nMáximo vendible: {mx}")
+                return "\n".join(lines)
+            avail_msg = prod.get("availability_message")
+            if avail_msg:
+                return str(avail_msg)
+            return f"Stock insuficiente. Disponible: {prod['existencia']:.2f} {prod['unidad']}"
+
         if cantidad <= 0:
             QMessageBox.warning(self, "Advertencia", "La cantidad debe ser mayor a cero.")
             self.limpiar_seleccion_producto()
@@ -3195,7 +3214,7 @@ class ModuloVentas(ModuloBase):
             
         if cantidad > producto['existencia']:
             QMessageBox.warning(self, "Stock Insuficiente",
-                f"Stock insuficiente. Disponible: {producto['existencia']:.2f} {producto['unidad']}")
+                _stock_msg(producto))
             self.limpiar_seleccion_producto()
             return
             
@@ -3215,7 +3234,7 @@ class ModuloVentas(ModuloBase):
                             if nueva_cantidad > producto['existencia']:
                                 QMessageBox.warning(
                                     self, "Stock Insuficiente",
-                                    f"Stock insuficiente. Disponible: {producto['existencia']:.2f} {producto['unidad']}"
+                                    _stock_msg(producto)
                                 )
                                 break
                                 
@@ -3235,6 +3254,11 @@ class ModuloVentas(ModuloBase):
                         'precio_unitario': producto['precio'],
                         'total': total_item,
                         '_uid': _uuid_mod.uuid4().hex,  # ISSUE 2 FIX
+                        'fulfillment_mode': producto.get('fulfillment_mode'),
+                        'component_movements': producto.get('component_movements'),
+                        'missing_components': producto.get('missing_components'),
+                        'max_sellable': producto.get('max_sellable'),
+                        'availability_message': producto.get('availability_message'),
                     }
                 # Verificar stock antes de agregar al carrito
                 # v13.4: Delegado a inventory_service para mantener abstracción de capa
@@ -3279,6 +3303,11 @@ class ModuloVentas(ModuloBase):
             # ISSUE 2 FIX: Identificador estable para que el descuento pertenezca
             # al ítem, no al índice de fila. Sobrevive cualquier pop/reordenamiento.
             '_uid': _uuid_mod.uuid4().hex,
+            'fulfillment_mode': producto.get('fulfillment_mode'),
+            'component_movements': producto.get('component_movements'),
+            'missing_components': producto.get('missing_components'),
+            'max_sellable': producto.get('max_sellable'),
+            'availability_message': producto.get('availability_message'),
         }
 
         self.compra_actual.append(item_compra)
@@ -3311,8 +3340,30 @@ class ModuloVentas(ModuloBase):
                       or str(item.get('id', '')))
             lbl_code = QLabel(f"Código: {codigo}")
             lbl_code.setObjectName("posCartItemCode")
+            mode_raw = str(item.get("fulfillment_mode") or "").upper().strip()
+            mode_map = {
+                "DIRECTO": "DIRECTO",
+                "COMBINACION": "COMPUESTO",
+                "COMPUESTO": "COMPUESTO",
+                "VIRTUAL": "VIRTUAL",
+            }
+            mode_tag = mode_map.get(mode_raw, "DIRECTO")
+            lbl_mode = QLabel(f"Modo: {mode_tag}")
+            lbl_mode.setObjectName("posCartItemCode")
             cell_lay.addWidget(lbl_name)
             cell_lay.addWidget(lbl_code)
+            cell_lay.addWidget(lbl_mode)
+            comp_moves = item.get("component_movements") or []
+            if comp_moves:
+                comp_lines = ["Descontará estos componentes:"]
+                for cm in comp_moves[:6]:
+                    nm = cm.get("component_name") or cm.get("nombre") or "Componente"
+                    qt = cm.get("qty") or cm.get("quantity") or cm.get("cantidad") or 0
+                    un = cm.get("unit") or item.get("unidad") or ""
+                    comp_lines.append(f"- {nm}: -{qt} {un}")
+                cell_w.setToolTip("\n".join(comp_lines))
+            elif item.get("availability_message"):
+                cell_w.setToolTip(str(item.get("availability_message")))
             self.tabla_compra.setCellWidget(row, 0, cell_w)
 
             cantidad_item = QTableWidgetItem(f"{item['cantidad']:.3f}")
@@ -4121,7 +4172,10 @@ class ModuloVentas(ModuloBase):
             QMessageBox.warning(self, "Aviso de Venta", str(e))
         except Exception as e:
             logger.error(f"Fallo crítico en UI de ventas: {str(e)}")
-            QMessageBox.critical(self, "Error Fatal", f"Error procesando la venta:\n{str(e)}")
+            QMessageBox.critical(
+                self, "Error al procesar venta",
+                "No se pudo completar la venta. Verifique stock, pagos y datos del cliente, e intente nuevamente."
+            )
 
     def generar_ticket(self, venta_id: int, datos_pago: Dict[str, Any]):
         try:


### PR DESCRIPTION
### Motivation
- Agregar paneles operativos y métricas para facilitar la gestión de inventario y catálogo. 
- Mejorar la experiencia de administración de recetas integrándolas con el módulo de Productos y ofreciendo mensajes de error más amigables. 
- Robustecer la UI para mostrar movimientos, disponibilidad virtual y metadatos de cumplimiento en ventas.

### Description
- Añade dos servicios de consulta: `core/services/inventory_query_service.py` con `get_recent_movements` y `get_inventory_operational_kpis`, y `core/services/product_catalog_query_service.py` con `get_product_configuration_kpis` y `get_catalog_filter_ids`.
- Rediseña el módulo de Inventario (`modulos/inventario_local.py`) para usar pestañas (`_build_inventory_tabs`) con vistas de existencias, disponibilidad, stock virtual, movimientos, reservas, ajustes y auditoría; incorpora KPIs interactivos y carga de movimientos con `get_recent_movements`, y convierte errores técnicos en mensajes de negocio con `_to_business_inventory_error`.
- Extiende el diálogo de producto (`modulos/productos.py`) con nuevas pestañas (Configuración, Precios, Receta, Referencias), nuevos campos (unidad venta/compra, estado), lógica para filtros KPI (`get_product_configuration_kpis` / `get_catalog_filter_ids`), y mejor manejo de guardado con mensajes menos técnicos.
- Mejora el módulo de Receta (`modulos/dialogs/receta_dialog.py`) para mapear errores de negocio a mensajes amigables mediante `DialogoReceta._to_business_recipe_error` y unificación del texto mostrado en `QMessageBox`.
- Actualiza Producción (`modulos/produccion.py`) para usar `KPICard` en la barra de estadísticas y migrar la UI de KPIs a componentes reutilizables; agrega indicación de migración de recetas.
- Actualiza Ventas (`modulos/ventas.py`) para mejorar los mensajes de disponibilidad, añadir metadatos de cumplimiento/componentes en los ítems del carrito (`component_movements`, `missing_components`, `max_sellable`, `availability_message`) y mostrar modo de fulfillment en la UI.
- Varios cambios menores de UX/UX textuales y logs para mayor resiliencia frente a errores inesperados.

### Testing
- No new automated tests were added for these UI and service changes.
- No automated test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1471bf5c90832883c071fb5c182161)