### PR TITLE
Unify ESC/POS ticket pipeline: PrinterService integration, Ticket model/layout/branding, renderer improvements and tests

### DIFF
--- a/pos_spj_v13.4/core/events/outbox.py
+++ b/pos_spj_v13.4/core/events/outbox.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any
+
+
+def _utc_now_iso() -> str:
+    """UTC timezone-aware timestamp in ISO8601 for outbox persistence."""
+    utc_tz = getattr(datetime, "UTC", timezone.utc)
+    return datetime.now(utc_tz).isoformat()
 
 
 def ensure_outbox_table(db) -> None:
@@ -46,7 +52,7 @@ def enqueue_event(
             json.dumps(payload or {}, ensure_ascii=False, default=str),
             aggregate_type or "",
             str(aggregate_id or ""),
-            datetime.utcnow().isoformat(),
+            _utc_now_iso(),
         ),
     )
     try:
@@ -91,10 +97,9 @@ def mark_dispatched(db, event_id: int, error: str = "") -> None:
         SET status=?, error=?, dispatched_at=?
         WHERE id=?
         """,
-        (status, error or "", datetime.utcnow().isoformat(), int(event_id)),
+        (status, error or "", _utc_now_iso(), int(event_id)),
     )
     try:
         db.commit()
     except Exception:
         pass
-

--- a/pos_spj_v13.4/core/services/caja_ticket_service.py
+++ b/pos_spj_v13.4/core/services/caja_ticket_service.py
@@ -19,9 +19,10 @@ logger = logging.getLogger("spj.caja.ticket")
 class CajaTicketService:
     """Genera HTML, PDF y envía ESC/POS para comprobantes de corte Z."""
 
-    def __init__(self, db=None, hardware_service=None):
+    def __init__(self, db=None, hardware_service=None, printer_service=None):
         self.db = db
         self._hw = hardware_service
+        self._printer_service = printer_service
 
     def generar_html_corte(self, datos: Dict, cierre_id: int) -> str:
         """Genera el HTML del ticket de corte Z."""
@@ -87,78 +88,25 @@ class CajaTicketService:
             return ""
 
     def enviar_escpos(self, datos: Dict, ancho: int = 48) -> bool:
-        """Envía ticket ESC/POS a impresora térmica via HardwareService."""
-        hw = self._hw
-        if not hw:
-            return False
-        try:
-            hw.load_configs()
-            cfg = hw._cache_config.get("ticket", {})
-            if not cfg:
-                return False
-            ubicacion = cfg.get("ubicacion", "")
-            ancho = 48 if "80" in cfg.get("ancho", "80") else 32
-            if not ubicacion:
-                return False
-
-            ESC = b"\x1b"
-            GS = b"\x1d"
-            data = bytearray()
-            data += ESC + b"@"
-            data += ESC + b"a\x01"
-            data += ESC + b"E\x01"
-            data += b"** CORTE Z **\n"
-            data += ESC + b"E\x00"
-            sep = b"-" * ancho + b"\n"
-            data += sep
-            data += f"Cajero: {datos.get('cajero','')}\n".encode()
-            data += f"Fecha:  {datos.get('fecha','')}\n".encode()
-            data += sep
-            data += ESC + b"a\x00"
-            ventas = float(datos.get("ventas_totales", datos.get("total_ventas", 0)))
-            retiros = float(datos.get("retiros", 0))
-            esperado = float(datos.get("esperado", datos.get("efectivo_esperado", 0)))
-            contado = float(datos.get("contado", datos.get("efectivo_contado", 0)))
-            dif = float(datos.get("diferencia", 0))
-            data += f"Ventas:   ${ventas:>10,.2f}\n".encode()
-            data += f"Retiros:  ${retiros:>10,.2f}\n".encode()
-            data += sep
-            data += ESC + b"E\x01"
-            data += f"Esperado: ${esperado:>10,.2f}\n".encode()
-            data += f"Contado:  ${contado:>10,.2f}\n".encode()
-            data += sep
-            dif_str = (
-                "CUADRADO        " if abs(dif) < 0.01
-                else (f"FALTANTE ${abs(dif):,.2f}" if dif < 0 else f"SOBRANTE ${dif:,.2f}")
-            )
-            data += f"DIFERENCIA: {dif_str}\n".encode()
-            data += ESC + b"E\x00"
-            data += b"\n\n\n"
-            data += GS + b"V\x42\x00"
-
-            tipo = cfg.get("tipo", "").lower()
-            if "red" in tipo or ":" in ubicacion:
-                import socket
-                ip, port = ubicacion.split(":") if ":" in ubicacion else (ubicacion, "9100")
-                s = socket.socket()
-                s.settimeout(5)
-                s.connect((ip.strip(), int(port)))
-                s.sendall(bytes(data))
-                s.close()
-            elif "serial" in tipo or "com" in ubicacion.upper():
-                import serial as _ser
-                with _ser.Serial(ubicacion, 9600, timeout=3) as s:
-                    s.write(bytes(data))
-            else:
-                try:
-                    with open(ubicacion, "wb") as f:
-                        f.write(bytes(data))
-                except Exception:
-                    return False
-            return True
-        except Exception as e:
-            logger.warning("ESC/POS: %s", e)
-            return False
+        """Envía ticket ESC/POS a impresora térmica via PrinterService."""
+        if self._printer_service and self._printer_service.has_ticket_printer():
+            try:
+                payload = {
+                    "ticket_type": "caja_corte_z",
+                    "folio": f"Z-{datos.get('cierre_id', '')}",
+                    "fecha": datos.get("fecha", ""),
+                    "cajero": datos.get("cajero", ""),
+                    "cliente": "Corte de caja",
+                    "items": [],
+                    "totales": {"total_final": float(datos.get("ventas_totales", 0) or 0)},
+                    "pago": {"forma_pago": "Resumen"},
+                    "mensaje_psicologico": f"Diferencia: {float(datos.get('diferencia',0) or 0):.2f}",
+                }
+                self._printer_service.print_ticket(payload)
+                return True
+            except Exception as e:
+                logger.warning("PrinterService corte_z: %s", e)
+        return False
 
     def preview_or_print_corte(self, resultado: Dict, cajero: str, parent=None) -> None:
         """

--- a/pos_spj_v13.4/core/services/printer_service.py
+++ b/pos_spj_v13.4/core/services/printer_service.py
@@ -27,7 +27,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, Dict, Any, Callable, List
-from datetime import datetime
+from datetime import datetime, timezone
 
 logger = logging.getLogger("spj.printer")
 
@@ -57,6 +57,15 @@ class PrintJobStatus(str, Enum):
     PRINTING = "printing"
     SUCCESS = "success"
     FAILED = "failed"
+
+
+@dataclass
+class ValidationResult:
+    ok: bool
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    transport: str = ""
+    destination: str = ""
 
 
 @dataclass
@@ -345,7 +354,7 @@ class PrintQueue:
                 float(rd.get("totales", {}).get("total_final",
                       rd.get("total", 0)) or 0),
                 job.error_msg or "",
-                datetime.utcnow().isoformat(),
+                datetime.now(getattr(datetime, "UTC", timezone.utc)).isoformat(),
             ))
             try:
                 self._db.commit()
@@ -575,6 +584,62 @@ class PrinterService:
 
     def has_ticket_printer(self) -> bool:
         return bool(self._ticket_cfg.get('ubicacion', ''))
+
+    def validate_ticket_printer_config(self) -> ValidationResult:
+        cfg = self._ticket_cfg or {}
+        transport = self._resolve_transport(cfg)
+        destination = str(cfg.get("ubicacion", "") or "").strip()
+        errors: List[str] = []
+        warnings: List[str] = []
+
+        if not destination:
+            errors.append("Destino de impresora vacío.")
+
+        if transport == TransportType.SYSTEM:
+            errors.append("TransportType.SYSTEM no es válido para ticket térmico ESC/POS.")
+
+        if transport == TransportType.NETWORK:
+            if ":" not in destination:
+                errors.append("Destino TCP inválido, use formato ip:puerto.")
+        elif transport == TransportType.SERIAL:
+            if not (destination.upper().startswith("COM") or "/dev/tty" in destination):
+                errors.append("Destino serial inválido.")
+            baud = self._safe_baud(cfg.get("baud_rate", 9600))
+            if baud <= 0:
+                errors.append("Baud rate inválido.")
+        elif transport == TransportType.USB_WIN32:
+            if not destination:
+                errors.append("Nombre de impresora Win32 vacío.")
+
+        enc = str(cfg.get("encoding", "cp850") or "cp850").lower()
+        if enc not in {"cp850", "latin-1", "utf-8"}:
+            warnings.append(f"Encoding no estándar para térmica: {enc}")
+
+        return ValidationResult(
+            ok=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+            transport=transport.value,
+            destination=destination,
+        )
+
+    def print_test_ticket(self) -> str:
+        vr = self.validate_ticket_printer_config()
+        if not vr.ok:
+            logger.warning("print_test_ticket bloqueado por config inválida: %s", "; ".join(vr.errors))
+            return ""
+        payload = {
+            "ticket_type": "test_ticket",
+            "folio": "TEST-ESC-POS",
+            "fecha": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "cajero": "Sistema",
+            "cliente": "Prueba",
+            "items": [{"nombre": "Prueba impresora", "cantidad": 1, "precio_unitario": 0, "total": 0}],
+            "totales": {"subtotal": 0, "descuento": 0, "total_final": 0},
+            "pago": {"forma_pago": "N/A"},
+            "mensaje_psicologico": "Impresión de prueba ESC/POS",
+        }
+        return self.print_ticket(payload)
 
     def has_label_printer(self) -> bool:
         return bool(self._label_cfg.get('ubicacion', ''))

--- a/pos_spj_v13.4/core/services/ticket_printer_service.py
+++ b/pos_spj_v13.4/core/services/ticket_printer_service.py
@@ -4,8 +4,9 @@ Two ticket types:
   Customer ticket:  products, total, QR, payment method, notes, weight adjustments
   Driver ticket:    address, references, phone, payment method, total to collect, zone
 
-Printing backend: QPrinter (thermal or default system printer).
-Falls back to a printable QDialog preview if QPrinter is unavailable.
+Printing backend:
+  - Thermal real print: PrinterService.print_ticket (ESC/POS RAW).
+  - Preview mode: printable QDialog (visual only).
 
 All heavy Qt work happens on the caller's thread (must be GUI thread).
 """
@@ -14,6 +15,9 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any, Dict, List, Optional
+from core.tickets.ticket_print_model import (
+    TicketPrintModel, TicketItem, TicketTotals, TicketPaymentInfo, TicketBranding
+)
 
 logger = logging.getLogger("spj.services.ticket_printer")
 
@@ -32,10 +36,11 @@ class TicketPrinterService:
         Useful for testing and when a physical printer is not available.
     """
 
-    def __init__(self, db, printer_name: Optional[str] = None, preview_mode: bool = False) -> None:
+    def __init__(self, db, printer_name: Optional[str] = None, preview_mode: bool = False, printer_service=None) -> None:
         self.db = db
         self._printer_name = printer_name
         self._preview_mode = preview_mode
+        self._printer_service = printer_service
 
     # ── Public ────────────────────────────────────────────────────────────────
 
@@ -47,7 +52,8 @@ class TicketPrinterService:
             return False
         items  = self._load_items(order_id)
         text   = self._build_customer_ticket(order, items)
-        return self._output(text, f"Ticket Cliente #{order.get('folio') or order_id}")
+        model = self._build_customer_model(order, items)
+        return self._output(text, f"Ticket Cliente #{order.get('folio') or order_id}", model=model)
 
     def print_driver_ticket(self, order_id: int) -> bool:
         """Print the driver-facing ticket. Returns True if printed/previewed."""
@@ -56,7 +62,8 @@ class TicketPrinterService:
             logger.warning("TicketPrinter: order %s not found", order_id)
             return False
         text = self._build_driver_ticket(order)
-        return self._output(text, f"Ticket Repartidor #{order.get('folio') or order_id}")
+        model = self._build_driver_model(order)
+        return self._output(text, f"Ticket Repartidor #{order.get('folio') or order_id}", model=model)
 
     def print_both(self, order_id: int) -> bool:
         """Print both tickets for an order."""
@@ -177,28 +184,25 @@ class TicketPrinterService:
 
     # ── Output ────────────────────────────────────────────────────────────────
 
-    def _output(self, text: str, title: str) -> bool:
+    def _output(self, text: str, title: str, model: Optional[TicketPrintModel] = None) -> bool:
         if self._preview_mode:
             return self._show_preview_dialog(text, title)
-        return self._print_via_qt(text, title)
+        return self._print_via_escpos(text, title, model=model)
 
-    def _print_via_qt(self, text: str, title: str) -> bool:
+    def _print_via_escpos(self, text: str, title: str, model: Optional[TicketPrintModel] = None) -> bool:
+        if not self._printer_service or not self._printer_service.has_ticket_printer():
+            logger.warning("TicketPrinter thermal print blocked (%s): no ESC/POS printer configured", title)
+            return False
         try:
-            from PyQt5.QtPrintSupport import QPrinter, QPrinterInfo
-            from PyQt5.QtGui import QTextDocument, QFont
-            printer = QPrinter()
-            if self._printer_name:
-                printer.setPrinterName(self._printer_name)
-            font = QFont("Courier New", 9)
-            doc = QTextDocument()
-            doc.setDefaultFont(font)
-            doc.setPlainText(text)
-            doc.print_(printer)
-            logger.info("TicketPrinter: printed '%s'", title)
+            payload = model.to_dict() if model else {
+                "folio": title, "texto_libre": text, "items": [], "totales": {}, "plantilla": "delivery_text_ticket",
+            }
+            job_id = self._printer_service.print_ticket(payload)
+            logger.info("TicketPrinter ESC/POS queued '%s' job_id=%s", title, job_id)
             return True
         except Exception as exc:
-            logger.warning("TicketPrinter print failed (%s): %s", title, exc)
-            return self._show_preview_dialog(text, title)
+            logger.warning("TicketPrinter ESC/POS failed (%s): %s", title, exc)
+            return False
 
     def _show_preview_dialog(self, text: str, title: str) -> bool:
         try:
@@ -231,7 +235,7 @@ class TicketPrinterService:
 
             def _do_print():
                 self._preview_mode = False
-                self._print_via_qt(text, title)
+                self._print_via_escpos(text, title, model=None)
                 self._preview_mode = True
 
             btn_print.clicked.connect(_do_print)
@@ -272,3 +276,43 @@ class TicketPrinterService:
         except Exception as exc:
             logger.debug("TicketPrinter _load_items: %s", exc)
             return []
+
+    def _build_customer_model(self, order: Dict[str, Any], items: List[Dict[str, Any]]) -> TicketPrintModel:
+        model_items = [
+            TicketItem(
+                nombre=str(it.get("nombre", "Producto")),
+                cantidad=float(it.get("prepared_qty") or it.get("cantidad") or 0),
+                precio_unitario=float(it.get("precio_unitario") or 0),
+                total=float(it.get("subtotal") or 0),
+                unidad=str(it.get("unidad") or "u"),
+            ) for it in items
+        ]
+        subtotal = sum(i.total for i in model_items)
+        total = float(order.get("total") or subtotal)
+        return TicketPrintModel(
+            ticket_type="delivery_customer",
+            folio=str(order.get("folio") or f"DEL-{order.get('id','')}"),
+            fecha=str(order.get("fecha") or ""),
+            cajero="delivery",
+            cliente_nombre=str(order.get("cliente_nombre") or "Cliente"),
+            items=model_items,
+            totals=TicketTotals(subtotal=subtotal, descuento=0.0, total_final=total),
+            payment=TicketPaymentInfo(forma_pago=str(order.get("pago_metodo") or "")),
+            branding=TicketBranding(),
+            footer_message="Gracias por su preferencia",
+        )
+
+    def _build_driver_model(self, order: Dict[str, Any]) -> TicketPrintModel:
+        total = float(order.get("total") or 0)
+        return TicketPrintModel(
+            ticket_type="delivery_driver",
+            folio=str(order.get("folio") or f"DEL-{order.get('id','')}"),
+            fecha=str(order.get("fecha") or ""),
+            cajero=str(order.get("driver_nombre") or "driver"),
+            cliente_nombre=str(order.get("cliente_nombre") or "Cliente"),
+            items=[],
+            totals=TicketTotals(subtotal=total, descuento=0.0, total_final=total),
+            payment=TicketPaymentInfo(forma_pago=str(order.get("pago_metodo") or "")),
+            branding=TicketBranding(),
+            footer_message=str(order.get("direccion") or ""),
+        )

--- a/pos_spj_v13.4/core/ticket_escpos_renderer.py
+++ b/pos_spj_v13.4/core/ticket_escpos_renderer.py
@@ -29,7 +29,11 @@ from __future__ import annotations
 import io
 import logging
 import struct
+import re
 from typing import Dict, Any, List, Optional, Tuple
+from core.tickets.ticket_print_model import TicketPrintModel
+from core.tickets.ticket_layout_config import TicketLayoutConfig
+from core.tickets.branding_service import BrandingService
 
 logger = logging.getLogger("spj.escpos")
 
@@ -85,14 +89,14 @@ CHARS_BY_WIDTH = {
 class TicketESCPOSRenderer:
     """Genera bytes ESC/POS a partir de ticket_data del ERP."""
 
-    def __init__(self, paper_width_mm: int = 80, encoding: str = "utf-8"):
+    def __init__(self, paper_width_mm: int = 80, encoding: str = "cp850"):
         self.paper_width = paper_width_mm
         self.encoding = encoding
         self.chars_per_line = CHARS_BY_WIDTH.get(paper_width_mm, 48)
 
     # ── API principal ─────────────────────────────────────────────────────────
 
-    def render(self, ticket_data: Dict[str, Any],
+    def render(self, ticket_data: Dict[str, Any] | TicketPrintModel,
                logo_b64: str = "", qr_content: str = "") -> bytes:
         """
         Genera bytes ESC/POS completos listos para enviar a la impresora.
@@ -105,14 +109,18 @@ class TicketESCPOSRenderer:
         Returns:
             bytes listos para enviar via socket/serial/USB
         """
+        if isinstance(ticket_data, TicketPrintModel):
+            ticket_data = ticket_data.to_dict()
+        layout = TicketLayoutConfig.from_dict(ticket_data.get("layout_config", {})) if isinstance(ticket_data, dict) else TicketLayoutConfig()
+        w = layout.chars_per_line
+
         buf = bytearray()
-        w = self.chars_per_line
 
         # 1. Init
         buf += INIT
 
         # 2. Logo
-        if logo_b64:
+        if layout.show_logo and logo_b64:
             logo_bytes = self._render_logo(logo_b64)
             if logo_bytes:
                 buf += ALIGN_CENTER
@@ -214,7 +222,7 @@ class TicketESCPOSRenderer:
                 buf += self._text(f"Saldo total: {puntos_total} puntos")
 
         # 9. QR code
-        if qr_content:
+        if layout.show_qr and qr_content:
             qr_bytes = self._render_qr(qr_content)
             if qr_bytes:
                 buf += ALIGN_CENTER
@@ -228,8 +236,8 @@ class TicketESCPOSRenderer:
         buf += self._text("")
 
         # 11. Feed + Cut
-        buf += FEED_N + b'\x04'   # 4 líneas de avance
-        buf += CUT_PARTIAL
+        buf += FEED_N + bytes([max(0, min(10, int(layout.feed_lines)))])
+        buf += CUT_PARTIAL if layout.cut_type == "partial" else CUT_FULL
 
         return bytes(buf)
 
@@ -237,7 +245,7 @@ class TicketESCPOSRenderer:
 
     def _text(self, text: str) -> bytes:
         """Línea de texto con newline."""
-        return (text + '\n').encode(self.encoding, errors='replace')
+        return (self._sanitize_text(text) + '\n').encode(self.encoding, errors='replace')
 
     def _separator(self, width: int, char: str = '=') -> bytes:
         return (char * width + '\n').encode(self.encoding)
@@ -252,8 +260,44 @@ class TicketESCPOSRenderer:
         mid_str = middle[:mid_w].rjust(mid_w)
         right_str = right[:right_w].rjust(right_w)
 
-        line = f"{left_str}{mid_str}{right_str}\n"
+        line = f"{self._sanitize_text(left_str)}{self._sanitize_text(mid_str)}{self._sanitize_text(right_str)}\n"
         return line.encode(self.encoding, errors='replace')
+
+    def _sanitize_text(self, text: Any) -> str:
+        raw = str(text or "")
+        # remove emoji / non-BMP symbols and non-printable controls
+        raw = re.sub(r"[\U00010000-\U0010ffff]", "", raw)
+        raw = "".join(ch for ch in raw if ch == "\n" or ch == "\t" or ord(ch) >= 32)
+        return raw
+
+    def render_text_preview(self, ticket_data: Dict[str, Any] | TicketPrintModel,
+                            layout_config: Optional[TicketLayoutConfig] = None) -> str:
+        if isinstance(ticket_data, TicketPrintModel):
+            ticket_data = ticket_data.to_dict()
+        layout = layout_config or TicketLayoutConfig.from_dict(ticket_data.get("layout_config", {}))
+        w = layout.chars_per_line
+        lines: List[str] = []
+        lines.append(self._sanitize_text(ticket_data.get("empresa", "SPJ POS")).center(w)[:w])
+        if ticket_data.get("direccion"):
+            lines.append(self._sanitize_text(ticket_data.get("direccion", ""))[:w])
+        lines.append("=" * w)
+        lines.append(f"Folio: {self._sanitize_text(ticket_data.get('folio', ''))}"[:w])
+        lines.append("-" * w)
+        for item in ticket_data.get("items", []):
+            nombre = self._sanitize_text(item.get("nombre", ""))
+            qty = float(item.get("cantidad", item.get("qty", 0)) or 0)
+            total_it = float(item.get("total", item.get("subtotal", 0)) or 0)
+            left_w = max(10, w - 14)
+            for i in range(0, len(nombre), left_w):
+                chunk = nombre[i:i+left_w]
+                if i == 0:
+                    lines.append(f"{chunk:<{left_w}} {qty:>5.2f} ${total_it:>6.2f}"[:w])
+                else:
+                    lines.append(chunk[:w])
+        total = float((ticket_data.get("totales", {}) or {}).get("total_final", 0) or 0)
+        lines.append("=" * w)
+        lines.append(f"TOTAL: ${total:.2f}".rjust(w)[:w])
+        return "\n".join(lines)
 
     # ── Logo: base64 → ESC/POS bitmap ─────────────────────────────────────────
 
@@ -473,16 +517,17 @@ def render_and_print_ticket(ticket_data: Dict[str, Any],
                     "SELECT valor FROM configuraciones WHERE clave=?", (k,)).fetchone()
                 return r[0] if r and r[0] else d
 
-            logo_b64 = _cfg('ticket_logo_b64', '')
+            branding = BrandingService(db_conn=db_conn).get_ticket_branding()
+            logo_b64 = branding.logo_b64
             paper_w = int(_cfg('ticket_paper_width', '80'))
 
             if _cfg('ticket_qr_enabled', '0') == '1':
                 qr_content = _cfg('ticket_qr_url', '') or ticket_data.get('folio', '')
 
             # Enriquecer ticket_data con datos de empresa
-            ticket_data.setdefault('empresa', _cfg('nombre_empresa', 'SPJ POS'))
-            ticket_data.setdefault('direccion', _cfg('direccion', ''))
-            ticket_data.setdefault('telefono', _cfg('telefono_empresa', ''))
+            ticket_data.setdefault('empresa', branding.brand_name)
+            ticket_data.setdefault('direccion', branding.address)
+            ticket_data.setdefault('telefono', branding.phone)
         except Exception as e:
             logger.debug("render_and_print_ticket config: %s", e)
 

--- a/pos_spj_v13.4/core/tickets/__init__.py
+++ b/pos_spj_v13.4/core/tickets/__init__.py
@@ -1,0 +1,35 @@
+from .ticket_print_model import (
+    TicketPrintModel,
+    TicketItem,
+    TicketTotals,
+    TicketPaymentInfo,
+    TicketBranding,
+    TicketLoyaltyInfo,
+    TicketFomoMessage,
+    TicketQRCodeInfo,
+    TicketLayoutConfig,
+)
+from .branding_service import BrandingService, BrandingProfile
+from .ticket_layout_config import TicketLayoutConfig, TicketLayoutBlock
+from .ticket_layout_repository import TicketLayoutRepository
+from .ticket_message_engine import TicketMessageEngine, TicketMessage, TicketMessageResult
+
+__all__ = [
+    "TicketPrintModel",
+    "TicketItem",
+    "TicketTotals",
+    "TicketPaymentInfo",
+    "TicketBranding",
+    "TicketLoyaltyInfo",
+    "TicketFomoMessage",
+    "TicketQRCodeInfo",
+    "TicketLayoutConfig",
+    "BrandingService",
+    "BrandingProfile",
+    "TicketLayoutConfig",
+    "TicketLayoutBlock",
+    "TicketLayoutRepository",
+    "TicketMessageEngine",
+    "TicketMessage",
+    "TicketMessageResult",
+]

--- a/pos_spj_v13.4/core/tickets/branding_service.py
+++ b/pos_spj_v13.4/core/tickets/branding_service.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class BrandingProfile:
+    logo_b64: str = ""
+    brand_name: str = "SPJ POS"
+    address: str = ""
+    phone: str = ""
+    slogan: str = ""
+    rfc: str = ""
+    regimen_fiscal: str = ""
+
+
+class BrandingService:
+    """Source of truth for ticket branding from system config with legacy fallback."""
+
+    def __init__(self, config_service=None, db_conn=None):
+        self._config_service = config_service
+        self._db_conn = db_conn
+
+    def _get(self, key: str, default: str = "") -> str:
+        try:
+            if self._config_service is not None:
+                v = self._config_service.get(key, default)
+                return v if v not in (None, "") else default
+            if self._db_conn is not None:
+                row = self._db_conn.execute(
+                    "SELECT valor FROM configuraciones WHERE clave=?", (key,)
+                ).fetchone()
+                if row and row[0] not in (None, ""):
+                    return str(row[0])
+        except Exception:
+            return default
+        return default
+
+    def get_ticket_branding(self) -> BrandingProfile:
+        # Global first, legacy ticket_* as fallback only.
+        logo = self._get("brand_logo_b64", "") or self._get("logo_b64", "") or self._get("ticket_logo_b64", "")
+        brand_name = self._get("brand_name", "") or self._get("nombre_empresa", "SPJ POS")
+        address = self._get("brand_address", "") or self._get("direccion", "")
+        phone = self._get("brand_phone", "") or self._get("telefono_empresa", "")
+        slogan = self._get("brand_slogan", "") or self._get("eslogan", "")
+        rfc = self._get("brand_rfc", "") or self._get("rfc", "")
+        regimen = self._get("brand_regimen_fiscal", "") or self._get("regimen_fiscal", "")
+        return BrandingProfile(
+            logo_b64=logo,
+            brand_name=brand_name,
+            address=address,
+            phone=phone,
+            slogan=slogan,
+            rfc=rfc,
+            regimen_fiscal=regimen,
+        )
+
+    def enrich_legacy_ticket_data(self, ticket_data: Dict[str, Any]) -> Dict[str, Any]:
+        profile = self.get_ticket_branding()
+        ticket_data.setdefault("empresa", profile.brand_name)
+        ticket_data.setdefault("direccion", profile.address)
+        ticket_data.setdefault("telefono", profile.phone)
+        return ticket_data

--- a/pos_spj_v13.4/core/tickets/ticket_layout_config.py
+++ b/pos_spj_v13.4/core/tickets/ticket_layout_config.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List
+
+CHARS_BY_PAPER_WIDTH = {58: 32, 72: 42, 80: 48}
+DEFAULT_BLOCK_ORDER = [
+    "logo", "brand_header", "sale_info", "customer", "items", "totals", "payment", "loyalty", "fomo", "qr", "barcode", "footer", "legal"
+]
+
+
+@dataclass
+class TicketLayoutBlock:
+    enabled: bool = True
+    order: int = 0
+    alignment: str = "left"
+    style: str = "normal"
+    priority: int = 0
+
+
+@dataclass
+class TicketLayoutConfig:
+    paper_width_mm: int = 80
+    chars_per_line: int = 48
+    show_logo: bool = True
+    logo_size: str = "md"
+    logo_alignment: str = "center"
+    show_brand_name: bool = True
+    show_slogan: bool = True
+    show_address: bool = True
+    show_phone: bool = True
+    show_rfc: bool = False
+    show_customer: bool = True
+    show_loyalty: bool = True
+    show_fomo: bool = True
+    show_qr: bool = True
+    show_barcode: bool = False
+    cut_type: str = "partial"
+    feed_lines: int = 4
+    block_order: List[str] = field(default_factory=lambda: list(DEFAULT_BLOCK_ORDER))
+    blocks: Dict[str, TicketLayoutBlock] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.chars_per_line = CHARS_BY_PAPER_WIDTH.get(self.paper_width_mm, self.chars_per_line)
+        if not self.blocks:
+            self.blocks = {
+                b: TicketLayoutBlock(enabled=(b not in {"barcode"}), order=i)
+                for i, b in enumerate(self.block_order)
+            }
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["blocks"] = {k: asdict(v) for k, v in self.blocks.items()}
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TicketLayoutConfig":
+        obj = cls(**{k: v for k, v in (data or {}).items() if k != "blocks"})
+        raw_blocks = (data or {}).get("blocks") or {}
+        if raw_blocks:
+            obj.blocks = {k: TicketLayoutBlock(**v) if isinstance(v, dict) else TicketLayoutBlock() for k, v in raw_blocks.items()}
+        return obj
+
+    @classmethod
+    def from_legacy_config(cls, legacy: Dict[str, Any]) -> "TicketLayoutConfig":
+        paper_w = int(legacy.get("ticket_paper_width", 80) or 80)
+        logo_pos = str(legacy.get("ticket_logo_pos", "Centrado"))
+        pos_map = {"Centrado": "center", "Izquierda": "left", "Derecha": "right"}
+        return cls(
+            paper_width_mm=paper_w,
+            show_qr=str(legacy.get("ticket_qr_enabled", "0")) == "1",
+            show_barcode=str(legacy.get("ticket_bc_enabled", "0")) == "1",
+            logo_alignment=pos_map.get(logo_pos, "center"),
+            logo_size=str(legacy.get("ticket_logo_width", "150")),
+        )

--- a/pos_spj_v13.4/core/tickets/ticket_layout_repository.py
+++ b/pos_spj_v13.4/core/tickets/ticket_layout_repository.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+from .ticket_layout_config import TicketLayoutConfig
+
+
+class TicketLayoutRepository:
+    def __init__(self, db_conn=None, config_service=None):
+        self.db = db_conn
+        self.config_service = config_service
+
+    def _get(self, key: str, default: str = "") -> str:
+        if self.config_service is not None:
+            v = self.config_service.get(key, default)
+            return v if v not in (None, "") else default
+        if self.db is None:
+            return default
+        row = self.db.execute("SELECT valor FROM configuraciones WHERE clave=?", (key,)).fetchone()
+        return row[0] if row and row[0] else default
+
+    def _set(self, key: str, value: str) -> None:
+        if self.config_service is not None:
+            self.config_service.set(key, value)
+            return
+        if self.db is None:
+            return
+        self.db.execute("INSERT OR REPLACE INTO configuraciones(clave, valor) VALUES (?,?)", (key, value))
+        self.db.commit()
+
+    def load(self) -> TicketLayoutConfig:
+        raw = self._get("ticket_layout_config", "")
+        if raw:
+            try:
+                return TicketLayoutConfig.from_dict(json.loads(raw))
+            except Exception:
+                pass
+        legacy = {
+            "ticket_paper_width": self._get("ticket_paper_width", "80"),
+            "ticket_logo_width": self._get("ticket_logo_width", "150"),
+            "ticket_logo_pos": self._get("ticket_logo_pos", "Centrado"),
+            "ticket_qr_enabled": self._get("ticket_qr_enabled", "0"),
+            "ticket_bc_enabled": self._get("ticket_bc_enabled", "0"),
+        }
+        return TicketLayoutConfig.from_legacy_config(legacy)
+
+    def save(self, cfg: TicketLayoutConfig) -> None:
+        self._set("ticket_layout_config", json.dumps(cfg.to_dict(), ensure_ascii=False))

--- a/pos_spj_v13.4/core/tickets/ticket_message_engine.py
+++ b/pos_spj_v13.4/core/tickets/ticket_message_engine.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class TicketMessage:
+    code: str
+    text: str
+    priority: int = 0
+    category: str = "info"
+
+
+@dataclass
+class TicketMessageResult:
+    loyalty_messages: List[TicketMessage] = field(default_factory=list)
+    fomo_messages: List[TicketMessage] = field(default_factory=list)
+    cta_messages: List[TicketMessage] = field(default_factory=list)
+    qr_content: str = ""
+
+    @property
+    def all_messages(self) -> List[TicketMessage]:
+        return self.loyalty_messages + self.fomo_messages + self.cta_messages
+
+
+class TicketMessageEngine:
+    """Builds loyalty/FOMO/CTA ticket messages from business context/services."""
+
+    def __init__(
+        self,
+        loyalty_service=None,
+        growth_engine=None,
+        promotion_engine=None,
+        campaign_service=None,
+        customer_service=None,
+        config_service=None,
+    ):
+        self.loyalty_service = loyalty_service
+        self.growth_engine = growth_engine
+        self.promotion_engine = promotion_engine
+        self.campaign_service = campaign_service
+        self.customer_service = customer_service
+        self.config_service = config_service
+
+    def _cfg(self, key: str, default: str) -> str:
+        try:
+            if self.config_service is None:
+                return default
+            v = self.config_service.get(key, default)
+            return v if v not in (None, "") else default
+        except Exception:
+            return default
+
+    def build_messages(self, sale_context: Dict[str, Any], customer_context: Optional[Dict[str, Any]] = None) -> TicketMessageResult:
+        ctx = dict(customer_context or {})
+        result = TicketMessageResult()
+
+        max_fomo = int(self._cfg("ticket_fomo_max_messages", "2") or 2)
+        points_gained = int(sale_context.get("puntos_ganados", 0) or 0)
+        points_total = int(sale_context.get("puntos_totales", 0) or 0)
+        cliente_id = ctx.get("cliente_id") or sale_context.get("cliente_id")
+
+        # Complementar contextos desde servicios de negocio si falta data.
+        if cliente_id and points_total <= 0 and self.loyalty_service:
+            try:
+                if hasattr(self.loyalty_service, "saldo_cliente"):
+                    points_total = int(self.loyalty_service.saldo_cliente(int(cliente_id)) or 0)
+                elif hasattr(self.loyalty_service, "process_loyalty_for_sale"):
+                    total_sale = float(sale_context.get("total", 0) or 0)
+                    data = self.loyalty_service.process_loyalty_for_sale(int(cliente_id), total_sale)
+                    points_total = int(data.get("puntos_totales", 0) or 0)
+            except Exception:
+                pass
+
+        if cliente_id and "goal_remaining" not in ctx and self.growth_engine:
+            try:
+                if hasattr(self.growth_engine, "get_metas_activas"):
+                    metas = self.growth_engine.get_metas_activas() or []
+                    # Heurística: próxima meta activa con menor faltante.
+                    pending = []
+                    for m in metas:
+                        umbral = float(m.get("umbral", 0) or 0)
+                        progreso = float(m.get("progreso", 0) or 0)
+                        faltan = max(0, int(round(umbral - progreso)))
+                        if faltan > 0:
+                            pending.append(faltan)
+                    if pending:
+                        ctx["goal_remaining"] = min(pending)
+            except Exception:
+                pass
+
+        if "promo_days_left" not in ctx and self.promotion_engine:
+            try:
+                if hasattr(self.promotion_engine, "get_expiring_promo"):
+                    promo = self.promotion_engine.get_expiring_promo(cliente_id=cliente_id) or {}
+                    if promo:
+                        ctx["promo_days_left"] = int(promo.get("days_left", 0) or 0)
+                        ctx["promo_name"] = promo.get("name", "tu promoción")
+            except Exception:
+                pass
+
+        if points_gained > 0:
+            result.loyalty_messages.append(TicketMessage("points_gained", f"Ganaste {points_gained} puntos.", 100, "loyalty"))
+        if points_total > 0:
+            result.loyalty_messages.append(TicketMessage("points_total", f"Tu saldo actual es {points_total} puntos.", 90, "loyalty"))
+
+        goal_remaining = ctx.get("goal_remaining")
+        if goal_remaining is not None and int(goal_remaining) > 0 and int(goal_remaining) <= 5:
+            tpl = self._cfg("ticket_msg_goal_near", "Estás a {remaining} compras de tu recompensa.")
+            result.fomo_messages.append(TicketMessage("goal_near", tpl.format(remaining=int(goal_remaining)), 95, "fomo"))
+
+        points_to_reward = ctx.get("points_to_reward")
+        if points_to_reward is not None and int(points_to_reward) > 0 and int(points_to_reward) <= 50:
+            result.fomo_messages.append(TicketMessage("points_near_reward", f"Te faltan {int(points_to_reward)} puntos para tu siguiente recompensa.", 85, "fomo"))
+
+        promo_days_left = ctx.get("promo_days_left")
+        promo_name = ctx.get("promo_name", "tu promoción")
+        if promo_days_left is not None and int(promo_days_left) >= 0 and int(promo_days_left) <= 4:
+            tpl = self._cfg("ticket_msg_promo_expiring", "Últimos {days} días de {promo}.")
+            result.fomo_messages.append(TicketMessage("promo_expiring", tpl.format(days=int(promo_days_left), promo=promo_name), 98, "fomo"))
+
+        if points_total > 0 and ctx.get("can_redeem", False):
+            tpl = self._cfg("ticket_msg_points_available", "Ya puedes canjear tus puntos en tu próxima compra.")
+            result.cta_messages.append(TicketMessage("points_available", tpl, 80, "cta"))
+
+        if not cliente_id:
+            result.cta_messages.append(TicketMessage("new_customer", self._cfg("ticket_msg_new_customer", "Regístrate para acumular puntos en tu próxima compra."), 70, "cta"))
+            result.cta_messages.append(TicketMessage("register_cta", self._cfg("ticket_msg_register_cta", "Pide al cajero tu alta al programa de fidelidad."), 60, "cta"))
+
+        # tolerant to optional services
+        try:
+            if self.campaign_service and hasattr(self.campaign_service, "get_ticket_qr"):
+                result.qr_content = self.campaign_service.get_ticket_qr(cliente_id=cliente_id) or ""
+        except Exception:
+            pass
+
+        result.fomo_messages = sorted(result.fomo_messages, key=lambda m: m.priority, reverse=True)[:max_fomo]
+        return result

--- a/pos_spj_v13.4/core/tickets/ticket_print_model.py
+++ b/pos_spj_v13.4/core/tickets/ticket_print_model.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional
+
+
+CHARS_BY_PAPER_WIDTH = {58: 32, 72: 42, 80: 48}
+
+
+@dataclass
+class TicketItem:
+    nombre: str
+    cantidad: float
+    precio_unitario: float
+    total: float
+    unidad: str = "pz"
+
+
+@dataclass
+class TicketTotals:
+    subtotal: float = 0.0
+    descuento: float = 0.0
+    total_final: float = 0.0
+
+
+@dataclass
+class TicketPaymentInfo:
+    forma_pago: str = ""
+    efectivo_recibido: float = 0.0
+    cambio: float = 0.0
+
+
+@dataclass
+class TicketBranding:
+    brand_name: str = "SPJ POS"
+    address: str = ""
+    phone: str = ""
+    slogan: str = ""
+    rfc: str = ""
+    logo_b64: str = ""
+
+
+@dataclass
+class TicketLoyaltyInfo:
+    puntos_ganados: int = 0
+    puntos_totales: int = 0
+    nivel: str = ""
+
+
+@dataclass
+class TicketFomoMessage:
+    code: str
+    message: str
+    priority: int = 0
+
+
+@dataclass
+class TicketQRCodeInfo:
+    content: str
+    enabled: bool = True
+
+
+@dataclass
+class TicketLayoutConfig:
+    paper_width_mm: int = 80
+    chars_per_line: int = 48
+    show_logo: bool = True
+    logo_size: str = "md"
+    logo_alignment: str = "center"
+    show_brand_name: bool = True
+    show_slogan: bool = True
+    show_address: bool = True
+    show_phone: bool = True
+    show_rfc: bool = False
+    show_customer: bool = True
+    show_loyalty: bool = True
+    show_fomo: bool = True
+    show_qr: bool = True
+    show_barcode: bool = False
+    cut_type: str = "partial"
+    feed_lines: int = 4
+    block_order: List[str] = field(default_factory=lambda: [
+        "logo", "brand_header", "sale_info", "customer", "items", "totals", "payment", "loyalty", "fomo", "qr", "footer"
+    ])
+
+    def __post_init__(self) -> None:
+        if self.paper_width_mm in CHARS_BY_PAPER_WIDTH:
+            self.chars_per_line = CHARS_BY_PAPER_WIDTH[self.paper_width_mm]
+
+
+@dataclass
+class TicketPrintModel:
+    ticket_type: str
+    folio: str
+    fecha: str
+    cajero: str
+    cliente_nombre: str
+    items: List[TicketItem]
+    totals: TicketTotals
+    payment: TicketPaymentInfo
+    branding: TicketBranding
+    loyalty: Optional[TicketLoyaltyInfo] = None
+    fomo_messages: List[TicketFomoMessage] = field(default_factory=list)
+    qr: Optional[TicketQRCodeInfo] = None
+    footer_message: str = ""
+    layout: TicketLayoutConfig = field(default_factory=TicketLayoutConfig)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        # Legacy adapter keys for current renderer/services.
+        data["cliente"] = data.pop("cliente_nombre", "")
+        data["totales"] = data.pop("totals", {})
+        data["pago"] = data.pop("payment", {})
+        data["empresa"] = data.get("branding", {}).get("brand_name", "SPJ POS")
+        data["direccion"] = data.get("branding", {}).get("address", "")
+        data["telefono"] = data.get("branding", {}).get("phone", "")
+        loyalty = data.get("loyalty") or {}
+        data["puntos_ganados"] = loyalty.get("puntos_ganados", 0)
+        data["puntos_totales"] = loyalty.get("puntos_totales", 0)
+        if self.qr and self.qr.enabled:
+            data["qr_content"] = self.qr.content
+        return data
+
+    @classmethod
+    def from_dict(cls, src: Dict[str, Any]) -> "TicketPrintModel":
+        items = [
+            TicketItem(
+                nombre=str(it.get("nombre", "")),
+                cantidad=float(it.get("cantidad", it.get("qty", 0)) or 0),
+                precio_unitario=float(it.get("precio_unitario", it.get("unit_price", 0)) or 0),
+                total=float(it.get("total", it.get("subtotal", 0)) or 0),
+                unidad=str(it.get("unidad", "pz")),
+            )
+            for it in (src.get("items") or [])
+        ]
+        totals_src = src.get("totales") or src.get("totals") or {}
+        payment_src = src.get("pago") or src.get("payment") or {}
+        branding_src = src.get("branding") or {}
+        layout_src = src.get("layout") or {}
+
+        loyalty = None
+        if src.get("puntos_ganados") or src.get("puntos_totales"):
+            loyalty = TicketLoyaltyInfo(
+                puntos_ganados=int(src.get("puntos_ganados", 0) or 0),
+                puntos_totales=int(src.get("puntos_totales", 0) or 0),
+            )
+
+        qr = None
+        qr_content = src.get("qr_content", "")
+        if qr_content:
+            qr = TicketQRCodeInfo(content=str(qr_content), enabled=True)
+
+        return cls(
+            ticket_type=str(src.get("ticket_type", "sale")),
+            folio=str(src.get("folio", "")),
+            fecha=str(src.get("fecha", "")),
+            cajero=str(src.get("cajero", "")),
+            cliente_nombre=str(src.get("cliente", src.get("cliente_nombre", ""))),
+            items=items,
+            totals=TicketTotals(
+                subtotal=float(totals_src.get("subtotal", 0) or 0),
+                descuento=float(totals_src.get("descuento", 0) or 0),
+                total_final=float(totals_src.get("total_final", totals_src.get("subtotal", 0)) or 0),
+            ),
+            payment=TicketPaymentInfo(
+                forma_pago=str(payment_src.get("forma_pago", src.get("forma_pago", ""))),
+                efectivo_recibido=float(payment_src.get("efectivo_recibido", 0) or 0),
+                cambio=float(payment_src.get("cambio", 0) or 0),
+            ),
+            branding=TicketBranding(
+                brand_name=str(branding_src.get("brand_name", src.get("empresa", "SPJ POS"))),
+                address=str(branding_src.get("address", src.get("direccion", ""))),
+                phone=str(branding_src.get("phone", src.get("telefono", ""))),
+                slogan=str(branding_src.get("slogan", "")),
+                rfc=str(branding_src.get("rfc", "")),
+                logo_b64=str(branding_src.get("logo_b64", src.get("logo_b64", ""))),
+            ),
+            loyalty=loyalty,
+            qr=qr,
+            footer_message=str(src.get("mensaje_psicologico", src.get("footer_message", ""))),
+            layout=TicketLayoutConfig(**layout_src) if isinstance(layout_src, dict) else TicketLayoutConfig(),
+        )

--- a/pos_spj_v13.4/docs/architecture/ticket_printing_architecture.md
+++ b/pos_spj_v13.4/docs/architecture/ticket_printing_architecture.md
@@ -1,0 +1,47 @@
+# Arquitectura de Impresión de Tickets (ESC/POS)
+
+## Por qué no HTML para ticket térmico físico
+Las impresoras térmicas no renderizan HTML/CSS; requieren bytes ESC/POS RAW. HTML/QPrinter puede cortar, escalar o deformar contenido.
+
+## Ruta oficial de impresión térmica
+1. `TicketPrintModel`
+2. `TicketESCPOSRenderer`
+3. bytes ESC/POS
+4. `PrinterService.print_ticket`
+5. `PrintTransport` RAW (TCP/Serial/USB_WIN32/FILE)
+
+## Preview vs PDF vs Ticket físico
+- **Preview HTML**: aproximado, no vinculante.
+- **Preview texto ESC/POS**: aproximación monoespaciada térmica.
+- **PDF auditoría**: evidencia/documentación.
+- **Ticket físico**: solo ESC/POS RAW.
+
+## Configuración de impresora
+Usar `PrinterService.validate_ticket_printer_config()` y `print_test_ticket()`.
+- `SYSTEM` inválido para térmica.
+- TCP requiere `ip:puerto`.
+- Serial requiere `COMx` o `/dev/tty*` + baud.
+
+## Branding
+Fuente oficial: Configuración del Sistema (global) con fallback legacy controlado.
+
+## Layout por bloques
+`TicketLayoutConfig` + `TicketLayoutRepository` persistido como `ticket_layout_config`.
+Bloques: logo, header, sale_info, customer, items, totals, payment, loyalty, fomo, qr, barcode, footer, legal.
+
+## Fidelidad/FOMO
+`TicketMessageEngine` genera mensajes desde contexto/servicios de negocio (no desde UI).
+
+## Pruebas recomendadas
+- `python -m pytest tests/test_ticket_escpos_renderer.py -q`
+- `python -m pytest tests/test_printer_service_config_validation.py -q`
+- `python -m pytest tests/test_ticket_pipeline_integration.py -q`
+
+## Troubleshooting
+- **Ticket cortado**: revisar `paper_width_mm`, `feed_lines`, `cut_type`.
+- **Caracteres raros**: usar `cp850`/`latin-1`; revisar sanitización.
+- **Logo no aparece**: validar `brand_logo_b64` o fallback `ticket_logo_b64`.
+- **QR no aparece**: revisar `show_qr` y contenido QR.
+- **Impresora no responde**: validar transporte/destino con `validate_ticket_printer_config()`.
+- **Corte no funciona**: probar `cut_type` y compatibilidad del firmware.
+- **Acentos mal impresos**: ajustar encoding térmico (`cp850` recomendado).

--- a/pos_spj_v13.4/docs/audits/ticket_printing_audit.md
+++ b/pos_spj_v13.4/docs/audits/ticket_printing_audit.md
@@ -1,0 +1,26 @@
+# Auditoría de Rutas de Impresión de Tickets
+
+## Rutas térmicas correctas
+- `PrinterService.print_ticket()` + `TicketESCPOSRenderer` + `PrintTransport` RAW.
+- Delivery y caja migrados para priorizar `PrinterService`.
+
+## Rutas permitidas no térmicas
+- PDF de auditoría (`guardar_ticket_pdf`, `guardar_pdf` en corte Z).
+- Previews visuales (HTML/diálogos) sin impresión térmica directa.
+
+## Riesgos identificados
+- Persisten rutas legacy para compatibilidad (hardware fallback en caja) que deben monitorearse.
+- UI aún puede mostrar conceptos HTML avanzados; debe mantenerse el aviso de preview no vinculante.
+
+## Duplicidades
+- Configuraciones legacy coexistentes con nuevas (`ticket_*` vs `brand_*` / `ticket_layout_config`).
+
+## Criterio de ruta térmica correcta
+1. Construye modelo de ticket.
+2. Renderiza ESC/POS RAW.
+3. Envía por `PrinterService` a transporte raw.
+4. No usa `QPrinter/QTextDocument/QPrintDialog` para impresión física térmica.
+
+## Plan de corrección continuo
+- Consolidar uso total de `TicketLayoutRepository` y `TicketMessageEngine` en todos los módulos.
+- Eliminar fallbacks legacy cuando despliegue y métricas de estabilidad lo permitan.

--- a/pos_spj_v13.4/docs/user/ticket_designer_guide.md
+++ b/pos_spj_v13.4/docs/user/ticket_designer_guide.md
@@ -1,0 +1,27 @@
+# Guía de Usuario — Diseñador de Tickets
+
+## Objetivo
+Configurar experiencia de ticket para impresión térmica real por ESC/POS.
+
+## Pestañas principales
+- **Estructura**: plantilla/orden visual base + preview.
+- **Marca**: presentación de logo/QR/barcode (la identidad oficial se gestiona en Configuración del Sistema).
+- **Impresión ESC/POS**: papel, márgenes, tipografía base y prueba de impresión.
+
+## Reglas importantes
+- HTML es solo preview/PDF.
+- Impresión física usa `PrinterService.print_ticket()` (ESC/POS).
+
+## Flujo recomendado
+1. Ajustar ancho papel (58/80).
+2. Validar branding en Configuración del Sistema.
+3. Revisar preview ESC/POS monoespaciado.
+4. Ejecutar impresión de muestra térmica.
+
+## Reimpresión y auditoría
+- **Reimprimir ticket térmico**: ESC/POS.
+- **PDF auditoría**: acción separada.
+
+## Errores comunes
+- "No hay impresora térmica ESC/POS configurada": configurar hardware y destino.
+- QR/logo no visibles: revisar flags y contenido en configuración.

--- a/pos_spj_v13.4/modulos/ticket_designer.py
+++ b/pos_spj_v13.4/modulos/ticket_designer.py
@@ -19,7 +19,7 @@ from PyQt5.QtWidgets import (
     QPlainTextEdit, QTextBrowser, QSplitter, QGroupBox,
     QListWidget, QMessageBox, QFileDialog, QTabWidget,
     QFormLayout, QLineEdit, QCheckBox, QComboBox, QSpinBox,
-    QDoubleSpinBox, QScrollArea, QFrame,
+    QDoubleSpinBox, QScrollArea, QFrame, QTextEdit,
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QFont, QPixmap
@@ -83,8 +83,12 @@ class ModuloTicketDesigner(QWidget):
         btn_save_all = QPushButton("💾 Guardar todo")
         btn_save_all = create_success_button(self, btn_save_all, "Guardar configuración del ticket")
         btn_save_all.clicked.connect(self._guardar_todo)
+        btn_brand = QPushButton("⚙️ Editar identidad del sistema")
+        btn_brand = create_secondary_button(self, btn_brand, "Editar marca en Configuración del Sistema")
+        btn_brand.clicked.connect(self._abrir_configuracion_sistema)
         
         header.addWidget(btn_print)
+        header.addWidget(btn_brand)
         header.addWidget(btn_save_all)
         lay.addLayout(header)
 
@@ -92,19 +96,23 @@ class ModuloTicketDesigner(QWidget):
         tabs.setObjectName("tabWidget")
         lay.addWidget(tabs)
 
-        # Tab 1: Diseño
+        warn = QLabel("⚠️ La impresión térmica real usa ESC/POS RAW. El HTML solo sirve para preview/PDF.")
+        warn.setObjectName("caption")
+        lay.addWidget(warn)
+
+        # Tab 1: Estructura
         tab_design = QWidget()
-        tabs.addTab(tab_design, "✍️ Diseño de Plantilla")
+        tabs.addTab(tab_design, "📦 Estructura")
         self._build_tab_design(tab_design)
 
-        # Tab 2: Medios
+        # Tab 2: Marca
         tab_media = QWidget()
-        tabs.addTab(tab_media, "🖼️ Logo / QR / Barcode")
+        tabs.addTab(tab_media, "🏷️ Marca")
         self._build_tab_media(tab_media)
 
-        # Tab 3: Papel
+        # Tab 3: Impresión ESC/POS
         tab_paper = QWidget()
-        tabs.addTab(tab_paper, "📐 Papel / Impresión")
+        tabs.addTab(tab_paper, "🖨️ Impresión ESC/POS")
         self._build_tab_paper(tab_paper)
 
     def _build_tab_design(self, parent):
@@ -138,7 +146,7 @@ class ModuloTicketDesigner(QWidget):
         le.addWidget(btn_rest)
         splitter.addWidget(grp_ed)
 
-        grp_prev = QGroupBox("👁️ Vista Previa")
+        grp_prev = QGroupBox("👁️ Vista previa HTML (aproximada)")
         grp_prev.setObjectName("styledGroup")
         lp = QVBoxLayout(grp_prev)
         self.visor_preview = QTextBrowser()
@@ -146,6 +154,11 @@ class ModuloTicketDesigner(QWidget):
         self.visor_preview.setMaximumWidth(350)
         self.visor_preview.setMinimumWidth(280)
         lp.addWidget(self.visor_preview)
+        self.txt_preview_escpos = QTextEdit()
+        self.txt_preview_escpos.setReadOnly(True)
+        self.txt_preview_escpos.setObjectName("codeEditor")
+        self.txt_preview_escpos.setPlaceholderText("Preview monoespaciado ESC/POS")
+        lp.addWidget(self.txt_preview_escpos)
         splitter.addWidget(grp_prev)
         splitter.setSizes([160, 440, 340])
 
@@ -157,6 +170,9 @@ class ModuloTicketDesigner(QWidget):
         grp_logo = QGroupBox("Logo de la empresa")
         grp_logo.setObjectName("styledGroup")
         fl = QFormLayout(grp_logo)
+        lbl_brand = QLabel("Usa logo de Configuración del Sistema como fuente principal.")
+        lbl_brand.setObjectName("caption")
+        fl.addRow("", lbl_brand)
         self.lbl_logo_preview = QLabel("Sin logo cargado")
         self.lbl_logo_preview.setFixedHeight(90)
         self.lbl_logo_preview.setFixedWidth(200)
@@ -483,6 +499,37 @@ class ModuloTicketDesigner(QWidget):
             for k, v in dummy.items(): html = html.replace('{{'+k+'}}', str(v))
         wrapper = f'<div style="font-family:\'{font_fam}\',monospace;font-size:{font_sz}px;max-width:{paper_w*3}px;margin:auto;">{html}</div>'
         self.visor_preview.setHtml(wrapper)
+        self._actualizar_preview_escpos(dummy)
+
+    def _actualizar_preview_escpos(self, dummy: dict):
+        try:
+            from core.ticket_escpos_renderer import TicketESCPOSRenderer
+            payload = {
+                "empresa": dummy.get("nombre_empresa", "SPJ POS"),
+                "direccion": dummy.get("direccion", ""),
+                "telefono": dummy.get("telefono", ""),
+                "folio": dummy.get("folio", "V-99998"),
+                "fecha": dummy.get("fecha", ""),
+                "cajero": dummy.get("cajero", ""),
+                "cliente": dummy.get("cliente_nombre", ""),
+                "items": [
+                    {"nombre": "Pechuga", "cantidad": 1.5, "total": 150},
+                    {"nombre": "Pierna", "cantidad": 2.0, "total": 120},
+                ],
+                "totales": {"total_final": 250.50},
+                "layout_config": {"paper_width_mm": self.spin_paper_w.value()},
+            }
+            txt = TicketESCPOSRenderer(paper_width_mm=self.spin_paper_w.value()).render_text_preview(payload)
+            self.txt_preview_escpos.setPlainText(txt)
+        except Exception as e:
+            self.txt_preview_escpos.setPlainText(f"[preview escpos no disponible] {e}")
+
+    def _abrir_configuracion_sistema(self):
+        QMessageBox.information(
+            self,
+            "Identidad del sistema",
+            "Para cambiar logo/nombre/dirección oficiales, use el módulo Configuración del Sistema.",
+        )
 
     def restaurar_defecto(self):
         if QMessageBox.question(self,"Confirmar","¿Restaurar plantilla original?") == QMessageBox.Yes:
@@ -522,34 +569,24 @@ Puntos: +{{puntos_ganados}} | Total: {{puntos_totales}}</p>
 
     def _imprimir_muestra(self):
         try:
-            from PyQt5.QtPrintSupport import QPrinter, QPrintDialog, QPrinterInfo
-            from PyQt5.QtGui import QTextDocument
-            from PyQt5.QtCore import QSizeF
+            printer_svc = getattr(self.container, "printer_service", None)
+            if not printer_svc or not printer_svc.has_ticket_printer():
+                QMessageBox.warning(self, "Aviso", "No hay impresora térmica ESC/POS configurada.")
+                return
 
-            html = self.visor_preview.toHtml()
-            if not html or not html.strip():
-                QMessageBox.warning(self, "Aviso", "No hay contenido."); return
-
-            doc = QTextDocument(); doc.setHtml(html)
-            pw = self.spin_paper_w.value()
-            ph = self.spin_paper_h.value() or 297
-            mt = self.spin_margin_top.value()
-            ms = self.spin_margin_side.value()
-
-            dp = QPrinterInfo.defaultPrinter()
-            if dp and not dp.isNull():
-                printer = QPrinter(dp, QPrinter.HighResolution)
-            else:
-                printer = QPrinter(QPrinter.HighResolution)
-                dlg = QPrintDialog(printer, self)
-                if dlg.exec_() != QPrintDialog.Accepted: return
-
-            printer.setPageSize(QPrinter.Custom)
-            printer.setPageSizeMM(QSizeF(pw, ph))
-            printer.setPageMargins(ms, mt, ms, mt, QPrinter.Millimeter)
-            doc.print_(printer)
-            pn = dp.printerName() if dp and not dp.isNull() else "impresora"
-            QMessageBox.information(self, "✅ Impreso",
-                f"Muestra enviada a: {pn}\nPapel: {pw}×{ph}mm")
+            sample_ticket = {
+                "folio": "TST-ESC-POS",
+                "fecha": "2026-01-01 12:00:00",
+                "cajero": "Diseñador",
+                "cliente": "Cliente muestra",
+                "items": [
+                    {"nombre": "Producto Demo", "cantidad": 1, "precio_unitario": 100, "total": 100},
+                ],
+                "totales": {"subtotal": 100, "descuento": 0, "total_final": 100},
+                "forma_pago": "Prueba",
+                "plantilla": "ticket_designer_sample",
+            }
+            printer_svc.print_ticket(sample_ticket)
+            QMessageBox.information(self, "✅ Impreso", "Muestra enviada a impresora térmica ESC/POS.")
         except Exception as e:
             QMessageBox.critical(self, "Error", str(e))

--- a/pos_spj_v13.4/modulos/ventas.py
+++ b/pos_spj_v13.4/modulos/ventas.py
@@ -37,7 +37,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import Qt, QDateTime, QTimer, pyqtSignal, QLocale, QPropertyAnimation, QRect, QUrl, QSize, QStringListModel
 from PyQt5.QtGui import QIcon, QDoubleValidator, QPixmap, QImage, QColor, QTextDocument, QFont, QPalette, QBrush, QPainter
-from PyQt5.QtPrintSupport import QPrinter, QPrintDialog
+from PyQt5.QtPrintSupport import QPrinter
 
 # Importación de la clase base y utilidades
 from .base import ModuloBase
@@ -2913,109 +2913,25 @@ class ModuloVentas(ModuloBase):
         """
         Impresión de ticket unificada (v13.4 Fase 1):
         1. PrinterService → ESC/POS con logo, QR, formato completo
-        2. QPrintDialog (sistema) como fallback si no hay impresora configurada
-        3. PDF de auditoría siempre
+        2. PDF de auditoría siempre
         """
-        from PyQt5.QtPrintSupport import QPrinter, QPrintDialog
-        from PyQt5.QtGui import QTextDocument
-
-        impreso = False
-
         # ── Ruta 1: PrinterService unificado (ESC/POS) ────────────────────────
         printer_svc = getattr(self.container, 'printer_service', None)
         if printer_svc and printer_svc.has_ticket_printer():
             try:
                 job_id = printer_svc.print_ticket(datos_ticket)
                 if job_id:
-                    impreso = True
                     self.guardar_ticket_pdf(datos_ticket)
                     return
             except Exception as _e:
                 logger.warning("PrinterService: %s", _e)
-
-        # ── Ruta 3: Impresora del sistema (QPrintDialog) ──────────────────────
-        # v13.4: QTextDocument con soporte para imágenes base64
-        try:
-            html = self.generar_html_ticket(datos_ticket)
-
-            doc = QTextDocument()
-
-            # v13.4: Registrar imágenes base64 como recursos del documento
-            # QTextDocument no entiende data:image/...;base64,... directamente
-            import re, base64
-            img_counter = 0
-            def _register_b64_image(match):
-                nonlocal img_counter
-                b64_full = match.group(1)  # "data:image/png;base64,XXXX"
-                try:
-                    if ',' in b64_full:
-                        b64_data = b64_full.split(',', 1)[1]
-                    else:
-                        b64_data = b64_full
-                    img_bytes = base64.b64decode(b64_data)
-                    qimg = QImage()
-                    qimg.loadFromData(img_bytes)
-                    if not qimg.isNull():
-                        img_counter += 1
-                        res_name = f"ticket_img_{img_counter}"
-                        doc.addResource(
-                            QTextDocument.ImageResource,
-                            __import__('PyQt5.QtCore', fromlist=['QUrl']).QUrl(res_name),
-                            qimg)
-                        return f'src="{res_name}"'
-                except Exception:
-                    pass
-                return match.group(0)
-
-            html = re.sub(r'src="(data:image/[^"]+)"', _register_b64_image, html)
-            doc.setHtml(html)
-
-            # Leer config de papel — usa config_service para evitar SQL directo en UI
-            paper_w = 80; paper_h = 297; margin_top = 5; margin_side = 3
-            try:
-                _cs = getattr(self.container, 'config_service', None)
-                def _pcfg(k, d=""):
-                    if _cs:
-                        v = _cs.get(k, d)
-                        return v if v else d
-                    r = self.container.db.execute("SELECT valor FROM configuraciones WHERE clave=?", (k,)).fetchone()
-                    return r[0] if r and r[0] else d
-                try: paper_w = int(_pcfg('ticket_paper_width', '80'))
-                except: pass
-                try: paper_h = int(_pcfg('ticket_paper_height', '0')) or 297
-                except: pass
-                try: margin_top = int(_pcfg('ticket_margin_top', '5'))
-                except: pass
-                try: margin_side = int(_pcfg('ticket_margin_side', '3'))
-                except: pass
-            except Exception:
-                pass
-
-            from PyQt5.QtPrintSupport import QPrinterInfo
-            from PyQt5.QtCore import QSizeF
-            default_printer = QPrinterInfo.defaultPrinter()
-
-            if default_printer and not default_printer.isNull():
-                printer = QPrinter(default_printer, QPrinter.HighResolution)
-                printer.setPageSize(QPrinter.Custom)
-                printer.setPageSizeMM(QSizeF(paper_w, paper_h))
-                printer.setPageMargins(margin_side, margin_top, margin_side, margin_top, QPrinter.Millimeter)
-                doc.print_(printer)
-                impreso = True
-                logger.info("Ticket impreso: %s (%dx%dmm)",
-                            default_printer.printerName(), paper_w, paper_h)
-            else:
-                printer = QPrinter(QPrinter.HighResolution)
-                dlg = QPrintDialog(printer, self)
-                dlg.setWindowTitle("Imprimir Ticket")
-                if dlg.exec_() == QPrintDialog.Accepted:
-                    printer.setPageSize(QPrinter.Custom)
-                    printer.setPageSizeMM(QSizeF(paper_w, paper_h))
-                    printer.setPageMargins(margin_side, margin_top, margin_side, margin_top, QPrinter.Millimeter)
-                    doc.print_(printer)
-                    impreso = True
-        except Exception as _e:
-            logger.debug("QPrintDialog ticket: %s", _e)
+        else:
+            QMessageBox.critical(
+                self,
+                "Impresión térmica no configurada",
+                "No hay impresora térmica ESC/POS configurada.",
+            )
+            logger.warning("Ticket térmico cancelado: no hay impresora ESC/POS configurada.")
 
         # ── Ruta 4: PDF de auditoría (siempre) ───────────────────────────────
         try:
@@ -4496,7 +4412,7 @@ class ModuloVentas(ModuloBase):
 
     # ── Devolución / Cancelación ─────────────────────────────────────────────
     def _reimprimir_ultima_venta(self) -> None:
-        """Retrieves last sale data from DB and opens the print dialog."""
+        """Reimprime ticket térmico (ESC/POS) de la última venta."""
         vid = getattr(self, '_ultima_venta_id', None)
         if not vid:
             QMessageBox.warning(self, "Sin venta", "No hay venta reciente para reimprimir.")
@@ -4529,9 +4445,40 @@ class ModuloVentas(ModuloBase):
                 'empresa':  getattr(self.container, '_nombre_empresa', 'SPJ POS'),
                 'logo_path': LOGO_TICKET_PATH,
             }
-            self._imprimir_ticket_consolidado(datos_ticket)
+            # Fase 10: Reimpresión térmica separada de PDF de auditoría.
+            ps = getattr(self.container, 'printer_service', None)
+            if not ps or not ps.has_ticket_printer():
+                QMessageBox.critical(self, "Impresión térmica no configurada",
+                                     "No hay impresora térmica ESC/POS configurada.")
+                return
+            ps.print_ticket(datos_ticket)
         except Exception as e:
             QMessageBox.critical(self, "Error", str(e))
+
+    def _guardar_pdf_auditoria_ultima_venta(self) -> None:
+        """Genera PDF de auditoría de la última venta sin requerir impresora térmica."""
+        vid = getattr(self, '_ultima_venta_id', None)
+        if not vid:
+            QMessageBox.warning(self, "Sin venta", "No hay venta reciente para PDF.")
+            return
+        try:
+            db = self.container.db
+            venta = db.execute(
+                "SELECT folio, fecha, usuario, forma_pago, efectivo_recibido, cambio, total "
+                "FROM ventas WHERE id=?", (vid,)).fetchone()
+            if not venta:
+                QMessageBox.warning(self, "No encontrada", f"Venta ID {vid} no encontrada.")
+                return
+            ticket_data = {
+                'folio': venta[0], 'venta_id': venta[0], 'fecha': str(venta[1] or '')[:16],
+                'cajero': venta[2] or self.obtener_usuario_actual(), 'cliente': 'Público General',
+                'items': [], 'totales': {'subtotal': float(venta[6] or 0), 'total_final': float(venta[6] or 0)},
+                'pago': {'forma_pago': venta[3] or 'Efectivo', 'efectivo_recibido': float(venta[4] or 0), 'cambio': float(venta[5] or 0)},
+            }
+            self.guardar_ticket_pdf(ticket_data)
+            QMessageBox.information(self, "PDF auditoría", "PDF de auditoría generado correctamente.")
+        except Exception as e:
+            QMessageBox.critical(self, "Error PDF", str(e))
 
     def abrir_devolucion(self) -> None:
         """Abre el diálogo de devolución/cancelación de venta anterior."""

--- a/pos_spj_v13.4/tests/conftest.py
+++ b/pos_spj_v13.4/tests/conftest.py
@@ -3,6 +3,12 @@
 import sys, os, sqlite3, pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# Perfil de entorno consistente para la suite multi-dominio.
+os.environ.setdefault("APP_ENV", "test")
+os.environ.setdefault("SPJ_ENV_PROFILE", "test")
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("TZ", "UTC")
+
 @pytest.fixture
 def mem_db():
     """BD en memoria con esquema mínimo para tests."""

--- a/pos_spj_v13.4/tests/test_caja_ticket_uses_escpos.py
+++ b/pos_spj_v13.4/tests/test_caja_ticket_uses_escpos.py
@@ -1,0 +1,20 @@
+from core.services.caja_ticket_service import CajaTicketService
+
+
+class _Printer:
+    def __init__(self):
+        self.calls = []
+    def has_ticket_printer(self):
+        return True
+    def print_ticket(self, data):
+        self.calls.append(data)
+        return 'job-z'
+
+
+def test_caja_corte_usa_printerservice():
+    p = _Printer()
+    svc = CajaTicketService(printer_service=p)
+    ok = svc.enviar_escpos({'cierre_id': 9, 'fecha': '2026-01-01', 'cajero': 'ana', 'ventas_totales': 100, 'diferencia': 0})
+    assert ok is True
+    assert len(p.calls) == 1
+    assert p.calls[0].get('ticket_type') == 'caja_corte_z'

--- a/pos_spj_v13.4/tests/test_delivery_ticket_uses_escpos.py
+++ b/pos_spj_v13.4/tests/test_delivery_ticket_uses_escpos.py
@@ -1,0 +1,35 @@
+import sqlite3
+from core.services.ticket_printer_service import TicketPrinterService
+
+
+class _Printer:
+    def __init__(self):
+        self.calls = []
+    def has_ticket_printer(self):
+        return True
+    def print_ticket(self, data):
+        self.calls.append(data)
+        return "job-1"
+
+
+def _db():
+    c = sqlite3.connect(':memory:')
+    c.row_factory = sqlite3.Row
+    c.execute('CREATE TABLE delivery_orders(id INTEGER, folio TEXT, cliente_nombre TEXT, cliente_tel TEXT, direccion TEXT, notas TEXT, pago_metodo TEXT, total REAL, costo_envio REAL, estado TEXT, fecha TEXT, driver_id INTEGER, tiempo_estimado INTEGER)')
+    c.execute('CREATE TABLE drivers(id INTEGER, nombre TEXT)')
+    c.execute('CREATE TABLE delivery_items(id INTEGER, delivery_id INTEGER, nombre TEXT, cantidad REAL, precio_unitario REAL, subtotal REAL, unidad TEXT, prepared_qty REAL, tolerance_exceeded INTEGER)')
+    c.execute("INSERT INTO drivers VALUES(1,'R1')")
+    c.execute("INSERT INTO delivery_orders VALUES(1,'D-1','C1','555','Dir','N','Efectivo',100,0,'nuevo','2026-01-01',1,30)")
+    c.execute("INSERT INTO delivery_items VALUES(1,1,'Prod',1,100,100,'u',1,0)")
+    c.commit()
+    return c
+
+
+def test_delivery_cliente_y_repartidor_usan_printerservice():
+    p = _Printer()
+    svc = TicketPrinterService(_db(), printer_service=p)
+    assert svc.print_customer_ticket(1) is True
+    assert svc.print_driver_ticket(1) is True
+    assert len(p.calls) == 2
+    assert p.calls[0].get('ticket_type') == 'delivery_customer'
+    assert p.calls[1].get('ticket_type') == 'delivery_driver'

--- a/pos_spj_v13.4/tests/test_no_qprinter_for_thermal_tickets.py
+++ b/pos_spj_v13.4/tests/test_no_qprinter_for_thermal_tickets.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+def _read(rel: str) -> str:
+    return Path(rel).read_text(encoding="utf-8")
+
+
+def test_ventas_no_qprinter_in_thermal_print_path():
+    src = _read("modulos/ventas.py")
+    start = src.index("def _imprimir_ticket_consolidado")
+    end = src.index("def _imprimir_ticket_hardware", start)
+    fn = src[start:end]
+    assert "QPrinter" not in fn
+    assert "QTextDocument" not in fn
+    assert "No hay impresora térmica ESC/POS configurada." in fn
+
+
+def test_ticket_designer_print_sample_uses_printer_service():
+    src = _read("modulos/ticket_designer.py")
+    start = src.index("def _imprimir_muestra")
+    fn = src[start:]
+    assert "print_ticket(" in fn
+    assert "QPrinter" not in fn
+    assert "QPrintDialog" not in fn
+
+
+def test_delivery_ticket_printer_service_no_qprinter_for_physical():
+    src = _read("core/services/ticket_printer_service.py")
+    assert "def _print_via_escpos" in src
+    assert "QPrinter" not in src
+    assert "doc.print_(" not in src
+
+
+def test_pdf_audit_path_still_present_in_ventas():
+    src = _read("modulos/ventas.py")
+    assert "def guardar_ticket_pdf" in src

--- a/pos_spj_v13.4/tests/test_printer_service_config_validation.py
+++ b/pos_spj_v13.4/tests/test_printer_service_config_validation.py
@@ -1,0 +1,45 @@
+from core.services.printer_service import PrinterService
+
+
+def _svc(cfg):
+    s = PrinterService(db_conn=None)
+    s._ticket_cfg = cfg
+    return s
+
+
+def test_config_valida_tcp():
+    s = _svc({"transport": "tcp", "ubicacion": "127.0.0.1:9100", "encoding": "cp850"})
+    r = s.validate_ticket_printer_config()
+    assert r.ok is True
+
+
+def test_config_valida_serial():
+    s = _svc({"transport": "serial", "ubicacion": "COM4", "baud_rate": "9600"})
+    r = s.validate_ticket_printer_config()
+    assert r.ok is True
+
+
+def test_config_valida_usb_win32():
+    s = _svc({"transport": "usb_win32", "ubicacion": "EPSON TM-T20"})
+    r = s.validate_ticket_printer_config()
+    assert r.ok is True
+
+
+def test_config_sin_ubicacion_falla():
+    s = _svc({"transport": "tcp", "ubicacion": ""})
+    r = s.validate_ticket_printer_config()
+    assert r.ok is False
+
+
+def test_system_no_valido_para_termica():
+    s = _svc({"transport": "system", "ubicacion": "Default"})
+    r = s.validate_ticket_printer_config()
+    assert r.ok is False
+    assert any("SYSTEM" in e for e in r.errors)
+
+
+def test_print_test_ticket_genera_job(monkeypatch):
+    s = _svc({"transport": "tcp", "ubicacion": "127.0.0.1:9100", "encoding": "cp850"})
+    monkeypatch.setattr(s, "print_ticket", lambda payload: "job-test" if payload.get("ticket_type") == "test_ticket" else "")
+    job = s.print_test_ticket()
+    assert job == "job-test"

--- a/pos_spj_v13.4/tests/test_ticket_branding_from_system_config.py
+++ b/pos_spj_v13.4/tests/test_ticket_branding_from_system_config.py
@@ -1,0 +1,50 @@
+import sqlite3
+
+from core.tickets.branding_service import BrandingService
+
+
+def _db_with_config(pairs):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE configuraciones (clave TEXT PRIMARY KEY, valor TEXT)")
+    for k, v in pairs.items():
+        conn.execute("INSERT INTO configuraciones(clave, valor) VALUES (?,?)", (k, v))
+    conn.commit()
+    return conn
+
+
+def test_uses_global_logo_when_present():
+    db = _db_with_config({"brand_logo_b64": "GLOBAL", "ticket_logo_b64": "LEGACY"})
+    svc = BrandingService(db_conn=db)
+    p = svc.get_ticket_branding()
+    assert p.logo_b64 == "GLOBAL"
+
+
+def test_fallback_to_legacy_logo_if_global_missing():
+    db = _db_with_config({"ticket_logo_b64": "LEGACY"})
+    svc = BrandingService(db_conn=db)
+    p = svc.get_ticket_branding()
+    assert p.logo_b64 == "LEGACY"
+
+
+def test_brand_name_from_global_config_with_legacy_fallback():
+    db = _db_with_config({"brand_name": "Mi Marca", "nombre_empresa": "Legacy SA"})
+    svc = BrandingService(db_conn=db)
+    p = svc.get_ticket_branding()
+    assert p.brand_name == "Mi Marca"
+
+
+def test_ticket_visual_preferences_can_remain_separate():
+    db = _db_with_config({
+        "ticket_logo_width": "180",
+        "ticket_logo_pos": "Centrado",
+        "ticket_show_logo": "1",
+        "nombre_empresa": "Legacy SA",
+    })
+    svc = BrandingService(db_conn=db)
+    p = svc.get_ticket_branding()
+    assert p.brand_name == "Legacy SA"
+    row_w = db.execute("SELECT valor FROM configuraciones WHERE clave='ticket_logo_width'").fetchone()
+    row_p = db.execute("SELECT valor FROM configuraciones WHERE clave='ticket_logo_pos'").fetchone()
+    assert row_w[0] == "180"
+    assert row_p[0] == "Centrado"

--- a/pos_spj_v13.4/tests/test_ticket_designer_ui_contract.py
+++ b/pos_spj_v13.4/tests/test_ticket_designer_ui_contract.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+def _read(rel):
+    return Path(rel).read_text(encoding='utf-8')
+
+
+def test_print_sample_calls_printer_service_not_qprinter():
+    src = _read('modulos/ticket_designer.py')
+    start = src.index('def _imprimir_muestra')
+    fn = src[start:]
+    assert 'printer_svc.print_ticket(' in fn
+    assert 'QPrinter' not in fn
+
+
+def test_ui_warns_html_is_preview_only_and_has_escpos_preview():
+    src = _read('modulos/ticket_designer.py')
+    assert 'La impresión térmica real usa ESC/POS RAW' in src
+    assert 'Vista previa HTML (aproximada)' in src
+    assert 'Preview monoespaciado ESC/POS' in src
+    assert 'render_text_preview' in src
+
+
+def test_branding_message_uses_system_config_source():
+    src = _read('modulos/ticket_designer.py')
+    assert 'Usa logo de Configuración del Sistema como fuente principal.' in src

--- a/pos_spj_v13.4/tests/test_ticket_escpos_renderer.py
+++ b/pos_spj_v13.4/tests/test_ticket_escpos_renderer.py
@@ -1,0 +1,59 @@
+from core.ticket_escpos_renderer import TicketESCPOSRenderer, INIT, CUT_PARTIAL
+
+
+def _sample(show_fomo=True):
+    return {
+        "empresa": "SPJ POS",
+        "direccion": "Calle 1",
+        "telefono": "123",
+        "folio": "V-1",
+        "fecha": "2026-01-01",
+        "cajero": "admin",
+        "cliente": "Cliente 😀 Largo Nombre Muy Muy Largo",
+        "items": [
+            {"nombre": "Producto con nombre extremadamente largo para envolver columnas", "cantidad": 1, "precio_unitario": 10, "total": 10}
+        ],
+        "totales": {"subtotal": 10, "descuento": 0, "total_final": 10},
+        "puntos_ganados": 5,
+        "puntos_totales": 20,
+        "mensaje_psicologico": "Gracias 😀",
+        "layout_config": {"paper_width_mm": 58, "show_qr": False, "show_fomo": show_fomo},
+    }
+
+
+def test_bytes_start_init_and_end_cut():
+    r = TicketESCPOSRenderer()
+    b = r.render(_sample())
+    assert b.startswith(INIT)
+    assert b.endswith(CUT_PARTIAL)
+
+
+def test_total_and_points_present_when_enabled():
+    r = TicketESCPOSRenderer()
+    b = r.render(_sample())
+    t = b.decode("cp850", errors="replace")
+    assert "TOTAL: $10.00" in t
+    assert "Puntos ganados" in t
+
+
+def test_58_and_80_chars_layout():
+    r = TicketESCPOSRenderer()
+    p58 = r.render_text_preview(_sample(), None)
+    assert max(len(x) for x in p58.splitlines()) <= 32
+    s = _sample()
+    s["layout_config"] = {"paper_width_mm": 80}
+    p80 = r.render_text_preview(s, None)
+    assert max(len(x) for x in p80.splitlines()) <= 48
+
+
+def test_sanitize_emoji_and_cp850_encoding_safe():
+    r = TicketESCPOSRenderer(encoding="cp850")
+    b = r.render(_sample())
+    t = b.decode("cp850", errors="replace")
+    assert "😀" not in t
+
+
+def test_long_names_wrapped_in_preview():
+    r = TicketESCPOSRenderer()
+    p = r.render_text_preview(_sample())
+    assert "extremadamente" in p

--- a/pos_spj_v13.4/tests/test_ticket_layout_config.py
+++ b/pos_spj_v13.4/tests/test_ticket_layout_config.py
@@ -1,0 +1,47 @@
+from core.tickets.ticket_layout_config import TicketLayoutConfig
+
+
+def test_default_layout_valid():
+    cfg = TicketLayoutConfig()
+    assert cfg.paper_width_mm == 80
+    assert cfg.chars_per_line == 48
+    assert "items" in cfg.block_order
+
+
+def test_disable_logo():
+    cfg = TicketLayoutConfig(show_logo=False)
+    assert cfg.show_logo is False
+
+
+def test_disable_fomo():
+    cfg = TicketLayoutConfig(show_fomo=False)
+    assert cfg.show_fomo is False
+
+
+def test_change_block_order():
+    order = ["logo", "items", "totals", "footer"]
+    cfg = TicketLayoutConfig(block_order=order)
+    assert cfg.block_order == order
+
+
+def test_paper_width_58_and_80():
+    assert TicketLayoutConfig(paper_width_mm=58).chars_per_line == 32
+    assert TicketLayoutConfig(paper_width_mm=80).chars_per_line == 48
+
+
+def test_legacy_migration_keys():
+    cfg = TicketLayoutConfig.from_legacy_config(
+        {
+            "ticket_paper_width": "58",
+            "ticket_logo_width": "170",
+            "ticket_logo_pos": "Derecha",
+            "ticket_qr_enabled": "1",
+            "ticket_bc_enabled": "0",
+        }
+    )
+    assert cfg.paper_width_mm == 58
+    assert cfg.chars_per_line == 32
+    assert cfg.logo_size == "170"
+    assert cfg.logo_alignment == "right"
+    assert cfg.show_qr is True
+    assert cfg.show_barcode is False

--- a/pos_spj_v13.4/tests/test_ticket_message_engine.py
+++ b/pos_spj_v13.4/tests/test_ticket_message_engine.py
@@ -1,0 +1,87 @@
+from core.tickets.ticket_message_engine import TicketMessageEngine
+
+
+class _Cfg:
+    def __init__(self, d=None):
+        self.d = d or {}
+
+    def get(self, k, default=None):
+        return self.d.get(k, default)
+
+
+def test_cliente_con_meta_cercana():
+    eng = TicketMessageEngine(config_service=_Cfg())
+    r = eng.build_messages({"puntos_ganados": 25, "puntos_totales": 180}, {"cliente_id": 1, "goal_remaining": 3})
+    codes = [m.code for m in r.fomo_messages]
+    assert "goal_near" in codes
+
+
+def test_promocion_por_vencer():
+    eng = TicketMessageEngine(config_service=_Cfg())
+    r = eng.build_messages({}, {"cliente_id": 1, "promo_days_left": 2, "promo_name": "Puntos dobles"})
+    assert any("Últimos" in m.text for m in r.fomo_messages)
+
+
+def test_cliente_sin_fidelidad():
+    eng = TicketMessageEngine(config_service=_Cfg())
+    r = eng.build_messages({}, {"cliente_id": 1})
+    assert len(r.loyalty_messages) == 0
+
+
+def test_cliente_con_puntos_suficientes():
+    eng = TicketMessageEngine(config_service=_Cfg())
+    r = eng.build_messages({"puntos_totales": 220}, {"cliente_id": 1, "can_redeem": True})
+    assert any(m.code == "points_available" for m in r.cta_messages)
+
+
+def test_cliente_nuevo():
+    eng = TicketMessageEngine(config_service=_Cfg())
+    r = eng.build_messages({}, {})
+    codes = [m.code for m in r.cta_messages]
+    assert "new_customer" in codes and "register_cta" in codes
+
+
+def test_servicio_no_disponible_no_rompe():
+    eng = TicketMessageEngine(campaign_service=object(), config_service=_Cfg())
+    r = eng.build_messages({}, {"cliente_id": 1})
+    assert r is not None
+
+
+def test_maximo_mensajes_y_prioridad():
+    cfg = _Cfg({"ticket_fomo_max_messages": "2"})
+    eng = TicketMessageEngine(config_service=cfg)
+    r = eng.build_messages(
+        {"puntos_totales": 100},
+        {"cliente_id": 1, "goal_remaining": 2, "promo_days_left": 1, "promo_name": "Promo", "points_to_reward": 20},
+    )
+    assert len(r.fomo_messages) == 2
+    assert r.fomo_messages[0].priority >= r.fomo_messages[1].priority
+
+
+class _Loyalty:
+    def saldo_cliente(self, _cliente_id):
+        return 321
+
+
+class _Growth:
+    def get_metas_activas(self):
+        return [{"umbral": 10, "progreso": 8}, {"umbral": 50, "progreso": 5}]
+
+
+class _Promo:
+    def get_expiring_promo(self, cliente_id=None):
+        return {"days_left": 3, "name": "Happy Hour"}
+
+
+def test_complementa_desde_servicios_de_negocio():
+    eng = TicketMessageEngine(
+        loyalty_service=_Loyalty(),
+        growth_engine=_Growth(),
+        promotion_engine=_Promo(),
+        config_service=_Cfg(),
+    )
+    r = eng.build_messages({"cliente_id": 7}, {"cliente_id": 7})
+    codes = [m.code for m in r.fomo_messages]
+    assert any(m.code == "points_total" for m in r.loyalty_messages)
+    assert "goal_near" in codes
+    assert "promo_expiring" in codes

--- a/pos_spj_v13.4/tests/test_ticket_pipeline_integration.py
+++ b/pos_spj_v13.4/tests/test_ticket_pipeline_integration.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+from core.ticket_escpos_renderer import TicketESCPOSRenderer, INIT
+from core.tickets.ticket_print_model import (
+    TicketPrintModel, TicketItem, TicketTotals, TicketPaymentInfo, TicketBranding, TicketLoyaltyInfo,
+)
+from core.tickets.ticket_message_engine import TicketMessageEngine
+
+
+class _FakePrinterService:
+    def __init__(self, enabled=True):
+        self.enabled = enabled
+        self.calls = []
+
+    def has_ticket_printer(self):
+        return self.enabled
+
+    def print_ticket(self, payload):
+        if not self.enabled:
+            raise RuntimeError("No hay impresora térmica ESC/POS configurada.")
+        self.calls.append(payload)
+        return "job-1"
+
+
+def test_venta_modelo_renderer_printer_pipeline():
+    model = TicketPrintModel(
+        ticket_type="sale",
+        folio="V-100",
+        fecha="2026-05-27 12:00:00",
+        cajero="ana",
+        cliente_nombre="Juan",
+        items=[TicketItem(nombre="Pechuga", cantidad=1, precio_unitario=100, total=100)],
+        totals=TicketTotals(subtotal=100, descuento=0, total_final=100),
+        payment=TicketPaymentInfo(forma_pago="Efectivo", efectivo_recibido=200, cambio=100),
+        branding=TicketBranding(brand_name="SPJ", address="Dir", phone="555"),
+        loyalty=TicketLoyaltyInfo(puntos_ganados=10, puntos_totales=120),
+    )
+    engine = TicketMessageEngine()
+    msg = engine.build_messages({"puntos_ganados": 10, "puntos_totales": 120}, {"cliente_id": 1, "promo_days_left": 2, "promo_name": "Promo"})
+    assert any(m.code == "promo_expiring" for m in msg.fomo_messages)
+
+    payload = model.to_dict()
+    renderer = TicketESCPOSRenderer(paper_width_mm=80)
+    raw = renderer.render(payload)
+    assert raw.startswith(INIT)
+    assert b"TOTAL" in raw
+
+    printer = _FakePrinterService(enabled=True)
+    jid = printer.print_ticket(payload)
+    assert jid == "job-1"
+    assert len(printer.calls) == 1
+
+
+def test_error_claro_si_no_hay_impresora():
+    printer = _FakePrinterService(enabled=False)
+    try:
+        printer.print_ticket({"folio": "V-1"})
+        assert False, "expected error"
+    except RuntimeError as e:
+        assert "No hay impresora térmica ESC/POS configurada." in str(e)
+
+
+def test_pdf_auditoria_ruta_separada_sigue_disponible():
+    src = Path("modulos/ventas.py").read_text(encoding="utf-8")
+    assert "def guardar_ticket_pdf" in src
+    assert "def _guardar_pdf_auditoria_ultima_venta" in src
+
+
+def test_delivery_y_caja_usan_printerservice_en_tests_dedicados():
+    src_delivery = Path("tests/test_delivery_ticket_uses_escpos.py").read_text(encoding="utf-8")
+    src_caja = Path("tests/test_caja_ticket_uses_escpos.py").read_text(encoding="utf-8")
+    assert "delivery_customer" in src_delivery and "delivery_driver" in src_delivery
+    assert "caja_corte_z" in src_caja
+
+
+def test_no_qprinter_en_rutas_termicas_principales():
+    for rel in [
+        "modulos/ventas.py",
+        "modulos/ticket_designer.py",
+        "core/services/ticket_printer_service.py",
+    ]:
+        src = Path(rel).read_text(encoding="utf-8")
+        if rel.endswith("ventas.py"):
+            start = src.index("def _imprimir_ticket_consolidado")
+            end = src.index("def _imprimir_ticket_hardware", start)
+            src = src[start:end]
+        assert "QPrinter" not in src

--- a/pos_spj_v13.4/tests/test_ticket_print_model.py
+++ b/pos_spj_v13.4/tests/test_ticket_print_model.py
@@ -1,0 +1,59 @@
+from core.tickets.ticket_print_model import (
+    TicketPrintModel,
+    TicketItem,
+    TicketTotals,
+    TicketPaymentInfo,
+    TicketBranding,
+    TicketLayoutConfig,
+)
+
+
+def _base_model(ticket_type: str = "sale"):
+    return TicketPrintModel(
+        ticket_type=ticket_type,
+        folio="V-001",
+        fecha="2026-05-26 10:00:00",
+        cajero="admin",
+        cliente_nombre="Cliente",
+        items=[TicketItem(nombre="Prod", cantidad=1, precio_unitario=10, total=10)],
+        totals=TicketTotals(subtotal=10, descuento=0, total_final=10),
+        payment=TicketPaymentInfo(forma_pago="Efectivo", efectivo_recibido=20, cambio=10),
+        branding=TicketBranding(brand_name="SPJ", address="Dir", phone="123"),
+    )
+
+
+def test_create_sale_ticket_model():
+    m = _base_model("sale")
+    assert m.ticket_type == "sale"
+    assert m.totals.total_final == 10
+
+
+def test_create_delivery_ticket_model():
+    m = _base_model("delivery_customer")
+    assert m.ticket_type == "delivery_customer"
+
+
+def test_layout_58mm_calculates_32_chars():
+    l = TicketLayoutConfig(paper_width_mm=58)
+    assert l.chars_per_line == 32
+
+
+def test_layout_80mm_calculates_48_chars():
+    l = TicketLayoutConfig(paper_width_mm=80)
+    assert l.chars_per_line == 48
+
+
+def test_defaults_are_safe():
+    l = TicketLayoutConfig()
+    assert l.feed_lines == 4
+    assert l.cut_type == "partial"
+    assert l.show_logo is True
+
+
+def test_serialization_roundtrip_basic():
+    m = _base_model("sale")
+    d = m.to_dict()
+    restored = TicketPrintModel.from_dict(d)
+    assert restored.folio == "V-001"
+    assert restored.totals.total_final == 10
+    assert restored.branding.brand_name == "SPJ"

--- a/pos_spj_v13.4/tests/test_ticket_reprint_and_pdf_separation.py
+++ b/pos_spj_v13.4/tests/test_ticket_reprint_and_pdf_separation.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+def _read(rel):
+    return Path(rel).read_text(encoding='utf-8')
+
+
+def test_reprint_uses_printerservice_and_not_pdf_fallback():
+    src = _read('modulos/ventas.py')
+    start = src.index('def _reimprimir_ultima_venta')
+    end = src.index('def _guardar_pdf_auditoria_ultima_venta', start)
+    fn = src[start:end]
+    assert 'ps.print_ticket(datos_ticket)' in fn
+    assert 'guardar_ticket_pdf' not in fn
+
+
+def test_pdf_auditoria_is_separate_action():
+    src = _read('modulos/ventas.py')
+    assert 'def _guardar_pdf_auditoria_ultima_venta' in src
+    start = src.index('def _guardar_pdf_auditoria_ultima_venta')
+    fn = src[start:]
+    assert 'self.guardar_ticket_pdf(ticket_data)' in fn
+
+
+def test_pdf_can_be_generated_without_printer_check():
+    src = _read('modulos/ventas.py')
+    start = src.index('def _guardar_pdf_auditoria_ultima_venta')
+    fn = src[start:]
+    assert 'has_ticket_printer' not in fn


### PR DESCRIPTION
### Motivation
- Replace ad-hoc QPrinter/QTextDocument thermal printing with a single raw ESC/POS pipeline using `PrinterService` to avoid HTML-to-thermal issues and unify transports.
- Provide a structured ticket model, layout and branding source to support consistent rendering, previews and persistence of layout preferences.
- Harden encoding/emoji handling, timestamping and config validation for more reliable printing across environments.

### Description
- Introduces a `TicketPrintModel` and related dataclasses plus `TicketLayoutConfig`, `BrandingService`, `TicketMessageEngine` and repository utilities under `core/tickets/` to model tickets, branding and layout preferences.
- Refactors ticket printing flow to use `PrinterService.print_ticket()` from delivery, caja and the ticket designer, and removes direct QPrinter usage from main thermal print paths while keeping PDF-audit generation as a separate action in the ventas module.
- Enhances `TicketESCPOSRenderer` with layout-driven rendering, text sanitization (emoji/control removal), `render_text_preview`, logo/QR handling and safer feed/cut behavior; defaults thermal encoding to `cp850` for better accent support.
- Extends `PrinterService` with configuration validation (`validate_ticket_printer_config`), a `print_test_ticket()` helper and a `ValidationResult` model; persist log timestamps as timezone-aware UTC ISO8601.
- Small utilities: timezone-aware `_utc_now_iso()` for outbox timestamps (and usage in `event_outbox`), and `CajaTicketService`/`TicketPrinterService` updated to accept and use a `printer_service` abstraction.
- Adds documentation pages describing the new printing architecture and a ticket designer UI updates to surface ESC/POS preview and branding guidance.

### Testing
- Added a broad test suite under `tests/` exercising the new pipeline including `test_ticket_escpos_renderer.py`, `test_printer_service_config_validation.py`, `test_ticket_print_model.py`, `test_ticket_pipeline_integration.py`, `test_delivery_ticket_uses_escpos.py`, `test_caja_ticket_uses_escpos.py`, `test_ticket_layout_config.py`, `test_ticket_message_engine.py`, `test_ticket_branding_from_system_config.py`, `test_ticket_designer_ui_contract.py`, and integration/contract checks; tests executed with `pytest -q tests`.
- All added unit tests passed in the test run and confirmed the new rendering, model roundtrips, config validation and `PrinterService` integration (no regressions reported by the suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e8fd17948328afaa8592005e1d51)