### PR TITLE
Loyalty: idempotency for financial events, ledger-based pasivo, config/UI and repo fixes

### DIFF
--- a/pos_spj_v13.4/core/services/loyalty_service.py
+++ b/pos_spj_v13.4/core/services/loyalty_service.py
@@ -63,13 +63,16 @@ class LoyaltyService:
                 sucursal_id=self.sucursal_id, usuario=str(cajero or ""),
             )
             if estrellas > 0:
+                is_idempotent = bool(resultado.get("idempotent"))
                 awarded = int(resultado.get("puntos_otorgados", estrellas) or 0)
-                if awarded > 0:
+                if awarded > 0 and not is_idempotent:
                     # La transacción la controla el orquestador superior (SalesService/SAVEPOINT).
                     self._registrar_pasivo(awarded, venta_id, "acreditar", commit=False)
-                self._publish_puntos(cliente_id, estrellas,
-                                     resultado.get("saldo", 0), venta_id)
-                self._publish_loyalty_fin_event("LOYALTY_POINTS_EARNED", cliente_id, estrellas, venta_id, cajero)
+                if not is_idempotent:
+                    self._publish_puntos(cliente_id, estrellas,
+                                         resultado.get("saldo", 0), venta_id)
+                if not is_idempotent and awarded > 0:
+                    self._publish_loyalty_fin_event("LOYALTY_POINTS_EARNED", cliente_id, estrellas, venta_id, cajero)
             return {"estrellas_ganadas": estrellas, "saldo_actual": resultado.get("saldo", self.saldo(cliente_id)), "mensaje_gamificacion": ""}
         except Exception as e:
             logger.error("acreditar_venta: %s", e)
@@ -160,11 +163,11 @@ class LoyaltyService:
             sucursal_id=self.sucursal_id, usuario=str(cajero_id),
         )
         if resultado.get("ok"):
+            is_idempotent = bool(resultado.get("idempotent"))
             canjeadas = int(resultado.get("puntos_canjeados", 0))
-            if canjeadas > 0:
-                if not bool(resultado.get("idempotent")):
-                    # La transacción la controla el orquestador superior (SalesService/SAVEPOINT).
-                    self._registrar_pasivo(-canjeadas, venta_id, "canje", commit=False)
+            if canjeadas > 0 and not is_idempotent:
+                # La transacción la controla el orquestador superior (SalesService/SAVEPOINT).
+                self._registrar_pasivo(-canjeadas, venta_id, "canje", commit=False)
                 self._publish_loyalty_fin_event("LOYALTY_POINTS_REDEEMED", cliente_id, -canjeadas, venta_id, str(cajero_id))
         return resultado
 
@@ -377,7 +380,21 @@ class LoyaltyService:
             return 0
 
     def pasivo_financiero(self) -> Dict:
+        """
+        Calcula pasivo financiero desde `loyalty_pasivo_log` (bitácora auxiliar).
+        No representa el saldo canónico de puntos; ese saldo está en `loyalty_ledger`
+        y se consulta vía `saldo()`.
+        """
         total = self.db.execute("SELECT COALESCE(SUM(estrellas),0) FROM loyalty_pasivo_log").fetchone()[0]
+        valor = float(self._cfg("loyalty_valor_estrella", "0.10"))
+        return {"total_estrellas": int(total or 0), "valor_monetario": float((total or 0) * valor)}
+
+    def pasivo_operativo_desde_ledger(self) -> Dict:
+        """
+        Estimación operativa desde el ledger canónico (`loyalty_ledger`).
+        Útil para contraste/auditoría con `pasivo_financiero()` sin cambiar la UI actual.
+        """
+        total = self.db.execute("SELECT COALESCE(SUM(puntos),0) FROM loyalty_ledger").fetchone()[0]
         valor = float(self._cfg("loyalty_valor_estrella", "0.10"))
         return {"total_estrellas": int(total or 0), "valor_monetario": float((total or 0) * valor)}
 
@@ -533,9 +550,11 @@ class LoyaltyService:
             )
             if not app_res.get("ok", False):
                 return {"ok": False, "error": app_res.get("error", "reversa_no_aplicada")}
-            # Ajustar pasivo financiero como bitácora auxiliar
-            self._registrar_pasivo(puntos_canjeados, referencia, "reversa", commit=False)
-            self._publish_loyalty_fin_event("LOYALTY_POINTS_REVERSED", cliente_id, puntos_canjeados, referencia, usuario)
+            is_idempotent = bool(app_res.get("idempotent"))
+            if not is_idempotent:
+                # Ajustar pasivo financiero como bitácora auxiliar
+                self._registrar_pasivo(puntos_canjeados, referencia, "reversa", commit=False)
+                self._publish_loyalty_fin_event("LOYALTY_POINTS_REVERSED", cliente_id, puntos_canjeados, referencia, usuario)
             nuevo_saldo = int(app_res.get("saldo", self.saldo(cliente_id)))
             logger.info("Reversa canje cliente=%d puntos=%d ref=%s",
                         cliente_id, puntos_canjeados, referencia)

--- a/pos_spj_v13.4/modulos/fidelidad_config.py
+++ b/pos_spj_v13.4/modulos/fidelidad_config.py
@@ -317,7 +317,9 @@ class ModuloFidelidadConfig(QWidget):
                     it = QTableWidgetItem(str(val or "Nunca"))
                     if j == 2 and v is not None and int(v) > 60:
                         it.setForeground(QColor(Colors.DANGER_HOVER))
-                        it.setFont(QFont("Arial", -1, QFont.Bold))
+                        font = it.font()
+                        font.setBold(True)
+                        it.setFont(font)
                     self.tbl_riesgo.setItem(i, j, it)
 
             self.lbl_riesgo_resumen.setText(

--- a/pos_spj_v13.4/modulos/modulo_growth_engine.py
+++ b/pos_spj_v13.4/modulos/modulo_growth_engine.py
@@ -267,10 +267,15 @@ class ModuloGrowthEngine(QWidget):
 
     def _cargar_config(self):
         cfg = self._engine_para().get_growth_config()
-        self.spin_expiry.setValue(int(cfg.get("growth_expiry_dias", "90")))
-        self.spin_otp_umbral.setValue(int(cfg.get("growth_otp_umbral", "200")))
-        self.spin_costo_estrella.setValue(float(cfg.get("growth_costo_estrella", "0.80")))
-        self.spin_cap.setValue(int(float(cfg.get("growth_cap_pct", "0.50")) * 100))
+        # Compat temporal: prioriza claves canónicas loyalty_* y deja growth_* como fallback legacy.
+        expiry = cfg.get("loyalty_expiry_dias", cfg.get("growth_expiry_dias", "90"))
+        otp = cfg.get("loyalty_otp_umbral", cfg.get("growth_otp_umbral", "200"))
+        valor = cfg.get("loyalty_valor_estrella", cfg.get("growth_costo_estrella", "0.80"))
+        cap = cfg.get("loyalty_max_pct_canje", cfg.get("growth_cap_pct", "0.50"))
+        self.spin_expiry.setValue(int(expiry))
+        self.spin_otp_umbral.setValue(int(otp))
+        self.spin_costo_estrella.setValue(float(valor))
+        self.spin_cap.setValue(int(float(cap) * 100))
 
     def _guardar_config(self):
         cfg = {

--- a/pos_spj_v13.4/repositories/loyalty_repository.py
+++ b/pos_spj_v13.4/repositories/loyalty_repository.py
@@ -127,6 +127,21 @@ class LoyaltyRepository:
             )
 
     def list_referrals(self, limit: int = 50) -> List[Any]:
+        self.ensure_referrals_table()
+        return self.db.execute(
+            """
+            SELECT r.fecha, c1.nombre AS referidor, c2.nombre AS referido, r.bono_dado, r.estado
+            FROM referidos r
+            LEFT JOIN clientes c1 ON c1.id=r.referidor_id
+            LEFT JOIN clientes c2 ON c2.id=r.referido_id
+            ORDER BY r.fecha DESC LIMIT ?
+            """,
+            (int(limit),),
+        ).fetchall()
+
+    def ensure_referrals_table(self) -> None:
+        # TODO: mover este DDL a migración formal cuando el bootstrap de migraciones
+        # de fidelidad quede consolidado en todos los entornos.
         self.db.execute(
             """
             CREATE TABLE IF NOT EXISTS referidos(
@@ -139,16 +154,6 @@ class LoyaltyRepository:
             )
             """
         )
-        return self.db.execute(
-            """
-            SELECT r.fecha, c1.nombre AS referidor, c2.nombre AS referido, r.bono_dado, r.estado
-            FROM referidos r
-            LEFT JOIN clientes c1 ON c1.id=r.referidor_id
-            LEFT JOIN clientes c2 ON c2.id=r.referido_id
-            ORDER BY r.fecha DESC LIMIT ?
-            """,
-            (int(limit),),
-        ).fetchall()
 
     # ──────────────────────────────────────────────────────────────────
     # Cumpleaños / retención

--- a/pos_spj_v13.4/tests/test_loyalty_refactor_regression.py
+++ b/pos_spj_v13.4/tests/test_loyalty_refactor_regression.py
@@ -140,3 +140,85 @@ def test_growth_engine_ui_compiles():
 def test_no_ui_private_repo_access():
     src = (ROOT / 'modulos' / 'fidelidad_config.py').read_text(encoding='utf-8')
     assert '_app.repo' not in src
+
+
+def test_acreditar_venta_no_duplica_evento_financiero():
+    db = _db_basic()
+    ls = LoyaltyService(db)
+    ls._publish_loyalty_fin_event = MagicMock()
+    ls._publish_puntos = MagicMock()
+    ls.acreditar_venta(cliente_id=1, venta_id='V-DUP', cajero='u', total=100.0)
+    ls.acreditar_venta(cliente_id=1, venta_id='V-DUP', cajero='u', total=100.0)
+    c = db.execute("SELECT COUNT(*) FROM loyalty_ledger WHERE cliente_id=1 AND tipo='acumulacion' AND referencia='V-DUP'").fetchone()[0]
+    assert c == 1
+    assert ls._publish_loyalty_fin_event.call_count == 1
+    assert ls._publish_puntos.call_count == 1
+
+
+def test_canjear_no_duplica_evento_financiero():
+    db = _db_basic()
+    ls = LoyaltyService(db)
+    ls.acreditar_venta(cliente_id=1, venta_id='BASE', cajero='u', total=1000.0)
+    ls._publish_loyalty_fin_event = MagicMock()
+    ls.canjear(cliente_id=1, cajero_id=1, subtotal=500.0, estrellas=10, venta_id=123)
+    ls.canjear(cliente_id=1, cajero_id=1, subtotal=500.0, estrellas=10, venta_id=123)
+    c = db.execute("SELECT COUNT(*) FROM loyalty_ledger WHERE cliente_id=1 AND tipo='canje' AND referencia='123'").fetchone()[0]
+    assert c == 1
+    assert ls._publish_loyalty_fin_event.call_count == 1
+
+
+def test_reversar_canje_no_duplica_evento_financiero():
+    db = _db_basic()
+    ls = LoyaltyService(db)
+    ls.acreditar_venta(cliente_id=1, venta_id='V-REV-EVT-BASE', cajero='u', total=1000.0)
+    ls.canjear(cliente_id=1, cajero_id=1, subtotal=1000.0, estrellas=15, venta_id='V-REV-EVT-1')
+    ls._publish_loyalty_fin_event = MagicMock()
+    ls.reversar_canje(cliente_id=1, puntos_canjeados=15, referencia='V-REV-EVT-1', usuario='u')
+    ls.reversar_canje(cliente_id=1, puntos_canjeados=15, referencia='V-REV-EVT-1', usuario='u')
+    c = db.execute("SELECT COUNT(*) FROM loyalty_ledger WHERE cliente_id=1 AND tipo='reversa' AND referencia='reversa:V-REV-EVT-1'").fetchone()[0]
+    assert c == 1
+    assert ls._publish_loyalty_fin_event.call_count == 1
+
+
+def test_growth_engine_carga_loyalty_y_fallback_growth_claves():
+    src = (ROOT / 'modulos' / 'modulo_growth_engine.py').read_text(encoding='utf-8')
+    assert 'def _cargar_config(self):' in src
+    assert 'cfg.get("loyalty_expiry_dias", cfg.get("growth_expiry_dias", "90"))' in src
+    assert 'cfg.get("loyalty_otp_umbral", cfg.get("growth_otp_umbral", "200"))' in src
+    assert 'cfg.get("loyalty_valor_estrella", cfg.get("growth_costo_estrella", "0.80"))' in src
+    assert 'cfg.get("loyalty_max_pct_canje", cfg.get("growth_cap_pct", "0.50"))' in src
+
+
+def test_growth_engine_guardado_sigue_en_claves_canonicas_loyalty():
+    src = (ROOT / 'modulos' / 'modulo_growth_engine.py').read_text(encoding='utf-8')
+    assert '"loyalty_expiry_dias"' in src
+    assert '"loyalty_otp_umbral"' in src
+    assert '"loyalty_valor_estrella"' in src
+    assert '"loyalty_max_pct_canje"' in src
+
+
+def test_pasivo_operativo_desde_ledger_es_canonico():
+    db = _db_basic()
+    ls = LoyaltyService(db)
+    ls.acreditar_venta(cliente_id=1, venta_id='V-PASIVO-1', cajero='u', total=100.0)  # +10
+    ls.canjear(cliente_id=1, cajero_id=1, subtotal=500.0, estrellas=4, venta_id=901)  # -4
+    res = ls.pasivo_operativo_desde_ledger()
+    assert res["total_estrellas"] == 6
+    assert abs(res["valor_monetario"] - 0.6) < 1e-9
+
+
+def test_loyalty_repository_aisla_ddl_referidos_en_ensure():
+    src = (ROOT / 'repositories' / 'loyalty_repository.py').read_text(encoding='utf-8')
+    assert 'def ensure_referrals_table(self) -> None:' in src
+    assert 'def list_referrals(self, limit: int = 50) -> List[Any]:' in src
+    assert 'self.ensure_referrals_table()' in src
+    # list_referrals no debe mezclar DDL inline; el CREATE se mantiene aislado en ensure_*.
+    list_block = src.split('def list_referrals(self, limit: int = 50) -> List[Any]:', 1)[1].split('def ensure_referrals_table(self) -> None:', 1)[0]
+    assert 'CREATE TABLE IF NOT EXISTS referidos' not in list_block
+
+
+def test_fidelidad_config_no_hardcodea_qfont_arial():
+    src = (ROOT / 'modulos' / 'fidelidad_config.py').read_text(encoding='utf-8')
+    assert 'QFont("Arial"' not in src
+    assert 'font = it.font()' in src
+    assert 'font.setBold(True)' in src


### PR DESCRIPTION
### Motivation
- Evitar duplicar registros y eventos financieros cuando las operaciones de fidelidad (acreditar, canjear, reversar) se procesan varias veces por reintentos o por orquestadores externos. 
- Proveer una visión operativa del pasivo desde el ledger canónico para auditoría y contraste con la bitácora auxiliar. 
- Limpiar pequeñas filtraciones de UI/DDL y mejorar compatibilidad de claves de configuración entre módulos nuevos y legacy.

### Description
- Añadida lógica de idempotencia en `LoyaltyService` para que `acreditar_venta`, `canjear` y `reversar_canje` no vuelvan a registrar pasivo ni publicar eventos financieros cuando la respuesta del backend indica `idempotent`; también se ajustó el flujo de publicación para no emitir eventos duplicados (`_publish_puntos` y `_publish_loyalty_fin_event`).
- Agregada la función `pasivo_operativo_desde_ledger` en `LoyaltyService` para calcular una estimación del pasivo desde la tabla `loyalty_ledger`, y documentado que `pasivo_financiero` sigue leyendo `loyalty_pasivo_log`.
- En `repositories/loyalty_repository.py` se extrajo el DDL de creación de la tabla `referidos` a `ensure_referrals_table()` y `list_referrals()` ahora llama a `ensure_referrals_table()` antes de listar filas, aislando el CREATE del flujo de consulta.
- En `modulos/modulo_growth_engine.py` la carga de configuración prioriza las claves canónicas `loyalty_*` y usa `growth_*` como fallback legacy, y el guardado persiste en claves canónicas `loyalty_*`.
- En `modulos/fidelidad_config.py` se eliminó el hardcodeo de `QFont("Arial"...)` por obtener la fuente del `QTableWidgetItem` y llamar a `font.setBold(True)` para marcar filas en riesgo.
- Se añadieron varios tests en `tests/test_loyalty_refactor_regression.py` que verifican idempotencia de eventos financieros, cálculo de pasivo desde ledger, la separación del DDL en el repositorio, la compatibilidad de claves en `GrowthEngine` y la corrección de UI.

### Testing
- Ejecutado el conjunto de pruebas unitarias relevantes en `tests/test_loyalty_refactor_regression.py` incluyendo `test_acreditar_venta_no_duplica_evento_financiero`, `test_canjear_no_duplica_evento_financiero`, `test_reversar_canje_no_duplica_evento_financiero`, `test_pasivo_operativo_desde_ledger_es_canonico`, `test_growth_engine_carga_loyalty_y_fallback_growth_claves`, `test_growth_engine_guardado_sigue_en_claves_canonicas_loyalty`, `test_loyalty_repository_aisla_ddl_referidos_en_ensure` y `test_fidelidad_config_no_hardcodea_qfont_arial`.
- Todos los tests mencionados se ejecutaron y pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1693a939208328b349382e8debe6d3)