### PR TITLE
Refactor sales flow: canonical UC/DTOs, query services, payment/dialog extraction, loyalty idempotency and SALE_* events

### DIFF
--- a/docs/architecture/EVENT_CATALOG_SALES.md
+++ b/docs/architecture/EVENT_CATALOG_SALES.md
@@ -1,0 +1,196 @@
+# EVENT CATALOG — SALES (FASE 8)
+
+Fecha: 2026-05-27  
+Estado: catálogo vivo (no destructivo, sin eliminar eventos legacy).
+
+## Convenciones
+- **Canónico**: nombre recomendado objetivo.
+- **Alias legacy**: nombres existentes equivalentes.
+- **Tx**: se emite dentro de transacción/SAVEPOINT.
+- **Post-commit**: se emite fuera de tx crítica.
+- **Strict**: `publish(strict=True)` (handler puede hacer fallar operación).
+- **Idempotency key**: `operation_id` en payload o derivado.
+
+---
+
+## 1) SALE_ITEMS_PROCESS
+- **Canónico**: `SALE_ITEMS_PROCESS`
+- **Alias legacy**: `sale_items_process` (domain event string)
+- **Publisher**: `SalesService.execute_sale()`
+- **Consumers**:
+  - `SaleInventoryHandler`
+  - `SaleFinanceHandler`
+  - `CreditSaleFinanceHandler`
+- **Cuándo se emite**: después de persistir cabecera+líneas de venta.
+- **Tx/Post-commit**: **Tx (SAVEPOINT)**.
+- **Strict**: **Sí** (`strict=True`).
+- **Puede fallar operación**: **Sí**.
+- **Payload schema (actual)**:
+  - `sale_id`, `folio`, `branch_id|sucursal_id`, `total`, `user|usuario`,
+  - `client_id|cliente_id`, `payment_method`, `items[]`, `operation_id`.
+- **Idempotency key**: `operation_id`.
+- **Tablas afectadas (consumidores)**:
+  - `inventory_movements`, `movimientos_caja`, `accounts_receivable|cuentas_por_cobrar` (según handler).
+- **Riesgo de duplicidad**:
+  - reintento sin idempotencia en handlers puede duplicar movimientos.
+
+---
+
+## 2) SALE_COMPLETED
+- **Canónico**: `SALE_COMPLETED`
+- **Alias legacy**: `VENTA_COMPLETADA`, `SALE_CREATED`.
+- **Publisher**: `SalesService.execute_sale()`.
+- **Consumers**:
+  - `_sync_venta`, `_loyalty_venta` (guardado por bandera), `_audit_venta`, `_treasury_venta`, `SaleTraceHandler`.
+- **Cuándo se emite**: tras `RELEASE SAVEPOINT`.
+- **Tx/Post-commit**: **Post-commit in-memory** (+ outbox persist best-effort).
+- **Strict**: No.
+- **Puede fallar operación**: No.
+- **Payload schema (actual)**:
+  - `venta_id`, `folio`, `branch_id|sucursal_id`, `total`, `usuario`, `cliente_id`, `payment_method`,
+  - `loyalty_already_processed`, `loyalty_snapshot`, `operation_id` (en payload enriquecido/outbox).
+- **Idempotency key**: `operation_id`.
+- **Tablas afectadas**: indirectas por handlers (`financial_event_log`, `treasury_*`, trazas).
+- **Riesgo de duplicidad**:
+  - lealtad si no se respeta `loyalty_already_processed` + policy idempotente.
+
+---
+
+## 3) SALE_CANCELLED
+- **Canónico**: `SALE_CANCELLED`
+- **Alias legacy**: `VENTA_CANCELADA`.
+- **Publisher**: `SalesReversalService.cancel_sale()`.
+- **Consumers**:
+  - `SaleCancelledFinanceHandler` y trazas financieras.
+- **Cuándo se emite**: al finalizar cancelación compensatoria.
+- **Tx/Post-commit**: Post-commit async.
+- **Strict**: No.
+- **Puede fallar operación**: No (venta ya cancelada).
+- **Payload schema (actual base)**:
+  - `venta_id`, `folio`, `total`, `operation_id`, metadatos de usuario/sucursal.
+- **Idempotency key**: `operation_id`.
+- **Tablas afectadas**: `journal_entries|financial_event_log|treasury_*` por handlers.
+- **Riesgo**: doble compensación si se reprocesa sin guardia idempotente.
+
+---
+
+## 4) SALE_REFUNDED
+- **Canónico**: `SALE_REFUNDED`
+- **Alias legacy**: eventos refund internos de reversa (`VENTA_REFUND*`).
+- **Publisher**: `SalesReversalService.refund_items()`.
+- **Consumers**: finanzas/inventario/auditoría (según wiring).
+- **Cuándo**: en devolución parcial/total.
+- **Tx/Post-commit**: operación compensatoria atómica + evento post.
+- **Strict**: No.
+- **Puede fallar operación**: evento no; operación sí durante tx.
+- **Payload mínimo esperado**:
+  - `sale_id`, `refund_ids`, `amount`, `operation_id`, `items`.
+- **Idempotency key**: `operation_id`.
+- **Tablas**: `sale_refunds`, `inventory_movements`, `movimientos_caja`.
+
+---
+
+## 5) SALE_CREDIT_NOTE_ISSUED
+- **Canónico**: `SALE_CREDIT_NOTE_ISSUED`
+- **Alias legacy**: eventos de `credit_notes` en reversa.
+- **Publisher**: `SalesReversalService.issue_credit_note()`.
+- **Consumers**: finanzas/GL/trazas.
+- **Cuándo**: emisión de nota de crédito.
+- **Tx/Post-commit**: operación atómica + notificación post.
+- **Strict**: No.
+- **Payload mínimo**:
+  - `sale_id`, `credit_note_id`, `amount`, `reason`, `operation_id`.
+- **Tablas**: `credit_notes`, `movimientos_caja`, `journal_entries`.
+
+---
+
+## 6) LOYALTY_POINTS_REDEEMED
+- **Canónico**: `LOYALTY_POINTS_REDEEMED`
+- **Alias legacy**: `LOYALTY_POINTS_REDEEMED` (event_bus upper), `loyalty_points_redeemed` (domain lower).
+- **Publisher**: `LoyaltyService` (invocado desde `SaleLoyaltyPolicy.apply_redemption`).
+- **Consumers**: handlers financieros de lealtad + trazas.
+- **Cuándo**: canje aplicado.
+- **Tx/Post-commit**: idealmente dentro de tx de venta (canje atómico).
+- **Strict**: depende del publisher; normalmente no-strict async para downstream.
+- **Payload**:
+  - `cliente_id`, `puntos`, `venta_id`, `usuario|cajero_id`, `operation_id`.
+- **Idempotency key**: `operation_id:redeem`.
+- **Riesgo**: doble canje mitigado con `SaleLoyaltyPolicy`.
+
+---
+
+## 7) LOYALTY_POINTS_EARNED
+- **Canónico**: `LOYALTY_POINTS_EARNED`
+- **Alias legacy**: `LOYALTY_POINTS_EARNED` / `loyalty_points_earned`.
+- **Publisher**: `LoyaltyService` (desde `SaleLoyaltyPolicy.earn_points`).
+- **Consumers**: finanzas de lealtad + trazas.
+- **Cuándo**: acreditación postventa.
+- **Tx/Post-commit**: post-commit.
+- **Strict**: No.
+- **Payload**: `cliente_id`, `puntos`, `venta_id`, `usuario`, `operation_id`.
+- **Idempotency key**: `operation_id:earn`.
+
+---
+
+## 8) STOCK_RESERVED
+- **Canónico**: `STOCK_RESERVED`
+- **Alias legacy**: `STOCK_RESERVADO`.
+- **Publisher**: `modulos/ventas.py` al suspender venta.
+- **Consumers**: auditoría/stock reservation flows.
+- **Cuándo**: suspensión de venta.
+- **Tx/Post-commit**: fuera de tx de venta final.
+- **Strict**: No.
+- **Payload**: `venta_id`, `reserva_id`, `sucursal_id`.
+
+## 9) STOCK_RESERVATION_RELEASED
+- **Canónico**: `STOCK_RESERVATION_RELEASED`
+- **Alias legacy**: `STOCK_RESERVA_LIBERADA`.
+- **Publisher**: `modulos/ventas.py` al cancelar reserva/suspensión.
+- **Payload**: `reserva_id`, `sucursal_id`.
+
+## 10) STOCK_RESERVATION_CONFIRMED
+- **Canónico**: `STOCK_RESERVATION_CONFIRMED`
+- **Alias legacy**: `STOCK_DESCONTADO_RESERVA` (+ `VENTA_CONFIRMADA_RESERVA`).
+- **Publisher**: `modulos/ventas.py` al confirmar venta reanudada.
+- **Payload**: `reserva_id`, `sucursal_id`, `folio`.
+
+---
+
+## 11) PAYMENT_CONFIRMED
+- **Canónico**: `PAYMENT_CONFIRMED`
+- **Alias legacy**: `payment_confirmed`.
+- **Publisher**: servicios financieros/CxC.
+- **Consumers**: `PaymentTraceHandler`.
+- **Cuándo**: confirmación de cobro.
+- **Tx/Post-commit**: post-commit.
+- **Payload**: `payment_id|document_id`, `amount`, `cliente|tercero`, `operation_id`.
+
+## 12) DELIVERY_PAYMENT_CONFIRMED
+- **Canónico**: `DELIVERY_PAYMENT_CONFIRMED`
+- **Alias legacy**: `delivery_payment_confirmed`.
+- **Publisher**: delivery/finance integration.
+- **Consumers**: `DeliveryPaymentHandler` en trazas.
+- **Payload**: `order_id`, `amount`, `payment_ref`, `operation_id`.
+
+---
+
+## Decisiones de deprecación (propuesta)
+1. Mantener `VENTA_COMPLETADA` como runtime actual y documentar `SALE_COMPLETED` como nombre canónico objetivo.
+2. Mantener eventos de reservas en español por compatibilidad, introducir aliases canónicos en inglés en fase posterior.
+3. No eliminar eventos legacy en esta fase.
+
+## Riesgos de duplicidad transversales
+- Eventos equivalentes ES/EN/lowercase en coexistencia.
+- Reintentos sin idempotencia en handlers financieros.
+- Doble fidelidad (acreditación en servicio + handler) mitigado por:
+  - `loyalty_already_processed` en `VENTA_COMPLETADA`.
+  - `SaleLoyaltyPolicy` con `operation_id` por operación (`redeem/earn/reverse`).
+
+## Recomendación operativa
+- Estándar mínimo de payload para todo evento de ventas:
+  - `operation_id` (obligatorio)
+  - `sale_id|venta_id`
+  - `branch_id|sucursal_id`
+  - `usuario`
+  - `timestamp`
+- Para fases siguientes: validar schema por evento con contrato explícito (pydantic/dataclass).

--- a/docs/refactor/VENTAS_CXC_SINGLE_SOURCE_OF_TRUTH.md
+++ b/docs/refactor/VENTAS_CXC_SINGLE_SOURCE_OF_TRUTH.md
@@ -1,0 +1,167 @@
+# VENTAS — CxC Single Source of Truth (FASE 9)
+
+Fecha: 2026-05-27  
+Estado: propuesta ejecutable incremental (sin cambios destructivos de esquema en esta fase).
+
+## 1) Objetivo
+Definir una **fuente única de verdad** para CxC de ventas a crédito y evitar doble escritura entre:
+- `cuentas_por_cobrar`
+- `accounts_receivable`
+- `financial_documents`
+
+Además, alinear trazabilidad con:
+- `clientes.saldo` / `clientes.credit_balance`
+- `financial_event_log`
+- `journal_entries`
+- `movimientos_caja`
+- `treasury_ledger`
+- `treasury_movements`
+
+---
+
+## 2) Hallazgos de auditoría técnica
+
+### 2.1 Escrituras CxC detectadas
+1. **Ruta de venta principal** (`SalesService.execute_sale`) no crea CxC directa; delega a handlers de `SALE_ITEMS_PROCESS`.
+2. `CreditSaleFinanceHandler` está suscrito a `SALE_ITEMS_PROCESS` (prioridad 85) y es el punto más cercano a writer canónico para CxC de venta crédito.
+3. Existen servicios alternos capaces de crear deuda/documento:
+   - `AccountsReceivableService` → `accounts_receivable`
+   - `FinancialDocumentService` → `financial_documents`
+4. `FinanceService` y módulos financieros consultan múltiples tablas (legacy + nuevas), generando riesgo de lectura inconsistente.
+
+### 2.2 Riesgo de doble CxC
+Riesgo alto de duplicidad cuando:
+- un flujo crea CxC en `cuentas_por_cobrar` vía handler;
+- otro flujo vuelve a crear deuda equivalente en `accounts_receivable` o `financial_documents`.
+
+### 2.3 Saldos de cliente
+- `clientes.saldo` y aliases como `credit_balance` funcionan como snapshot/read model,
+  pero no deben ser tratados como ledger canónico de CxC.
+
+---
+
+## 3) Decisión arquitectónica (FASE 9)
+
+## 3.1 Tabla canónica temporal (runtime actual)
+**`cuentas_por_cobrar`**
+
+Motivo:
+- ya está integrada al flujo de venta crédito vía `CreditSaleFinanceHandler` en `SALE_ITEMS_PROCESS`;
+- participa en el momento transaccional correcto de la venta;
+- minimiza riesgo de romper operación actual.
+
+## 3.2 Tabla canónica futura (target)
+**`financial_documents`** (document ledger unificado)
+
+Motivo:
+- modelo unificado para CxC/CxP;
+- soporte explícito de `operation_id` idempotente;
+- mejor trazabilidad ERP y convergencia contable.
+
+## 3.3 Writer único permitido (regla)
+**Solo `CreditSaleFinanceHandler` debe crear CxC automática por venta crédito, dentro de `SALE_ITEMS_PROCESS`**.
+
+Prohibido (durante fase incremental):
+- crear CxC de venta crédito directamente desde UI;
+- duplicar CxC desde `SalesService` post-commit;
+- recrear documento equivalente por otro handler sin verificación por `operation_id`.
+
+---
+
+## 4) Política de coexistencia (sin ruptura)
+
+1. `cuentas_por_cobrar` = **source of truth temporal** para venta crédito POS.
+2. `accounts_receivable` y/o `financial_documents` = **read model / compatibilidad** mientras dura migración.
+3. Cualquier proceso de espejo (sync) debe ser **idempotente por `operation_id`** y nunca crear segundo documento económico.
+4. En reportes, priorizar una sola fuente por reporte y etiquetar origen de datos.
+
+---
+
+## 5) Estrategia anti-duplicidad
+
+## 5.1 Llave idempotente obligatoria
+Para CxC de venta crédito:
+- `operation_id` derivado de la venta (`sale_operation_id` o `sale_id + tipo_evento`).
+
+## 5.2 Constraint recomendado
+Agregar constraint único en writer canónico (cuando aplique migración SQL):
+- `UNIQUE(operation_id)` en tabla de CxC canónica.
+- Si no existe `operation_id`, usar llave compuesta temporal: `(venta_id, tipo_documento)`.
+
+## 5.3 Guardrail en handlers
+`CreditSaleFinanceHandler` debe:
+- verificar existencia previa por `operation_id` antes de insertar;
+- registrar no-op idempotente si reintento detectado;
+- no lanzar segunda escritura de deuda.
+
+---
+
+## 6) Reconciliación de saldos de cliente
+
+### 6.1 Fuente de cálculo de saldo usado
+`SUM(saldo_pendiente)` de CxC canónica (temporal: `cuentas_por_cobrar`).
+
+### 6.2 `clientes.saldo` / `credit_balance`
+Tratar como cache/read projection.
+
+### 6.3 Job de conciliación recomendado
+- recalcular saldo de cliente desde CxC canónica;
+- comparar contra `clientes.saldo`;
+- registrar diferencias en `financial_event_log` con tipo `CXC_RECONCILIATION`.
+
+---
+
+## 7) Casos de pago y criterio financiero
+
+1. **Venta contado**
+   - no crea CxC.
+   - registra ingreso en caja/tesorería según policy.
+
+2. **Venta crédito**
+   - crea una sola CxC en writer canónico (handler crédito).
+
+3. **Mercado Pago pendiente**
+   - no registra ingreso definitivo hasta confirmación de pago.
+   - no debe crear CxC de crédito comercial salvo regla explícita de negocio.
+
+4. **Reintento con mismo `operation_id`**
+   - no duplica CxC ni movimientos financieros.
+
+---
+
+## 8) Plan de implementación incremental
+
+## Paso 1 (inmediato)
+- Bloquear nuevos writers de CxC fuera de handler canónico.
+- Documentar tabla canónica temporal por módulo/report.
+
+## Paso 2
+- Instrumentar/verificar idempotencia `operation_id` en `CreditSaleFinanceHandler`.
+- Añadir pruebas de reintento.
+
+## Paso 3
+- Definir bridge controlado `cuentas_por_cobrar -> financial_documents` (one-way, idempotente).
+
+## Paso 4
+- Migrar reportes a `financial_documents` cuando cobertura sea completa.
+
+---
+
+## 9) Tests mínimos requeridos (aceptación Fase 9)
+
+1. `venta_credito_crea_una_sola_cxc`
+2. `reintento_mismo_operation_id_no_duplica_cxc`
+3. `venta_contado_no_crea_cxc`
+4. `mercadopago_pendiente_no_registra_ingreso_hasta_confirmacion`
+
+> Nota: en esta fase documental no se altera esquema; los tests se implementan en fases de endurecimiento financiero/eventos.
+
+---
+
+## 10) Riesgos abiertos
+
+1. Coexistencia prolongada de múltiples tablas CxC.
+2. Reportes que mezclan fuentes sin indicar precedencia.
+3. Handlers legacy sin control de idempotencia fuerte.
+
+Mitigación: reforzar `operation_id`, unificar writer y mantener catálogo de eventos financiero asociado.

--- a/docs/refactor/VENTAS_REFACTOR_AUDIT.md
+++ b/docs/refactor/VENTAS_REFACTOR_AUDIT.md
@@ -1,0 +1,317 @@
+# VENTAS — Auditoría de Refactor (FASE 0)
+
+Fecha: 2026-05-27  
+Alcance auditado:
+- `pos_spj_v13.4/modulos/ventas.py`
+- `pos_spj_v13.4/core/use_cases/venta.py`
+- `pos_spj_v13.4/core/services/sales_service.py`
+- `pos_spj_v13.4/core/services/sales_reversal_service.py`
+- `pos_spj_v13.4/core/events/domain_events.py`
+- `pos_spj_v13.4/core/events/event_bus.py`
+- referencias de eventos/handlers en `core/events/wiring.py` y flujos relacionados detectados por búsqueda.
+
+> **Importante (FASE 0):** este documento solo mapea riesgos y propone migración incremental. No se cambió lógica de negocio.
+
+---
+
+## 1) Métodos en `modulos/ventas.py` con SQL directo
+
+### Lectura (SELECT)
+- `actualizar_completer_model` (consulta clientes para autocompletado).
+- `_cargar_categorias` (consulta categorías desde `productos`).
+- `cargar_productos_interactivos` (consulta catálogo/productos y stock mostrado).
+- `_cargar_hardware_config` (consulta configuración de hardware/ticket).
+- `_log_scan` (consulta `trazabilidad_qr`).
+- `_reimprimir_ultima_venta` (consulta `ventas` y `detalles_venta`).
+- `_guardar_pdf_auditoria_ultima_venta` (consulta `ventas`).
+- `_buscar` (consulta `ventas` y detalle para soporte de cancelación).
+- `_cfg` (consulta configuraciones de ticket).
+
+### Escritura (INSERT/UPDATE/COMMIT)
+- `guardar_nuevo_cliente`:
+  - `INSERT INTO clientes`
+  - `INSERT OR IGNORE INTO tarjetas_fidelidad`
+  - `commit()` directo desde UI
+- `_cancelar` mantiene explícitamente una protección para **no** hacer `UPDATE` directo de estado (correcto como guardrail), pero evidencia que antes existía esa ruta.
+
+**Riesgo:** Alto. Mezcla UI + persistencia con commits directos en pantalla de ventas.
+**Prioridad:** P0–P1.
+
+---
+
+## 2) Métodos que modifican estado de dominio desde UI (`modulos/ventas.py`)
+
+### Carrito
+- `agregar_al_carrito`, `eliminar_producto_carrito`, `cancelar_venta`, `_quitar_descuento_item`, `_quitar_descuento_por_uid`, `_descuento_rapido`, `_descuento_custom`, `actualizar_tabla_compras`.
+
+### Cliente/Fidelidad
+- `seleccionar_cliente`, `limpiar_cliente`, `guardar_nuevo_cliente`.
+- En flujo de cobro hay actualización visual de puntos y consultas de saldo post-venta.
+
+### Pagos/Descuentos
+- `cobrar_venta` (orquesta diálogo, arma payload, rutas alternas UC/servicio legacy).
+- `_descuento_rapido`, `_descuento_custom`.
+
+### Tickets
+- `_imprimir_ticket_consolidado`, `_imprimir_ticket_hardware`, `generar_ticket`, `guardar_ticket_pdf`, `generar_html_ticket`, `_reimprimir_ultima_venta`, `_guardar_pdf_auditoria_ultima_venta`.
+
+### Reservas
+- `suspender_venta` (reserva stock y publica eventos de reserva).
+- `reanudar_venta`.
+- `cancelar_venta` (libera reserva activa y publica eventos).
+
+### Inventario
+- Verificación de stock previa al agregado de carrito y uso de `stock_reservas` en suspensión/confirmación/cancelación.
+
+**Riesgo:** Alto por cohesión baja y reglas de negocio distribuidas.
+**Prioridad:** P0.
+
+---
+
+## 3) Métodos que llaman directamente a `SalesService`
+
+En `modulos/ventas.py`:
+- `cobrar_venta`:
+  - Ruta preferida: `ProcesarVentaUC.ejecutar(...)`.
+  - Fallback legacy: `self.container.sales_service.execute_sale(...)`.
+
+En `core/use_cases/venta.py`:
+- `ProcesarVentaUC.ejecutar` invoca `self._sales.execute_sale(...)` como backend transaccional.
+
+**Riesgo:** Medio-Alto por doble ruta efectiva (UC vs fallback directo).
+**Prioridad:** P0.
+
+---
+
+## 4) Métodos que **deberían** llamar canónicamente a `ProcesarVentaUC`
+
+- `modulos/ventas.py::cobrar_venta` (ya lo intenta, pero mantiene bypass).
+- Cualquier adapter externo que hoy llame `SalesService.execute_sale` directamente (WhatsApp/delivery/webhook) debe converger a UC + adapters de compatibilidad.
+
+**Gap actual:** existe fallback directo a `sales_service.execute_sale` en UI.
+
+---
+
+## 5) Métodos que mezclan UI + lógica de negocio
+
+Críticos en `modulos/ventas.py`:
+- `cobrar_venta` (armado de payload, selección de ruta, reglas de crédito/pago/puntos, impresión, reservas, publicación de eventos).
+- `actualizar_totales` (cálculo subtotal/descuento/total/puntos en UI).
+- `agregar_al_carrito` (stock + pricing por ítem + UID + reglas de agregado).
+- `guardar_nuevo_cliente` (persistencia transaccional desde UI).
+- `suspender_venta` / `reanudar_venta` / `cancelar_venta` (reglas de reserva + eventos).
+- bloque de ticketing (`generar_html_ticket`, impresión, PDF) con consulta de configuración.
+
+**Riesgo:** Alto.
+**Prioridad:** P0–P1.
+
+---
+
+## 6) Duplicados detectados (fuentes múltiples de verdad)
+
+### Cálculo de total / descuentos
+- UI (`ventas.py`) calcula totales y descuentos para display y payload.
+- UC (`ProcesarVentaUC`) recalcula subtotal/total.
+- `SalesService` vuelve a normalizar/calcular internamente.
+
+### Cálculo de cambio / pago
+- UI/diálogo de pago calcula y valida preview.
+- `SalesService.execute_sale` valida pago final.
+
+### Puntos fidelidad
+- UI calcula/preview de puntos y actualiza labels.
+- `SalesService` aplica canje y/o acredita según flujo.
+- documentación/comentarios indican handlers post-venta potencialmente acreditan también.
+
+### Validación de stock
+- UI valida antes de agregar/cobrar.
+- UC valida pre-chequeo.
+- `SalesService` valida en la transacción de venta.
+
+### Validación de crédito
+- UI prepara datos de crédito.
+- `SalesService` valida y registra condiciones financieras.
+
+### Generación de ticket
+- `SalesService.execute_sale` retorna ticket.
+- UC regenera ticket si falta.
+- UI vuelve a construir/imprimir/guardar ticket.
+
+**Riesgo:** Alto por divergencia e inconsistencias.
+**Prioridad:** P0.
+
+---
+
+## 7) Eventos publicados por ventas (mapa actual)
+
+### Desde `SalesService` / flujo transaccional
+- `SALE_ITEMS_PROCESS` (evento transaccional estricto, dentro de savepoint/tx).
+- `VENTA_COMPLETADA`/aliases `SALE_COMPLETED` (post-commit/downstream).
+
+### Desde UI (`modulos/ventas.py`) en reservas/suspensión
+- `VENTA_SUSPENDIDA`
+- `STOCK_RESERVADO`
+- `VENTA_CONFIRMADA_RESERVA`
+- `STOCK_DESCONTADO_RESERVA`
+- `VENTA_SUSPENDIDA_CANCELADA`
+- `STOCK_RESERVA_LIBERADA`
+
+### Desde reversas (`sales_reversal_service.py`)
+- `VENTA_CANCELADA`
+- (y equivalentes de refund/credit note según `_fire_event` por operación)
+
+### Catálogo y alias (`domain_events.py` + `event_bus.py`)
+- coexistencia de nombres legacy ES, aliases EN y eventos lowercase modernos (`loyalty_points_*`, etc.).
+
+**Riesgo:** Medio-Alto (semánticas solapadas y ambigüedad tx vs post-commit).
+**Prioridad:** P1.
+
+---
+
+## 8) Handlers que escuchan eventos de venta (resumen)
+
+Se detecta en wiring/event system:
+- handlers financieros/caja/tesorería atados a `VENTA_COMPLETADA`.
+- handlers potenciales de fidelidad post-venta.
+- handlers de inventario/proceso de ítems sobre `SALE_ITEMS_PROCESS` (strict).
+
+**Riesgo clave:** posible doble efecto si una misma responsabilidad vive en `SalesService` y en handler post-evento.
+**Prioridad:** P0–P1.
+
+---
+
+## 9) Tablas escritas durante una venta (consolidado de rutas detectadas)
+
+### Núcleo venta
+- `ventas`
+- `detalles_venta`
+- `payments`
+
+### Inventario / reservas
+- `inventory_movements` (vía handlers/engine)
+- tablas de reservas (vía servicio de reservas de stock)
+
+### Caja/finanzas
+- `movimientos_caja`
+- posibles rutas: `financial_documents`, `accounts_receivable`/`cuentas_por_cobrar`, `journal_entries`, `treasury_*` (según handler/servicio conectado)
+
+### Fidelidad
+- `clientes` (puntos)
+- `historico_puntos`
+
+### Sincronización/auxiliares
+- tablas de sync/outbox según integración activa.
+
+**Riesgo:** Alto por multiplicidad de writers.
+**Prioridad:** P0.
+
+---
+
+## 10) Tablas escritas durante cancelación/devolución (`sales_reversal_service.py`)
+
+- `ventas` (estado)
+- `sale_refunds`
+- `credit_notes`
+- `movimientos_caja`
+- `inventory_movements` (vía `InventoryEngine`)
+- `clientes` (reversión de puntos)
+- `historico_puntos`
+
+**Riesgo:** Alto. `SalesReversalService` toca inventario + caja + fidelidad de forma directa; requiere políticas/servicios canónicos para evitar duplicidad.
+**Prioridad:** P0.
+
+---
+
+## Matriz de riesgo y prioridad
+
+| Hallazgo | Riesgo | Impacto | Prioridad |
+|---|---:|---:|---:|
+| SQL y commit directo en UI ventas | Alto | Alto | P0 |
+| Doble ruta de cobro (UC + SalesService directo) | Alto | Alto | P0 |
+| Duplicidad de cálculo total/pago/stock/puntos | Alto | Alto | P0 |
+| Doble acreditación/canje de fidelidad potencial | Alto | Alto | P0 |
+| Ambigüedad de eventos (legacy/alias/lowercase) | Medio-Alto | Alto | P1 |
+| Escrituras financieras paralelas CxC | Alto | Alto | P0 |
+| Reversas con responsabilidades cruzadas | Alto | Alto | P0 |
+
+---
+
+## Propuesta de migración incremental (sin ruptura)
+
+1. **Canonizar entrada:** forzar `ProcesarVentaUC` como puerta de entrada y dejar adapter legacy explícito temporal.
+2. **Separar lectura UI:** extraer query services de productos/clientes y reemplazar SELECT de `ventas.py` por llamadas a servicio.
+3. **Centralizar cálculos:** `CartCalculator` + `PaymentPolicy` + DTOs canónicos.
+4. **Unificar fidelidad:** una sola política (preview, redeem, earn, reverse) con `operation_id`.
+5. **Endurecer `SalesService.execute_sale`:** orquestador legible + límites tx/post-commit claros.
+6. **Catalogar eventos:** canonical names, aliases, strictness, idempotencia, payload.
+7. **Unificar CxC:** un solo writer para venta crédito (handler financiero canónico).
+8. **Reversas compensatorias idempotentes:** delegación por dominio (inventario/finanzas/fidelidad).
+9. **Limpieza progresiva de UI:** extraer dialogs/controllers/widgets manteniendo adapters.
+
+---
+
+## Checklist por fase (ejecutable)
+
+### Fase 0 (esta entrega)
+- [x] Auditoría automática de SQL en `ventas.py`.
+- [x] Mapeo de duplicidades de reglas y rutas de venta.
+- [x] Mapeo de eventos y riesgos.
+- [x] Documento de auditoría en `docs/refactor/`.
+
+### Fase 1 (siguiente)
+- [ ] Consolidar/extender DTOs canónicos en `core/use_cases/venta.py` o `core/use_cases/sales/`.
+- [ ] Agregar normalización de métodos de pago y `operation_id` opcional.
+- [ ] Pruebas unitarias de DTO/normalización (sin tocar flujo de cobro todavía).
+- [ ] Mantener compatibilidad de imports actuales.
+
+### Fase 2+
+- [ ] Forzar POS UI → `ProcesarVentaUC`.
+- [ ] Remover bypass directo a `SalesService` (con adapter temporal controlado).
+- [ ] Continuar según plan maestro por fases 3–12.
+
+---
+
+## Plan exacto de commits propuesto para Fase 1
+
+1. **`feat(sales-dto): consolidar contratos canónicos de venta`**
+   - Añadir/expandir DTOs: `ItemCarrito`, `DatosPago`, `ResultadoVenta`, `ClienteVentaDTO`, `PaymentBreakdown`, `LoyaltyRedemptionRequest`, `LoyaltyRedemptionPreview`, `SaleContext`.
+   - Normalizadores no disruptivos (método de pago, montos, `operation_id`).
+   - Mantener backward compatibility (aliases/campos opcionales).
+
+2. **`test(sales-dto): cubrir construcción y normalización de DTOs`**
+   - Tests de efectivo/tarjeta/transferencia/crédito/mixto/MercadoPago.
+   - Tests de puntos, descuentos, `cliente_id` opcional, `sucursal_id`, `usuario`, `notas`, `operation_id`.
+
+3. **`docs(refactor): registrar decisiones de DTOs y compatibilidad legacy`**
+   - Actualizar `docs/refactor/VENTAS_REFACTOR_AUDIT.md` con estado “Fase 1 completada”.
+   - Notas de compatibilidad y adapters.
+
+
+
+---
+
+## Re-ejecución controlada (solicitada) — 2026-05-27
+
+
+### Alcance de esta entrega
+- Se **re-ejecutó FASE 0 únicamente** (auditoría + plan).
+- **Sin cambios de lógica** en `modulos/ventas.py`, `core/use_cases/venta.py`, `core/services/sales_service.py`, `core/services/sales_reversal_service.py`.
+
+### Validación rápida de hallazgos clave (confirmados)
+1. `modulos/ventas.py` mantiene mezcla UI + reglas + consultas DB (catálogo/clientes/tickets/reservas).
+2. Persisten rutas múltiples de verdad: UI, UC y `SalesService` (con legado/fallbacks en ecosistema).
+3. Fidelidad sigue siendo área de alto riesgo por coexistencia servicio+eventos+UI preview.
+4. CxC/finanzas siguen con riesgo de paralelismo entre tablas (`cuentas_por_cobrar`, `accounts_receivable`, `financial_documents`).
+5. Catálogo de eventos sigue híbrido (ES/EN/lowercase) y requiere normalización progresiva sin ruptura.
+
+### Plan exacto de commits para Fase 1 (propuesto)
+1. `feat(sales-dto): consolidar contratos canónicos de venta`
+   - Extender DTOs en `core/use_cases/venta.py` sin romper imports.
+   - Incluir `operation_id`, pago mixto, Mercado Pago, descuentos línea/global.
+2. `test(sales-dto): cubrir construcción/normalización de DTOs`
+   - Tests unitarios para métodos de pago, descuentos, puntos y campos opcionales.
+3. `docs(refactor): actualizar estado fase 1 y compatibilidad legacy`
+   - Registrar decisiones, adapters y riesgos remanentes.
+
+### Criterio de parada
+- Esta entrega **se detiene en FASE 0** por solicitud explícita.

--- a/pos_spj_v13.4/core/services/sales/cart_calculator.py
+++ b/pos_spj_v13.4/core/services/sales/cart_calculator.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class CartCalculator:
+    """Single source of truth for cart totals/discounts/change preview."""
+
+    @staticmethod
+    def calculate(items: List[Dict[str, Any]], iva_rate: float = 0.0, global_discount: float = 0.0,
+                  loyalty_discount: float = 0.0, amount_paid: float = 0.0) -> Dict[str, float]:
+        precio_base = sum(float(it.get('cantidad', 0)) * float(it.get('precio_unitario', 0)) for it in items)
+        subtotal_lineas = sum(float(it.get('total', 0.0)) for it in items)
+        discount_lines = round(precio_base - subtotal_lineas, 2)
+
+        subtotal = round(max(subtotal_lineas - float(global_discount or 0.0) - float(loyalty_discount or 0.0), 0.0), 2)
+        impuestos = round(subtotal * float(iva_rate or 0.0), 2)
+        total_final = round(subtotal + impuestos, 2)
+        cambio = round(float(amount_paid or 0.0) - total_final, 2) if amount_paid else 0.0
+
+        return {
+            'precio_base': round(precio_base, 2),
+            'descuento_lineas': discount_lines,
+            'descuento_global': round(float(global_discount or 0.0), 2),
+            'descuento_puntos': round(float(loyalty_discount or 0.0), 2),
+            'subtotal': subtotal,
+            'impuestos': impuestos,
+            'total_final': total_final,
+            'cambio': cambio,
+            'puntos_preview': int(total_final),
+        }

--- a/pos_spj_v13.4/core/services/sales/customer_lookup_service.py
+++ b/pos_spj_v13.4/core/services/sales/customer_lookup_service.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+class CustomerLookupService:
+    """Read-only customer finder for POS."""
+
+    def __init__(self, db_conn):
+        self.db = db_conn
+
+    def buscar_cliente(self, termino: str, limit: int = 12) -> List[Dict[str, Any]]:
+        term = (termino or "").strip()
+        if not term:
+            return []
+        like = f"%{term}%"
+        rows = self.db.execute(
+            "SELECT id, nombre, COALESCE(telefono,'') telefono, COALESCE(email,'') email, "
+            "COALESCE(direccion,'') direccion, COALESCE(rfc,'') rfc, COALESCE(puntos,0) puntos, "
+            "COALESCE(codigo_qr,'') codigo_qr, COALESCE(saldo,0) saldo "
+            "FROM clientes WHERE COALESCE(activo,1)=1 AND "
+            "(nombre LIKE ? OR telefono LIKE ? OR codigo_qr LIKE ?) "
+            "ORDER BY nombre LIMIT ?",
+            (like, like, like, int(limit)),
+        ).fetchall()
+        out = []
+        for r in rows:
+            get = (lambda k, i: r[k] if hasattr(r, 'keys') else r[i])
+            out.append({
+                'id': get('id', 0), 'nombre': get('nombre', 1), 'telefono': get('telefono', 2),
+                'email': get('email', 3), 'direccion': get('direccion', 4), 'rfc': get('rfc', 5),
+                'puntos': int(get('puntos', 6) or 0), 'codigo_qr': get('codigo_qr', 7),
+                'saldo': float(get('saldo', 8) or 0),
+            })
+        return out
+
+    def get_credit_balance(self, cliente_id: int) -> float:
+        row = self.db.execute("SELECT COALESCE(saldo,0) FROM clientes WHERE id=?", (cliente_id,)).fetchone()
+        if not row:
+            return 0.0
+        return float(row[0] if not hasattr(row, 'keys') else list(row)[0] or 0.0)
+
+    def get_loyalty_status(self, cliente_id: int) -> Dict[str, Any]:
+        row = self.db.execute(
+            "SELECT COALESCE(puntos,0), COALESCE(nivel_fidelidad,'') FROM clientes WHERE id=?", (cliente_id,)
+        ).fetchone()
+        if not row:
+            return {'puntos': 0, 'nivel': ''}
+        if hasattr(row, 'keys'):
+            vals = list(row)
+            return {'puntos': int(vals[0] or 0), 'nivel': vals[1] or ''}
+        return {'puntos': int(row[0] or 0), 'nivel': row[1] or ''}
+
+    def get_by_loyalty_card(self, card_code: str) -> Optional[Dict[str, Any]]:
+        row = self.db.execute(
+            "SELECT c.id, c.nombre FROM clientes c "
+            "JOIN tarjetas_fidelidad t ON t.id_cliente = c.id "
+            "WHERE t.codigo = ? AND t.activa = 1 LIMIT 1",
+            (card_code,),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            'id': row['id'] if hasattr(row, 'keys') else row[0],
+            'nombre': row['nombre'] if hasattr(row, 'keys') else row[1],
+        }

--- a/pos_spj_v13.4/core/services/sales/payment_policy.py
+++ b/pos_spj_v13.4/core/services/sales/payment_policy.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class PaymentPolicy:
+    @staticmethod
+    def normalize_payment_method(method: str) -> str:
+        raw = (method or "").strip().lower()
+        mapping = {
+            "efectivo": "Efectivo",
+            "tarjeta": "Tarjeta",
+            "transferencia": "Transferencia",
+            "credito": "Crédito",
+            "crédito": "Crédito",
+            "pago mixto": "Pago Mixto",
+            "mixto": "Pago Mixto",
+            "mercado pago": "Mercado Pago",
+            "mercadopago": "Mercado Pago",
+        }
+        return mapping.get(raw, method or "Efectivo")
+
+    @staticmethod
+    def is_credit_sale(method: str) -> bool:
+        return PaymentPolicy.normalize_payment_method(method) == "Crédito"
+
+    @staticmethod
+    def is_pending_payment(method: str) -> bool:
+        return PaymentPolicy.normalize_payment_method(method) == "Mercado Pago"
+
+    @staticmethod
+    def calculate_change(total: float, amount_paid: float, method: str) -> float:
+        m = PaymentPolicy.normalize_payment_method(method)
+        if m != "Efectivo":
+            return 0.0
+        return round(float(amount_paid or 0.0) - float(total or 0.0), 2)
+
+    @staticmethod
+    def validate_mixed_payment(total: float, cash: float, card: float) -> Dict[str, Any]:
+        paid = round(float(cash or 0.0) + float(card or 0.0), 2)
+        diff = round(paid - float(total or 0.0), 2)
+        return {"ok": diff >= -0.01, "diff": diff, "paid": paid}
+
+    @staticmethod
+    def validate_payment(total: float, method: str, amount_paid: float = 0.0,
+                         cash: float = 0.0, card: float = 0.0) -> Dict[str, Any]:
+        m = PaymentPolicy.normalize_payment_method(method)
+        if m == "Efectivo":
+            ch = PaymentPolicy.calculate_change(total, amount_paid, m)
+            return {"ok": ch >= 0, "change": ch, "error": "" if ch >= 0 else "Pago insuficiente"}
+        if m == "Pago Mixto":
+            v = PaymentPolicy.validate_mixed_payment(total, cash, card)
+            return {"ok": v["ok"], "change": max(v["diff"], 0.0), "error": "" if v["ok"] else "Pago mixto insuficiente"}
+        return {"ok": True, "change": 0.0, "error": ""}
+
+    @staticmethod
+    def build_payment_breakdown(total: float, method: str, amount_paid: float = 0.0,
+                                cash: float = 0.0, card: float = 0.0,
+                                saldo_credito: float = 0.0) -> Dict[str, Any]:
+        m = PaymentPolicy.normalize_payment_method(method)
+        data = {
+            "forma_pago": m,
+            "total_pagado": float(total or 0.0),
+            "efectivo_recibido": float(amount_paid or 0.0),
+            "monto_tarjeta_mixto": 0.0,
+            "cambio": 0.0,
+            "saldo_credito": 0.0,
+        }
+        if m == "Pago Mixto":
+            data["efectivo_recibido"] = float(cash or 0.0)
+            data["monto_tarjeta_mixto"] = float(card or 0.0)
+            v = PaymentPolicy.validate_mixed_payment(total, cash, card)
+            data["cambio"] = max(v["diff"], 0.0)
+        elif m == "Crédito":
+            data["saldo_credito"] = float(saldo_credito or total or 0.0)
+            data["efectivo_recibido"] = float(total or 0.0)
+        else:
+            data["cambio"] = PaymentPolicy.calculate_change(total, amount_paid, m)
+            if m != "Efectivo":
+                data["efectivo_recibido"] = float(total or 0.0)
+        return data

--- a/pos_spj_v13.4/core/services/sales/product_catalog_query_service.py
+++ b/pos_spj_v13.4/core/services/sales/product_catalog_query_service.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class ProductCatalogQueryService:
+    """Read-only queries for POS product catalog."""
+
+    def __init__(self, db_conn):
+        self.db = db_conn
+
+    def get_categories(self) -> List[str]:
+        rows = self.db.execute(
+            "SELECT DISTINCT COALESCE(categoria,'') AS categoria "
+            "FROM productos "
+            "WHERE COALESCE(oculto,0)=0 AND COALESCE(activo,1)=1 "
+            "AND categoria IS NOT NULL AND categoria != '' "
+            "ORDER BY categoria"
+        ).fetchall()
+        return [r[0] if not hasattr(r, 'keys') else r['categoria'] for r in rows]
+
+    def list_visible_products(self, branch_id: int, filtro: str = "", categoria: str = "") -> List[Dict[str, Any]]:
+        query = (
+            "SELECT p.id, p.nombre, p.precio, "
+            "COALESCE(bi.quantity, p.existencia, 0) as stock_sucursal, "
+            "p.unidad, p.categoria, p.stock_minimo, p.imagen_path, "
+            "p.es_compuesto, p.es_subproducto, "
+            "COALESCE(p.codigo_barras,'') as codigo_barras, COALESCE(p.codigo,'') as codigo "
+            "FROM productos p "
+            "LEFT JOIN branch_inventory bi ON bi.product_id=p.id AND bi.branch_id=? "
+            "WHERE p.oculto = 0 AND COALESCE(p.activo,1)=1"
+        )
+        params: List[Any] = [branch_id]
+        if filtro:
+            query += (
+                " AND (p.nombre LIKE ? OR p.id = ? OR p.categoria LIKE ? "
+                "OR COALESCE(p.codigo_barras,'') = ? OR COALESCE(p.codigo,'') = ?)"
+            )
+            params += [f"%{filtro}%", filtro, f"%{filtro}%", filtro, filtro]
+        if categoria:
+            query += " AND COALESCE(p.categoria,'') = ?"
+            params.append(categoria)
+        query += " ORDER BY p.nombre"
+
+        rows = self.db.execute(query, params).fetchall()
+        out: List[Dict[str, Any]] = []
+        for r in rows:
+            get = (lambda k, i: r[k] if hasattr(r, 'keys') else r[i])
+            out.append({
+                'id': get('id', 0),
+                'nombre': get('nombre', 1),
+                'codigo': get('codigo', 11),
+                'precio': float(get('precio', 2) or 0),
+                'unidad': get('unidad', 4),
+                'existencia': float(get('stock_sucursal', 3) or 0),
+                'stock_state': 'ok',
+                'imagen_path': get('imagen_path', 7),
+                'categoria': get('categoria', 5),
+                'stock_minimo': float(get('stock_minimo', 6) or 0),
+                'es_compuesto': int(get('es_compuesto', 8) or 0),
+                'es_subproducto': int(get('es_subproducto', 9) or 0),
+                'codigo_barras': get('codigo_barras', 10),
+            })
+        return out
+
+    def get_product_by_barcode(self, branch_id: int, barcode: str) -> Dict[str, Any] | None:
+        rows = self.list_visible_products(branch_id=branch_id, filtro=str(barcode or ""))
+        for p in rows:
+            if p.get('codigo_barras') == barcode or p.get('codigo') == barcode:
+                return p
+        return None

--- a/pos_spj_v13.4/core/services/sales/sale_loyalty_policy.py
+++ b/pos_spj_v13.4/core/services/sales/sale_loyalty_policy.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+class SaleLoyaltyPolicy:
+    """Canonical loyalty policy with idempotency guard by operation_id."""
+
+    def __init__(self, db_conn, loyalty_service=None, event_bus=None):
+        self.db = db_conn
+        self.loyalty_service = loyalty_service
+        self.event_bus = event_bus
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        try:
+            self.db.execute(
+                "CREATE TABLE IF NOT EXISTS loyalty_operations ("
+                "operation_id TEXT PRIMARY KEY, kind TEXT NOT NULL, cliente_id INTEGER, "
+                "venta_id INTEGER, payload TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP)"
+            )
+        except Exception:
+            pass
+
+    def _seen(self, operation_id: str) -> bool:
+        if not operation_id:
+            return False
+        row = self.db.execute("SELECT 1 FROM loyalty_operations WHERE operation_id=? LIMIT 1", (operation_id,)).fetchone()
+        return bool(row)
+
+    def _mark(self, operation_id: str, kind: str, cliente_id: Optional[int], venta_id: Optional[int], payload: str = "") -> None:
+        if not operation_id:
+            return
+        self.db.execute(
+            "INSERT OR IGNORE INTO loyalty_operations(operation_id, kind, cliente_id, venta_id, payload) VALUES(?,?,?,?,?)",
+            (operation_id, kind, cliente_id, venta_id, payload),
+        )
+
+    def preview_redemption(self, cliente_id: int, puntos: int, subtotal: float) -> Dict[str, Any]:
+        if not self.loyalty_service:
+            return {"ok": False, "descuento": 0.0, "error": "loyalty_service no disponible"}
+        return self.loyalty_service.preview_redemption(
+            cliente_id=cliente_id, puntos_solicitados=int(max(0, puntos)), subtotal=float(subtotal)
+        )
+
+    def apply_redemption(self, cliente_id: int, venta_id: int, puntos: int, operation_id: str) -> Dict[str, Any]:
+        if self._seen(operation_id):
+            return {"ok": True, "idempotent": True}
+        if not self.loyalty_service:
+            return {"ok": False, "error": "loyalty_service no disponible"}
+        res = self.loyalty_service.apply_redemption(
+            cliente_id=cliente_id, venta_id=venta_id, cajero_id="system", subtotal=0.0, puntos=int(max(0, puntos))
+        )
+        if res.get("ok"):
+            self._mark(operation_id, "redeem", cliente_id, venta_id, str(res))
+        return res
+
+    def earn_points(self, cliente_id: int, venta_id: int, total: float, operation_id: str, branch_id: int = 0, usuario: str = "") -> Dict[str, Any]:
+        if self._seen(operation_id):
+            return {"ok": True, "idempotent": True, "puntos_ganados": 0}
+        if not self.loyalty_service:
+            return {"ok": False, "error": "loyalty_service no disponible"}
+        res = self.loyalty_service.process_loyalty_for_sale(
+            client_id=cliente_id, total_sale=float(total), branch_id=branch_id, venta_id=venta_id, usuario=str(usuario or "system")
+        ) or {}
+        self._mark(operation_id, "earn", cliente_id, venta_id, str(res))
+        return {"ok": True, **res}
+
+    def reverse_points(self, cliente_id: int, venta_id: int, operation_id: str, puntos: int = 0, usuario: str = "system") -> Dict[str, Any]:
+        if self._seen(operation_id):
+            return {"ok": True, "idempotent": True}
+        # fallback SQL canonicalized here while no loyalty reverse API exists
+        self.db.execute("UPDATE clientes SET puntos = MAX(0, COALESCE(puntos,0) - ?) WHERE id = ?", (int(max(0, puntos)), cliente_id))
+        self.db.execute(
+            "INSERT INTO historico_puntos (cliente_id, tipo, puntos, descripcion, saldo_actual, usuario, venta_id) "
+            "SELECT ?, 'CANCELACION', ?, ?, MAX(0, COALESCE(puntos,0) - ?), ?, ? FROM clientes WHERE id=?",
+            (cliente_id, -int(max(0, puntos)), f"Reversa venta #{venta_id}", int(max(0, puntos)), usuario, venta_id, cliente_id),
+        )
+        self._mark(operation_id, "reverse", cliente_id, venta_id, str(puntos))
+        return {"ok": True}

--- a/pos_spj_v13.4/core/services/sales_reversal_service.py
+++ b/pos_spj_v13.4/core/services/sales_reversal_service.py
@@ -314,21 +314,32 @@ class SalesReversalService:
             cliente_id = venta.get("cliente_id")
             puntos = int(venta.get("puntos_ganados") or 0)
             if cliente_id and puntos > 0:
-                conn.execute(
-                    "UPDATE clientes SET puntos = MAX(0, puntos - ?) WHERE id = ?",
-                    (puntos, cliente_id)
-                )
-                conn.execute("""
-                    INSERT INTO historico_puntos
-                        (cliente_id, tipo, puntos, descripcion, saldo_actual, usuario, venta_id)
-                    SELECT ?, 'CANCELACION', ?, ?,
-                           MAX(0, puntos - ?), ?, ?
-                    FROM clientes WHERE id = ?
-                """, (
-                    cliente_id, -puntos,
-                    f"Cancelación venta {venta['folio']}",
-                    puntos, usuario, sale_id, cliente_id,
-                ))
+                try:
+                    from core.services.sales.sale_loyalty_policy import SaleLoyaltyPolicy
+                    _lp = SaleLoyaltyPolicy(conn, loyalty_service=getattr(self, "loyalty_service", None))
+                    _lp.reverse_points(
+                        cliente_id=int(cliente_id),
+                        venta_id=int(sale_id),
+                        puntos=int(puntos),
+                        operation_id=f"{operation_id}:reverse_loyalty",
+                        usuario=str(usuario),
+                    )
+                except Exception:
+                    conn.execute(
+                        "UPDATE clientes SET puntos = MAX(0, puntos - ?) WHERE id = ?",
+                        (puntos, cliente_id)
+                    )
+                    conn.execute("""
+                        INSERT INTO historico_puntos
+                            (cliente_id, tipo, puntos, descripcion, saldo_actual, usuario, venta_id)
+                        SELECT ?, 'CANCELACION', ?, ?,
+                               MAX(0, puntos - ?), ?, ?
+                        FROM clientes WHERE id = ?
+                    """, (
+                        cliente_id, -puntos,
+                        f"Cancelación venta {venta['folio']}",
+                        puntos, usuario, sale_id, cliente_id,
+                    ))
 
             # ── PASO 6: Marcar cancelada (fin de transacción) ─────────────────
             conn.execute(
@@ -351,6 +362,29 @@ class SalesReversalService:
             "payment_method": forma_pago,
             "cliente_id":     venta.get("cliente_id"),
             "sucursal_id":    venta.get("sucursal_id", self.branch_id),
+        })
+        self._fire_event("SALE_CANCELLED", {
+            "sale_id": sale_id,
+            "folio": venta["folio"],
+            "operation_id": operation_id,
+            "sucursal_id": venta.get("sucursal_id", self.branch_id),
+        })
+        self._fire_event("SALE_LOYALTY_REVERSED", {
+            "sale_id": sale_id,
+            "cliente_id": venta.get("cliente_id"),
+            "puntos": int(venta.get("puntos_ganados") or 0),
+            "operation_id": f"{operation_id}:reverse_loyalty",
+        })
+        self._fire_event("SALE_CASH_COMPENSATED", {
+            "sale_id": sale_id,
+            "amount": -total,
+            "payment_method": forma_pago,
+            "operation_id": operation_id,
+        })
+        self._fire_event("SALE_INVENTORY_RESTORED", {
+            "sale_id": sale_id,
+            "items_restored": items_restaurados,
+            "operation_id": operation_id,
         })
 
         return CancelResultDTO(
@@ -544,6 +578,24 @@ class SalesReversalService:
                 )
             except Exception as exc:
                 logger.warning("refund_items GL: %s", exc)
+        self._fire_event("SALE_REFUNDED", {
+            "sale_id": sale_id,
+            "refund_ids": refund_ids,
+            "amount": total_f,
+            "method": method,
+            "operation_id": operation_id,
+        })
+        self._fire_event("SALE_CASH_COMPENSATED", {
+            "sale_id": sale_id,
+            "amount": -total_f if method == "Efectivo" else 0.0,
+            "payment_method": method,
+            "operation_id": operation_id,
+        })
+        self._fire_event("SALE_INVENTORY_RESTORED", {
+            "sale_id": sale_id,
+            "items_restored": len(refund_ids),
+            "operation_id": operation_id,
+        })
 
         return RefundResultDTO(
             sale_id=sale_id,
@@ -684,6 +736,20 @@ class SalesReversalService:
                 )
             except Exception as exc:
                 logger.warning("issue_credit_note GL: %s", exc)
+        self._fire_event("SALE_CREDIT_NOTE_ISSUED", {
+            "sale_id": sale_id,
+            "credit_note_id": credit_note_id,
+            "amount": amount,
+            "reason": reason,
+            "method": method,
+            "operation_id": operation_id,
+        })
+        self._fire_event("SALE_CASH_COMPENSATED", {
+            "sale_id": sale_id,
+            "amount": -amount if method == "Efectivo" else 0.0,
+            "payment_method": method,
+            "operation_id": operation_id,
+        })
 
         return CreditNoteResultDTO(
             sale_id=sale_id,

--- a/pos_spj_v13.4/core/services/sales_service.py
+++ b/pos_spj_v13.4/core/services/sales_service.py
@@ -51,6 +51,7 @@ class SalesService:
         self.feature_flag_service = feature_flag_service
         self.customer_service = customer_service
         self._fulfillment = SaleFulfillmentService(db_conn)
+        self._sale_loyalty_policy = None
 
     def _generate_unique_sale_folio(self) -> str:
         """
@@ -132,6 +133,47 @@ class SalesService:
                 merged[key]["qty"] += r["qty"]
                 merged[key]["cantidad"] += r["cantidad"]
         return list(merged.values())
+
+    def _loyalty_policy(self):
+        if self._sale_loyalty_policy is None:
+            try:
+                from core.services.sales.sale_loyalty_policy import SaleLoyaltyPolicy
+                self._sale_loyalty_policy = SaleLoyaltyPolicy(self.db, loyalty_service=self.loyalty_service)
+            except Exception:
+                self._sale_loyalty_policy = None
+        return self._sale_loyalty_policy
+
+    def _normalize_payment_method(self, payment_method: str) -> str:
+        try:
+            from core.services.payment_normalization import normalize_payment_method as _npm
+            return _npm(payment_method)
+        except Exception:
+            return payment_method
+
+    def _normalize_items_payload(self, items: list) -> list:
+        normalized = []
+        for _it in items:
+            normalized.append({
+                'product_id': _it.get('product_id', _it.get('id', 0)),
+                'qty': float(_it.get('qty', _it.get('cantidad', 1))),
+                'unit_price': float(_it.get('unit_price', _it.get('precio_unitario', 0))),
+                'precio_unitario': float(_it.get('unit_price', _it.get('precio_unitario', 0))),
+                'cantidad': float(_it.get('qty', _it.get('cantidad', 1))),
+                'nombre': _it.get('nombre', _it.get('name', '')),
+                'unidad': _it.get('unidad', 'pz'),
+                'es_compuesto': _it.get('es_compuesto', 0),
+                'promo_nombre': _it.get('promo_nombre', ''),
+            })
+        return normalized
+
+    def _validate_payment(self, payment_method: str, amount_paid: float, total_a_pagar: float, client_id: int = None):
+        from core.services.payment_normalization import is_credit_sale
+        if is_credit_sale(payment_method) and client_id and self.customer_service:
+            ok, msg = self.customer_service.validate_credit(client_id, total_a_pagar)
+            if not ok:
+                raise ValueError(msg)
+        if amount_paid < total_a_pagar and not is_credit_sale(payment_method):
+            raise ValueError(f"El monto pagado (${amount_paid:,.2f}) es menor al total a cobrar (${total_a_pagar:,.2f})")
 
     def create_pending_payment_sale(self, branch_id: int, user: str, items: list,
                                     client_id: int = None, notes: str = "",
@@ -234,30 +276,8 @@ class SalesService:
         """
         operation_id = str(uuid.uuid4())
 
-        # ── Normalizar método de pago (UI envía "Crédito" con acento; backend espera "Credito") ──
-        try:
-            from core.services.payment_normalization import normalize_payment_method as _npm
-            payment_method = _npm(payment_method)
-        except Exception:
-            pass  # normalization is non-critical; proceed with original value
-
-        # ── Normalizar claves de items (la UI puede usar distintos nombres) ──
-        # UI envía: unit_price / qty / id
-        # Servicios internos esperan: precio_unitario / cantidad / product_id
-        _normalized = []
-        for _it in items:
-            _normalized.append({
-                'product_id':    _it.get('product_id', _it.get('id', 0)),
-                'qty':           float(_it.get('qty', _it.get('cantidad', 1))),
-                'unit_price':    float(_it.get('unit_price', _it.get('precio_unitario', 0))),
-                'precio_unitario': float(_it.get('unit_price', _it.get('precio_unitario', 0))),
-                'cantidad':      float(_it.get('qty', _it.get('cantidad', 1))),
-                'nombre':        _it.get('nombre', _it.get('name', '')),
-                'unidad':        _it.get('unidad', 'pz'),
-                'es_compuesto':  _it.get('es_compuesto', 0),
-                'promo_nombre':  _it.get('promo_nombre', ''),
-            })
-        items = _normalized
+        payment_method = self._normalize_payment_method(payment_method)
+        items = self._normalize_items_payload(items)
 
         # =========================================================
         # 1. PRE-PROCESAMIENTO: Matemáticas y Promociones
@@ -342,16 +362,7 @@ class SalesService:
             total_a_pagar = round(total_a_pagar - loyalty_discount, 2)
             discount = round(discount + loyalty_discount, 2)
 
-        # ── Validación de crédito (si aplica) ────────────────────────────────
-        from core.services.payment_normalization import is_credit_sale
-        if is_credit_sale(payment_method) and client_id and self.customer_service:
-            ok, msg = self.customer_service.validate_credit(client_id, total_a_pagar)
-            if not ok:
-                raise ValueError(msg)
-
-        # Validamos el pago
-        if amount_paid < total_a_pagar and not is_credit_sale(payment_method):
-            raise ValueError(f"El monto pagado (${amount_paid:,.2f}) es menor al total a cobrar (${total_a_pagar:,.2f})")
+        self._validate_payment(payment_method, amount_paid, total_a_pagar, client_id=client_id)
 
         # Guardia de margen v13.4 — no bloquea la venta, solo registra en audit
         if self.finance_service and hasattr(self.finance_service, 'validar_margen'):
@@ -460,12 +471,18 @@ class SalesService:
 
             # ── Canje real dentro de transacción crítica (atómico con venta) ──
             if loyalty_redemption_pts > 0 and client_id and self.loyalty_service:
-                red = self.loyalty_service.apply_redemption(
-                    cliente_id=client_id,
-                    venta_id=sale_id,
-                    cajero_id=user,
-                    subtotal=total_a_pagar,
-                    puntos=loyalty_redemption_pts,
+                _lp = self._loyalty_policy()
+                _op = f"{operation_id}:redeem"
+                red = (
+                    _lp.apply_redemption(client_id, sale_id, loyalty_redemption_pts, _op)
+                    if _lp else
+                    self.loyalty_service.apply_redemption(
+                        cliente_id=client_id,
+                        venta_id=sale_id,
+                        cajero_id=user,
+                        subtotal=total_a_pagar,
+                        puntos=loyalty_redemption_pts,
+                    )
                 )
                 if not red.get("ok", False):
                     raise RuntimeError(f"Canje de lealtad no aplicado: {red.get('error', 'desconocido')}")
@@ -482,12 +499,24 @@ class SalesService:
             loyalty_result = {"puntos_ganados": 0, "puntos_totales": 0, "nivel": "Bronce", "mensaje": ""}
             if client_id and self.loyalty_service:
                 try:
-                    loyalty_result = self.loyalty_service.process_loyalty_for_sale(
-                        client_id=client_id,
-                        total_sale=float(total_a_pagar),
-                        branch_id=branch_id,
-                        venta_id=sale_id,
-                        usuario=str(user),
+                    _lp = self._loyalty_policy()
+                    _op = f"{operation_id}:earn"
+                    loyalty_result = (
+                        _lp.earn_points(
+                            cliente_id=client_id,
+                            venta_id=sale_id,
+                            total=float(total_a_pagar),
+                            operation_id=_op,
+                            branch_id=branch_id,
+                            usuario=str(user),
+                        ) if _lp else
+                        self.loyalty_service.process_loyalty_for_sale(
+                            client_id=client_id,
+                            total_sale=float(total_a_pagar),
+                            branch_id=branch_id,
+                            venta_id=sale_id,
+                            usuario=str(user),
+                        )
                     ) or loyalty_result
                 except Exception as _lyl_aw_err:
                     logger.warning("loyalty accrual venta=%s: %s", sale_id, _lyl_aw_err)

--- a/pos_spj_v13.4/core/use_cases/venta.py
+++ b/pos_spj_v13.4/core/use_cases/venta.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 logger = logging.getLogger("spj.use_cases.venta")
 
@@ -55,6 +55,78 @@ class DatosPago:
     puntos_canjeados: int   = 0
     descuento_puntos: float = 0.0
     notas:            str   = ""
+    sucursal_id:      Optional[int] = None
+    usuario:          str = ""
+    operation_id:     str = ""
+    descuento_lineas: float = 0.0
+    mercado_pago_ref: str = ""
+    pago_mixto:       Dict[str, float] = field(default_factory=dict)
+    total_pagado:     float = 0.0
+
+    def __post_init__(self) -> None:
+        self.forma_pago = _normalize_payment_label(self.forma_pago)
+        self.monto_pagado = float(self.monto_pagado or 0.0)
+        self.total_pagado = float(self.total_pagado or self.monto_pagado or 0.0)
+        self.descuento_global = float(self.descuento_global or 0.0)
+        self.descuento_lineas = float(self.descuento_lineas or 0.0)
+        self.puntos_canjeados = int(self.puntos_canjeados or 0)
+        self.descuento_puntos = float(self.descuento_puntos or 0.0)
+        self.pago_mixto = {str(k): float(v or 0.0) for k, v in (self.pago_mixto or {}).items()}
+
+
+@dataclass
+class ClienteVentaDTO:
+    cliente_id: Optional[int] = None
+    nombre: str = ""
+    telefono: str = ""
+    email: str = ""
+    saldo_credito: float = 0.0
+    puntos: int = 0
+    nivel: str = ""
+
+
+@dataclass
+class PaymentBreakdown:
+    metodo: str = "Efectivo"
+    total: float = 0.0
+    recibido: float = 0.0
+    cambio: float = 0.0
+    pendiente: float = 0.0
+    lineas: Dict[str, float] = field(default_factory=dict)
+    mercado_pago_ref: str = ""
+    operation_id: str = ""
+
+
+@dataclass
+class LoyaltyRedemptionRequest:
+    cliente_id: Optional[int] = None
+    puntos: int = 0
+    subtotal: float = 0.0
+    operation_id: str = ""
+
+
+@dataclass
+class LoyaltyRedemptionPreview:
+    cliente_id: Optional[int] = None
+    puntos_solicitados: int = 0
+    puntos_aplicables: int = 0
+    descuento_aplicable: float = 0.0
+    subtotal: float = 0.0
+    total_estimado: float = 0.0
+    mensaje: str = ""
+
+
+@dataclass
+class SaleContext:
+    items: List[ItemCarrito] = field(default_factory=list)
+    datos_pago: DatosPago = field(default_factory=DatosPago)
+    cliente: ClienteVentaDTO = field(default_factory=ClienteVentaDTO)
+    payment_breakdown: PaymentBreakdown = field(default_factory=PaymentBreakdown)
+    loyalty_redemption: LoyaltyRedemptionRequest = field(default_factory=LoyaltyRedemptionRequest)
+    sucursal_id: int = 0
+    usuario: str = ""
+    notas: str = ""
+    operation_id: str = ""
 
 
 @dataclass
@@ -69,6 +141,7 @@ class ResultadoVenta:
     nivel_cliente: str        = "Bronce"
     ticket_html:   str        = ""
     error:         str        = ""
+    operation_id:  str        = ""
 
 
 # ── Caso de uso ───────────────────────────────────────────────────────────────
@@ -323,3 +396,26 @@ def _get_bus():
         return get_bus()
     except Exception:
         return None
+
+
+def _normalize_payment_label(value: str) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return "Efectivo"
+    key = raw.lower()
+    aliases = {
+        "efectivo": "Efectivo",
+        "cash": "Efectivo",
+        "tarjeta": "Tarjeta",
+        "card": "Tarjeta",
+        "transferencia": "Transferencia",
+        "transfer": "Transferencia",
+        "credito": "Crédito",
+        "crédito": "Crédito",
+        "credito normalizado": "Crédito",
+        "mixto": "Mixto",
+        "pago mixto": "Mixto",
+        "mercadopago": "Mercado Pago",
+        "mercado pago": "Mercado Pago",
+    }
+    return aliases.get(key, raw)

--- a/pos_spj_v13.4/modulos/ventas.py
+++ b/pos_spj_v13.4/modulos/ventas.py
@@ -615,7 +615,12 @@ class DialogoPago(QDialog):
             self.txt_recibido.selectAll()))
         
     def cambiar_forma_pago(self, forma_pago):
-        self.forma_pago = forma_pago
+        try:
+            from core.services.sales.payment_policy import PaymentPolicy
+            self.forma_pago = PaymentPolicy.normalize_payment_method(forma_pago)
+        except Exception:
+            self.forma_pago = forma_pago
+        forma_pago = self.forma_pago
         if forma_pago == "Efectivo":
             self.txt_recibido.setEnabled(True)
             self.txt_recibido.setValue(self.total_a_pagar)
@@ -659,10 +664,23 @@ class DialogoPago(QDialog):
 
     def calcular_cambio(self):
         self.efectivo_recibido = self.txt_recibido.value()
+        try:
+            from core.services.sales.payment_policy import PaymentPolicy
+            validation = PaymentPolicy.validate_payment(
+                total=self.total_a_pagar,
+                method=self.forma_pago,
+                amount_paid=self.efectivo_recibido,
+                cash=self.spin_efectivo_mixto.value() if hasattr(self, "spin_efectivo_mixto") else 0.0,
+                card=self.spin_tarjeta_mixto.value() if hasattr(self, "spin_tarjeta_mixto") else 0.0,
+            )
+            self.cambio = float(validation.get("change", 0.0))
+            ok = bool(validation.get("ok", True))
+        except Exception:
+            ok = True
+            self.cambio = round(self.efectivo_recibido - self.total_a_pagar, 2) if self.forma_pago == "Efectivo" else 0.0
         if self.forma_pago == "Efectivo":
-            self.cambio = round(self.efectivo_recibido - self.total_a_pagar, 2)
             self.lbl_cambio.setText(f"Cambio: ${self.cambio:.2f}")
-            if self.cambio < 0:
+            if not ok or self.cambio < 0:
                 self.btn_aceptar.setEnabled(False)
                 self.lbl_cambio.setProperty("class", "payment-change-negative")
             else:
@@ -678,8 +696,13 @@ class DialogoPago(QDialog):
             return
         ef = self.spin_efectivo_mixto.value()
         ta = self.spin_tarjeta_mixto.value()
-        total = ef + ta
-        diff = round(total - self.total_a_pagar, 2)
+        try:
+            from core.services.sales.payment_policy import PaymentPolicy
+            v = PaymentPolicy.validate_mixed_payment(self.total_a_pagar, ef, ta)
+            diff = float(v.get("diff", 0.0))
+        except Exception:
+            total = ef + ta
+            diff = round(total - self.total_a_pagar, 2)
         if abs(diff) < 0.01:
             self.lbl_mixto_diff.setText("✅ Cuadra")
             self.lbl_mixto_diff.setProperty("class", "text-success caption")
@@ -734,23 +757,30 @@ class DialogoPago(QDialog):
         self.calcular_cambio()
 
     def get_datos_pago(self) -> Dict[str, Any]:
-        return {
-            "forma_pago": self.forma_pago,
-            "total_pagado": self.total_a_pagar,
-            "efectivo_recibido": (
-                self.spin_efectivo_mixto.value()
-                if self.forma_pago == "Pago Mixto"
-                else self.efectivo_recibido
-            ),
-            "monto_tarjeta_mixto": (
-                self.spin_tarjeta_mixto.value()
-                if self.forma_pago == "Pago Mixto" else 0.0
-            ),
-            "cambio": self.cambio,
-            "saldo_credito": self.txt_saldo_credito.value() if self.forma_pago == "Crédito" else 0.0,
+        try:
+            from core.services.sales.payment_policy import PaymentPolicy
+            payload = PaymentPolicy.build_payment_breakdown(
+                total=self.total_a_pagar,
+                method=self.forma_pago,
+                amount_paid=self.efectivo_recibido,
+                cash=self.spin_efectivo_mixto.value() if self.forma_pago == "Pago Mixto" else 0.0,
+                card=self.spin_tarjeta_mixto.value() if self.forma_pago == "Pago Mixto" else 0.0,
+                saldo_credito=self.txt_saldo_credito.value() if self.forma_pago == "Crédito" else 0.0,
+            )
+        except Exception:
+            payload = {
+                "forma_pago": self.forma_pago,
+                "total_pagado": self.total_a_pagar,
+                "efectivo_recibido": self.efectivo_recibido,
+                "monto_tarjeta_mixto": 0.0,
+                "cambio": self.cambio,
+                "saldo_credito": self.txt_saldo_credito.value() if self.forma_pago == "Crédito" else 0.0,
+            }
+        payload.update({
             "puntos_canjeados": self.puntos_a_canjear,
             "descuento_puntos": self.descuento_puntos,
-        }
+        })
+        return payload
 
 # ==============================================================================
 # 4. DIÁLOGO PARA AGREGAR CLIENTE
@@ -1199,6 +1229,30 @@ class ModuloVentas(ModuloBase):
     def _prod_repo(self):
         return getattr(self.container, 'producto_repo', None)
 
+    @property
+    def _product_catalog_qs(self):
+        svc = getattr(self, "_product_catalog_query_service", None)
+        if svc is None:
+            try:
+                from core.services.sales.product_catalog_query_service import ProductCatalogQueryService
+                svc = ProductCatalogQueryService(self.conexion)
+            except Exception:
+                svc = None
+            self._product_catalog_query_service = svc
+        return svc
+
+    @property
+    def _customer_lookup_svc(self):
+        svc = getattr(self, "_customer_lookup_service", None)
+        if svc is None:
+            try:
+                from core.services.sales.customer_lookup_service import CustomerLookupService
+                svc = CustomerLookupService(self.conexion)
+            except Exception:
+                svc = None
+            self._customer_lookup_service = svc
+        return svc
+
     def set_usuario_actual(self, usuario: str, rol: str) -> None:
         """Activa/desactiva botones según el rol del usuario logueado."""
         self.usuario_actual = usuario
@@ -1230,8 +1284,12 @@ class ModuloVentas(ModuloBase):
 
     def actualizar_completer_model(self):
         try:
+            catalog_qs = self._product_catalog_qs
             prod_repo = self._prod_repo
-            if prod_repo:
+            if catalog_qs:
+                rows = catalog_qs.list_visible_products(branch_id=getattr(self, "sucursal_id", 1))
+                productos = [(p['nombre'], p.get('codigo_barras', '')) for p in rows]
+            elif prod_repo:
                 productos = [(p['nombre'], p.get('codigo_barras', '')) for p in prod_repo.get_all()]
             else:
                 cursor = self.conexion.cursor()
@@ -1998,8 +2056,11 @@ class ModuloVentas(ModuloBase):
 
         categorias = [""]  # "" = Todos
         try:
+            catalog_qs = self._product_catalog_qs
             prod_repo = self._prod_repo
-            if prod_repo:
+            if catalog_qs:
+                categorias += catalog_qs.get_categories()
+            elif prod_repo:
                 categorias += prod_repo.get_categories()
             else:
                 rows = self.conexion.execute(
@@ -2072,31 +2133,36 @@ class ModuloVentas(ModuloBase):
                 widget.setParent(None)
 
         try:
-            cursor = self.conexion.cursor()
-            # v13.4: Read stock from branch_inventory for active branch
-            query = """
-                SELECT p.id, p.nombre, p.precio,
-                       COALESCE(bi.quantity, p.existencia, 0) as stock_sucursal,
-                       p.unidad, p.categoria,
-                       p.stock_minimo, p.imagen_path, p.es_compuesto, p.es_subproducto,
-                       COALESCE(p.codigo_barras,'') as codigo_barras,
-                       COALESCE(p.codigo,'') as codigo
-                FROM productos p
-                LEFT JOIN branch_inventory bi ON bi.product_id=p.id AND bi.branch_id=?
-                WHERE p.oculto = 0 AND COALESCE(p.activo,1) = 1
-            """
-            params = [self.sucursal_id]
-            if filtro:
-                query += """ AND (p.nombre LIKE ? OR p.id = ? OR p.categoria LIKE ?
-                             OR COALESCE(p.codigo_barras,'') = ? OR COALESCE(p.codigo,'') = ?)"""
-                params += [f'%{filtro}%', filtro, f'%{filtro}%', filtro, filtro]
-            if categoria:
-                query += " AND COALESCE(p.categoria,'') = ?"
-                params.append(categoria)
-
-            query += " ORDER BY p.nombre"
-            cursor.execute(query, params)
-            productos = cursor.fetchall()
+            catalog_qs = self._product_catalog_qs
+            if catalog_qs:
+                productos = catalog_qs.list_visible_products(
+                    branch_id=self.sucursal_id, filtro=filtro, categoria=categoria
+                )
+            else:
+                cursor = self.conexion.cursor()
+                # DEPRECATED fallback: SQL directo legacy
+                query = """
+                    SELECT p.id, p.nombre, p.precio,
+                           COALESCE(bi.quantity, p.existencia, 0) as stock_sucursal,
+                           p.unidad, p.categoria,
+                           p.stock_minimo, p.imagen_path, p.es_compuesto, p.es_subproducto,
+                           COALESCE(p.codigo_barras,'') as codigo_barras,
+                           COALESCE(p.codigo,'') as codigo
+                    FROM productos p
+                    LEFT JOIN branch_inventory bi ON bi.product_id=p.id AND bi.branch_id=?
+                    WHERE p.oculto = 0 AND COALESCE(p.activo,1) = 1
+                """
+                params = [self.sucursal_id]
+                if filtro:
+                    query += """ AND (p.nombre LIKE ? OR p.id = ? OR p.categoria LIKE ?
+                                 OR COALESCE(p.codigo_barras,'') = ? OR COALESCE(p.codigo,'') = ?)"""
+                    params += [f'%{filtro}%', filtro, f'%{filtro}%', filtro, filtro]
+                if categoria:
+                    query += " AND COALESCE(p.categoria,'') = ?"
+                    params.append(categoria)
+                query += " ORDER BY p.nombre"
+                cursor.execute(query, params)
+                productos = cursor.fetchall()
 
             # Responsive column count: fill available viewport width with fixed-width cards
             _spacing = self.grid_productos.spacing()
@@ -2108,20 +2174,23 @@ class ModuloVentas(ModuloBase):
             col_count = max(2, _vp_w // _card_cell)
 
             for i, producto in enumerate(productos):
-                producto_data = {
-                    'id': producto[0],
-                    'nombre': producto[1],
-                    'precio': float(producto[2]),
-                    'existencia': float(producto[3]),
-                    'unidad': producto[4],
-                    'categoria': producto[5],
-                    'stock_minimo': float(producto[6]),
-                    'imagen_path': producto[7],
-                    'es_compuesto': producto[8],
-                    'es_subproducto': producto[9],
-                    'codigo_barras': producto[10],
-                    'codigo': producto[11]
-                }
+                if isinstance(producto, dict):
+                    producto_data = producto
+                else:
+                    producto_data = {
+                        'id': producto[0],
+                        'nombre': producto[1],
+                        'precio': float(producto[2]),
+                        'existencia': float(producto[3]),
+                        'unidad': producto[4],
+                        'categoria': producto[5],
+                        'stock_minimo': float(producto[6]),
+                        'imagen_path': producto[7],
+                        'es_compuesto': producto[8],
+                        'es_subproducto': producto[9],
+                        'codigo_barras': producto[10],
+                        'codigo': producto[11]
+                    }
 
                 card = ProductCard(producto_data)
                 card.product_selected.connect(self.seleccionar_producto)
@@ -2902,21 +2971,37 @@ class ModuloVentas(ModuloBase):
         """
         # ── Ruta 1: PrinterService unificado (ESC/POS) ────────────────────────
         printer_svc = getattr(self.container, 'printer_service', None)
+        tiene_termica = False
         if printer_svc and printer_svc.has_ticket_printer():
+            tiene_termica = True
+        elif self._hw_impresora_habilitada:
+            # Compatibilidad legacy: hay configuración hardware activa aunque
+            # el contenedor no exponga PrinterService completo.
+            tiene_termica = True
+
+        if tiene_termica:
             try:
-                job_id = printer_svc.print_ticket(datos_ticket)
-                if job_id:
+                if printer_svc and printer_svc.has_ticket_printer():
+                    job_id = printer_svc.print_ticket(datos_ticket)
+                    if job_id:
+                        self.guardar_ticket_pdf(datos_ticket)
+                        return
+                else:
+                    # Fallback legacy de impresión térmica cuando solo existe
+                    # configuración de hardware en BD.
+                    self._imprimir_ticket_hardware(datos_ticket)
                     self.guardar_ticket_pdf(datos_ticket)
                     return
             except Exception as _e:
                 logger.warning("PrinterService: %s", _e)
         else:
-            QMessageBox.critical(
+            QMessageBox.information(
                 self,
                 "Impresión térmica no configurada",
-                "No hay impresora térmica ESC/POS configurada.",
+                "No hay impresora térmica ESC/POS configurada.\n"
+                "Se guardará PDF de auditoría del ticket.",
             )
-            logger.warning("Ticket térmico cancelado: no hay impresora ESC/POS configurada.")
+            logger.info("Ticket térmico no disponible (sin ESC/POS). Se guardará PDF de auditoría.")
 
         # ── Ruta 4: PDF de auditoría (siempre) ───────────────────────────────
         try:
@@ -3396,27 +3481,36 @@ class ModuloVentas(ModuloBase):
             self.mostrar_mensaje("Éxito", f"Producto '{producto}' eliminado del carrito.")
 
     def calcular_totales(self):
-        precio_base = sum(
-            item['cantidad'] * item['precio_unitario']
-            for item in self.compra_actual
-        )
-        subtotal = sum(item['total'] for item in self.compra_actual)
-        descuento_total = round(precio_base - subtotal, 2)
-
         # IVA: carnes y alimentos basicos = 0% en Mexico (LIVA Art. 2-A)
         # Delegado a ConfigService — sin SQL directo en UI
         try:
             tasa_iva = float(self.container.config_service.get('tasa_iva', 0.0) or 0.0)
         except Exception:
             tasa_iva = 0.0
-        impuestos = subtotal * tasa_iva
-        total_final = subtotal + impuestos
+        try:
+            from core.services.sales.cart_calculator import CartCalculator
+            resumen = CartCalculator.calculate(
+                items=self.compra_actual,
+                iva_rate=tasa_iva,
+            )
+        except Exception:
+            resumen = {
+                'precio_base': sum(item['cantidad'] * item['precio_unitario'] for item in self.compra_actual),
+                'descuento_lineas': 0.0,
+                'subtotal': sum(item['total'] for item in self.compra_actual),
+                'impuestos': 0.0,
+                'total_final': sum(item['total'] for item in self.compra_actual),
+                'puntos_preview': 0,
+            }
 
         self.totales = {
-            'subtotal': subtotal,
-            'impuestos': impuestos,
-            'total_final': total_final
+            'subtotal': resumen['subtotal'],
+            'impuestos': resumen['impuestos'],
+            'total_final': resumen['total_final']
         }
+        precio_base = resumen['precio_base']
+        descuento_total = resumen['descuento_lineas']
+        total_final = resumen['total_final']
 
         # Update breakdown labels
         if hasattr(self, '_lbl_subtotal_val'):
@@ -3449,7 +3543,7 @@ class ModuloVentas(ModuloBase):
             else:
                 self.btn_cobrar.setText("💰 COBRAR")
 
-        puntos_venta = int(total_final)
+        puntos_venta = int(resumen.get('puntos_preview', total_final))
         self.lbl_puntos_venta.setText(f"+ {puntos_venta} pts")
 
     def _cliente_textchanged(self, text: str) -> None:
@@ -3510,8 +3604,12 @@ class ModuloVentas(ModuloBase):
             return
 
         try:
+            lookup = self._customer_lookup_svc
             _cli = self._cli_repo
-            clientes = _cli.buscar(termino, limit=1) if _cli else []
+            if lookup:
+                clientes = lookup.buscar_cliente(termino, limit=1)
+            else:
+                clientes = _cli.buscar(termino, limit=1) if _cli else []
             cliente = clientes[0] if clientes else None
 
             if cliente:
@@ -3780,7 +3878,8 @@ class ModuloVentas(ModuloBase):
                 puntos_solicitados=int(max(0, puntos)),
             )
 
-        dialogo = DialogoPago(
+        from presentation.sales.dialogs.payment_dialog import DialogoPago as PaymentDialog
+        dialogo = PaymentDialog(
             total_a_pagar,
             self,
             loyalty_balance=loyalty_preview,
@@ -3922,52 +4021,19 @@ class ModuloVentas(ModuloBase):
             except Exception:
                 pass  # No bloquea la venta si la validación falla
 
-            # v13.1: use ProcesarVentaUC (orquestador) when available
-            _uc = getattr(self.container, 'uc_venta', None)
-            if _uc:
-                from core.use_cases.venta import ItemCarrito, DatosPago as _DP
-                _items_uc = [ItemCarrito(
-                    producto_id  = it['product_id'],
-                    cantidad     = float(it['qty']),
-                    precio_unit  = float(it['unit_price']),
-                    nombre       = it.get('name', ''),
-                    es_compuesto = int(it.get('es_compuesto', 0)),
-                ) for it in carrito_limpio]
-                _dp = _DP(
-                    forma_pago       = datos_pago['forma_pago'],
-                    monto_pagado     = datos_pago['efectivo_recibido'] if datos_pago['forma_pago'] == 'Efectivo' else self.totales['total_final'],
-                    cliente_id       = cliente_id,
-                    descuento_global = float(datos_pago.get('descuento', 0)),
-                    puntos_canjeados = int(datos_pago.get('puntos_canjeados', 0) or 0),
-                    descuento_puntos = float(datos_pago.get('descuento_puntos', 0.0) or 0.0),
-                    notas            = f"Venta POS Mostrador. Cajero: {usuario}.",
-                )
-                _r = _uc.ejecutar(_items_uc, _dp, self.sucursal_id, usuario)
-                if not _r.ok:
-                    raise RuntimeError(_r.error)
-                folio = _r.folio
-                self._ultima_venta_id = _r.venta_id
-                self.btn_factura.setEnabled(bool(_r.venta_id))
-                self.btn_reimprimir.setEnabled(bool(_r.venta_id))
-                if _r.ticket_html:
-                    self._ticket_html_cache = _r.ticket_html
-            else:
-                # Fallback directo (sin UC — compatibilidad)
-                folio, _ticket_html = self.container.sales_service.execute_sale(
-                    branch_id=self.sucursal_id,
-                    user=usuario,
-                    items=carrito_limpio,
-                    payment_method=datos_pago['forma_pago'],
-                    amount_paid=datos_pago['efectivo_recibido'] if datos_pago['forma_pago'] == 'Efectivo' else self.totales['total_final'],
-                    client_id=cliente_id,
-                    loyalty_redemption_pts=int(datos_pago.get('puntos_canjeados', 0) or 0),
-                    notes=f"Venta POS Mostrador. Cajero: {usuario}.",
-                )
-                _sale = getattr(self.container, 'sales_repo', None)
-                _sr = _sale.get_sale_by_folio(folio) if _sale else None
-                self._ultima_venta_id = _sr['id'] if _sr else None
-                if hasattr(self,'btn_reimprimir'):
-                    self.btn_reimprimir.setEnabled(bool(self._ultima_venta_id))
+            # Fase 2: entrada canónica obligatoria vía ProcesarVentaUC
+            _r = self._procesar_venta_via_uc(
+                carrito_limpio=carrito_limpio,
+                datos_pago=datos_pago,
+                cliente_id=cliente_id,
+                usuario=usuario,
+            )
+            folio = _r.folio
+            self._ultima_venta_id = _r.venta_id
+            self.btn_factura.setEnabled(bool(_r.venta_id))
+            self.btn_reimprimir.setEnabled(bool(_r.venta_id))
+            if _r.ticket_html:
+                self._ticket_html_cache = _r.ticket_html
 
             self._abrir_cajon()
 
@@ -4090,6 +4156,46 @@ class ModuloVentas(ModuloBase):
             self.guardar_ticket_pdf(ticket_data)
         except Exception as e:
             logger.error("Error generando ticket: %s", e)
+
+    def _procesar_venta_via_uc(self, carrito_limpio, datos_pago, cliente_id, usuario):
+        """
+        Fase 2: punto único desde POS UI para crear ventas.
+        Prohíbe bypass directo a SalesService desde la vista.
+        """
+        _uc = getattr(self.container, 'uc_venta', None)
+        if _uc is None:
+            raise RuntimeError(
+                "ProcesarVentaUC no disponible en AppContainer. "
+                "La UI de ventas no puede ejecutar ventas sin UC canónico."
+            )
+
+        from core.use_cases.venta import ItemCarrito, DatosPago as _DP
+        _items_uc = [ItemCarrito(
+            producto_id=it['product_id'],
+            cantidad=float(it['qty']),
+            precio_unit=float(it['unit_price']),
+            nombre=it.get('name', ''),
+            es_compuesto=int(it.get('es_compuesto', 0)),
+        ) for it in carrito_limpio]
+        _dp = _DP(
+            forma_pago=datos_pago['forma_pago'],
+            monto_pagado=(
+                datos_pago['efectivo_recibido']
+                if datos_pago['forma_pago'] == 'Efectivo'
+                else self.totales['total_final']
+            ),
+            cliente_id=cliente_id,
+            descuento_global=float(datos_pago.get('descuento', 0)),
+            puntos_canjeados=int(datos_pago.get('puntos_canjeados', 0) or 0),
+            descuento_puntos=float(datos_pago.get('descuento_puntos', 0.0) or 0.0),
+            notas=f"Venta POS Mostrador. Cajero: {usuario}.",
+            sucursal_id=self.sucursal_id,
+            usuario=usuario,
+        )
+        _r = _uc.ejecutar(_items_uc, _dp, self.sucursal_id, usuario)
+        if not _r.ok:
+            raise RuntimeError(_r.error)
+        return _r
 
     def guardar_ticket_pdf(self, ticket_data: Dict[str, Any]):
         try:
@@ -4425,11 +4531,20 @@ class ModuloVentas(ModuloBase):
             }
             # Fase 10: Reimpresión térmica separada de PDF de auditoría.
             ps = getattr(self.container, 'printer_service', None)
+            if ps and ps.has_ticket_printer():
+                ps.print_ticket(datos_ticket)
+                return
+
+            # Compatibilidad legacy: si hay impresora habilitada en
+            # hardware_config, intentar la ruta de hardware clásica.
+            if self._hw_impresora_habilitada:
+                self._imprimir_ticket_hardware(datos_ticket)
+                return
+
             if not ps or not ps.has_ticket_printer():
                 QMessageBox.critical(self, "Impresión térmica no configurada",
                                      "No hay impresora térmica ESC/POS configurada.")
                 return
-            ps.print_ticket(datos_ticket)
         except Exception as e:
             QMessageBox.critical(self, "Error", str(e))
 

--- a/pos_spj_v13.4/presentation/sales/cart_view_model.py
+++ b/pos_spj_v13.4/presentation/sales/cart_view_model.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+
+class CartViewModel:
+    """UI-focused cart state holder, independent from persistence/services."""
+
+    def __init__(self, items: Optional[List[Dict[str, Any]]] = None):
+        self._items: List[Dict[str, Any]] = []
+        for it in (items or []):
+            self.add_item(dict(it))
+
+    @property
+    def items(self) -> List[Dict[str, Any]]:
+        return self._items
+
+    def clear(self) -> None:
+        self._items.clear()
+
+    def add_item(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        out = dict(item)
+        out.setdefault('_uid', uuid.uuid4().hex)
+        out.setdefault('cantidad', 0.0)
+        out.setdefault('precio_unitario', 0.0)
+        out.setdefault('descuento_pct', 0.0)
+        out['total'] = float(out.get('total', float(out['cantidad']) * float(out['precio_unitario'])))
+        self._items.append(out)
+        return out
+
+    def remove_by_uid(self, uid: str) -> bool:
+        before = len(self._items)
+        self._items = [it for it in self._items if it.get('_uid') != uid]
+        return len(self._items) != before
+
+    def update_quantity(self, uid: str, qty: float) -> bool:
+        for it in self._items:
+            if it.get('_uid') == uid:
+                it['cantidad'] = float(qty)
+                it['total'] = round(float(qty) * float(it.get('precio_unitario', 0.0)), 2)
+                return True
+        return False
+
+    def selected(self, uid: str) -> Optional[Dict[str, Any]]:
+        for it in self._items:
+            if it.get('_uid') == uid:
+                return it
+        return None
+
+    def to_item_carrito_payload(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                'producto_id': it.get('id'),
+                'cantidad': float(it.get('cantidad', 0.0)),
+                'precio_unit': float(it.get('precio_unitario', 0.0)),
+                'nombre': it.get('nombre', ''),
+                'es_compuesto': int(it.get('es_compuesto', 0) or 0),
+            }
+            for it in self._items
+        ]

--- a/pos_spj_v13.4/presentation/sales/dialogs/payment_dialog.py
+++ b/pos_spj_v13.4/presentation/sales/dialogs/payment_dialog.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+from PyQt5.QtWidgets import (QDialog, QWidget, QVBoxLayout, QFrame, QLabel, QFormLayout, QComboBox, QDoubleSpinBox,
+    QHBoxLayout, QCheckBox, QSpinBox, QPushButton)
+from PyQt5.QtCore import Qt
+
+
+class DialogoPago(QDialog):
+    def __init__(self, total_a_pagar: float, parent: QWidget = None,
+                 loyalty_balance: Dict = None, loyalty_preview_provider=None):
+        super().__init__(parent)
+        self.setWindowTitle("Cobrar")
+        self.setModal(True)
+        self.setMinimumSize(460, 400)
+        self.resize(500, 460)
+        # ISSUE 4 FIX: objectName para que el QSS global pueda estilizar el diálogo
+        self.setObjectName("paymentDialog")
+        self.total_a_pagar = float(total_a_pagar) if total_a_pagar is not None else 0.0
+        self.total_original = self.total_a_pagar
+        self.efectivo_recibido = 0.0
+        self.cambio = 0.0
+        self.forma_pago = "Efectivo"
+        self.saldo_credito = 0.0
+        self._loyalty = loyalty_balance or {}
+        self._loyalty_preview_provider = loyalty_preview_provider
+        self.puntos_a_canjear = 0
+        self.descuento_puntos = 0.0
+        self.init_ui()
+        self.conectar_eventos()
+
+    def init_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setSpacing(8)
+        layout.setContentsMargins(16, 14, 16, 14)
+
+        # ── Header: Total prominente ────────────────────────────────────────
+        header = QFrame()
+        header.setObjectName("paymentHeader")
+        hdr_lay = QVBoxLayout(header)
+        hdr_lay.setContentsMargins(12, 10, 12, 10)
+        hdr_lay.setSpacing(2)
+        lbl_caption = QLabel("TOTAL A COBRAR")
+        lbl_caption.setObjectName("paymentCaption")
+        lbl_caption.setAlignment(Qt.AlignCenter)
+        self.lbl_total = QLabel(f"${self.total_a_pagar:.2f}")
+        self.lbl_total.setObjectName("paymentTotalAmount")
+        self.lbl_total.setAlignment(Qt.AlignCenter)
+        hdr_lay.addWidget(lbl_caption)
+        hdr_lay.addWidget(self.lbl_total)
+        layout.addWidget(header)
+
+        # ── Form ────────────────────────────────────────────────────────────
+        form_layout = QFormLayout()
+        form_layout.setSpacing(8)
+        form_layout.setContentsMargins(0, 4, 0, 4)
+        form_layout.setLabelAlignment(Qt.AlignRight | Qt.AlignVCenter)
+
+        self.cmb_forma_pago = QComboBox()
+        self.cmb_forma_pago.addItems(["Efectivo", "Tarjeta", "Transferencia", "Crédito", "Pago Mixto", "Mercado Pago"])
+        self.cmb_forma_pago.setObjectName("paymentCombo")
+        self.cmb_forma_pago.setMinimumHeight(32)
+        form_layout.addRow("Forma de pago:", self.cmb_forma_pago)
+
+        self.txt_recibido = QDoubleSpinBox()
+        self.txt_recibido.setRange(0.00, 99999.00)
+        self.txt_recibido.setDecimals(2)
+        self.txt_recibido.setValue(self.total_a_pagar)
+        self.txt_recibido.setSingleStep(10.0)
+        self.txt_recibido.setPrefix("$ ")
+        self.txt_recibido.setMinimumHeight(36)
+        self.txt_recibido.setObjectName("paymentSpinbox")
+        self.txt_recibido.lineEdit().setReadOnly(False)
+        form_layout.addRow("Monto recibido:", self.txt_recibido)
+        
+        self.lbl_cambio = QLabel("Cambio: $0.00")
+        self.lbl_cambio.setObjectName("paymentChange")
+        form_layout.addRow("", self.lbl_cambio)
+
+        # v13.4 Fase 2: Sección de canje de puntos
+        self._loyalty_widget = QWidget()
+        _loy_lay = QVBoxLayout(self._loyalty_widget)
+        _loy_lay.setContentsMargins(0, 0, 0, 0)
+        _loy_lay.setSpacing(3)
+        pts = self._loyalty.get("puntos_disponibles", self._loyalty.get("puntos", 0))
+        valor = self._loyalty.get("descuento_maximo", self._loyalty.get("valor_canje", 0))
+        puede = self._loyalty.get("enabled", self._loyalty.get("puede_canjear", False))
+
+        _loy_header = QHBoxLayout()
+        self._lbl_puntos = QLabel(f"⭐ {pts} puntos disponibles (=${valor:.2f})")
+        self._lbl_puntos.setProperty("class", "text-bold")
+        _loy_header.addWidget(self._lbl_puntos)
+        _loy_lay.addLayout(_loy_header)
+
+        _loy_row = QHBoxLayout()
+        self._chk_canjear = QCheckBox("Usar puntos")
+        self._chk_canjear.setEnabled(puede)
+        self._chk_canjear.toggled.connect(self._toggle_canje)
+        self._spin_puntos = QSpinBox()
+        self._spin_puntos.setRange(0, pts)
+        self._spin_puntos.setValue(pts)
+        self._spin_puntos.setEnabled(False)
+        self._spin_puntos.setSuffix(" pts")
+        self._spin_puntos.valueChanged.connect(self._recalcular_canje)
+        self._lbl_desc_puntos = QLabel("")
+        self._lbl_desc_puntos.setProperty("class", "text-success")
+        _loy_row.addWidget(self._chk_canjear)
+        _loy_row.addWidget(self._spin_puntos)
+        _loy_row.addWidget(self._lbl_desc_puntos)
+        _loy_lay.addLayout(_loy_row)
+
+        if not puede and pts > 0:
+            mn = self._loyalty.get("min_puntos_canje", 100)
+            _loy_lay.addWidget(QLabel(f"Mínimo {mn} puntos para canjear"))
+        self._loyalty_widget.setVisible(pts > 0)
+        form_layout.addRow("", self._loyalty_widget)
+        
+        self.txt_saldo_credito = QDoubleSpinBox()
+        self.txt_saldo_credito.setRange(0.00, 99999.00)
+        self.txt_saldo_credito.setDecimals(2)
+        self.txt_saldo_credito.setValue(self.total_a_pagar)
+        self.txt_saldo_credito.setProperty("class", "payment-spinbox")
+        form_layout.addRow("Saldo Adeudado:", self.txt_saldo_credito)
+        self.txt_saldo_credito.hide()
+
+        # Pago mixto (efectivo + tarjeta)
+        self._mixto_widget = QWidget()
+        _ml = QHBoxLayout(self._mixto_widget)
+        _ml.setContentsMargins(0, 0, 0, 0)
+        _ml.addWidget(QLabel("Efectivo:"))
+        self.spin_efectivo_mixto = QDoubleSpinBox()
+        self.spin_efectivo_mixto.setRange(0, 99999); self.spin_efectivo_mixto.setDecimals(2)
+        self.spin_efectivo_mixto.valueChanged.connect(self._recalcular_mixto)
+        _ml.addWidget(self.spin_efectivo_mixto)
+        _ml.addWidget(QLabel("Tarjeta:"))
+        self.spin_tarjeta_mixto = QDoubleSpinBox()
+        self.spin_tarjeta_mixto.setRange(0, 99999); self.spin_tarjeta_mixto.setDecimals(2)
+        self.spin_tarjeta_mixto.valueChanged.connect(self._recalcular_mixto)
+        _ml.addWidget(self.spin_tarjeta_mixto)
+        self.lbl_mixto_diff = QLabel("")
+        self.lbl_mixto_diff.setProperty("class", "text-danger caption")
+        _ml.addWidget(self.lbl_mixto_diff)
+        self._mixto_widget.hide()
+        form_layout.addRow("", self._mixto_widget)
+        
+        layout.addLayout(form_layout)
+        layout.addStretch(1)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.setSpacing(8)
+        self.btn_cancelar = QPushButton("Cancelar")
+        self.btn_cancelar.setObjectName("paymentCancelBtn")
+        self.btn_cancelar.setMinimumHeight(36)
+        self.btn_aceptar = QPushButton("💰 Confirmar Pago")
+        self.btn_aceptar.setObjectName("paymentConfirmBtn")
+        self.btn_aceptar.setMinimumHeight(40)
+        btn_layout.addWidget(self.btn_cancelar)
+        btn_layout.addWidget(self.btn_aceptar, 2)
+        layout.addLayout(btn_layout)
+
+        self.calcular_cambio()
+        
+    def conectar_eventos(self):
+        self.txt_recibido.valueChanged.connect(self.calcular_cambio)
+        self.cmb_forma_pago.currentTextChanged.connect(self.cambiar_forma_pago)
+        self.btn_aceptar.clicked.connect(self.accept)
+        self.btn_cancelar.clicked.connect(self.reject)
+
+    def showEvent(self, event):
+        """v13.4: Auto-focus y select all en campo de efectivo."""
+        super().showEvent(event)
+        from PyQt5.QtCore import QTimer
+        QTimer.singleShot(50, lambda: (
+            self.txt_recibido.setFocus(),
+            self.txt_recibido.selectAll()))
+        
+    def cambiar_forma_pago(self, forma_pago):
+        try:
+            from core.services.sales.payment_policy import PaymentPolicy
+            self.forma_pago = PaymentPolicy.normalize_payment_method(forma_pago)
+        except Exception:
+            self.forma_pago = forma_pago
+        forma_pago = self.forma_pago
+        if forma_pago == "Efectivo":
+            self.txt_recibido.setEnabled(True)
+            self.txt_recibido.setValue(self.total_a_pagar)
+            self.lbl_cambio.show()
+            self.txt_saldo_credito.hide()
+        elif forma_pago == "Crédito":
+            self.txt_recibido.setEnabled(False)
+            self.lbl_cambio.hide()
+            self.txt_saldo_credito.show()
+            self.txt_saldo_credito.setValue(self.total_a_pagar)
+        elif forma_pago == "Mercado Pago":
+            self.txt_recibido.setEnabled(False)
+            self.txt_recibido.setValue(self.total_a_pagar)
+            self.lbl_cambio.hide()
+            self.txt_saldo_credito.hide()
+            self._mixto_widget.hide()
+            # Mostrar info: se generará link al confirmar
+            self.lbl_mp_info = getattr(self, 'lbl_mp_info', None)
+            if not self.lbl_mp_info:
+                from PyQt5.QtWidgets import QLabel
+                self.lbl_mp_info = QLabel("🔗 Se generará link de pago al confirmar")
+                self.lbl_mp_info.setProperty("class", "text-info caption-bold")
+                self.layout().insertWidget(self.layout().count()-1, self.lbl_mp_info)
+            self.lbl_mp_info.show()
+        elif forma_pago == "Pago Mixto":
+            self.txt_recibido.setEnabled(False)
+            self.lbl_cambio.hide()
+            self.txt_saldo_credito.hide()
+            self._mixto_widget.show()
+            self.spin_efectivo_mixto.setValue(round(self.total_a_pagar * 0.5, 2))
+            self.spin_tarjeta_mixto.setValue(round(self.total_a_pagar * 0.5, 2))
+        else:
+            self.txt_recibido.setEnabled(False)
+            self.txt_recibido.setValue(self.total_a_pagar)
+            self.lbl_cambio.hide()
+            self.txt_saldo_credito.hide()
+            self._mixto_widget.hide()
+        if hasattr(self,'lbl_mp_info') and self.lbl_mp_info and forma_pago != 'Mercado Pago':
+            self.lbl_mp_info.hide()
+        self.calcular_cambio()
+
+    def calcular_cambio(self):
+        self.efectivo_recibido = self.txt_recibido.value()
+        try:
+            from core.services.sales.payment_policy import PaymentPolicy
+            validation = PaymentPolicy.validate_payment(
+                total=self.total_a_pagar,
+                method=self.forma_pago,
+                amount_paid=self.efectivo_recibido,
+                cash=self.spin_efectivo_mixto.value() if hasattr(self, "spin_efectivo_mixto") else 0.0,
+                card=self.spin_tarjeta_mixto.value() if hasattr(self, "spin_tarjeta_mixto") else 0.0,
+            )
+            self.cambio = float(validation.get("change", 0.0))
+            ok = bool(validation.get("ok", True))
+        except Exception:
+            ok = True
+            self.cambio = round(self.efectivo_recibido - self.total_a_pagar, 2) if self.forma_pago == "Efectivo" else 0.0
+        if self.forma_pago == "Efectivo":
+            self.lbl_cambio.setText(f"Cambio: ${self.cambio:.2f}")
+            if not ok or self.cambio < 0:
+                self.btn_aceptar.setEnabled(False)
+                self.lbl_cambio.setProperty("class", "payment-change-negative")
+            else:
+                self.btn_aceptar.setEnabled(True)
+                self.lbl_cambio.setProperty("class", "payment-change")
+        else:
+            self.efectivo_recibido = self.total_a_pagar
+            self.cambio = 0.0
+            self.btn_aceptar.setEnabled(True)
+
+    def _recalcular_mixto(self):
+        if self.forma_pago != "Pago Mixto":
+            return
+        ef = self.spin_efectivo_mixto.value()
+        ta = self.spin_tarjeta_mixto.value()
+        try:
+            from core.services.sales.payment_policy import PaymentPolicy
+            v = PaymentPolicy.validate_mixed_payment(self.total_a_pagar, ef, ta)
+            diff = float(v.get("diff", 0.0))
+        except Exception:
+            total = ef + ta
+            diff = round(total - self.total_a_pagar, 2)
+        if abs(diff) < 0.01:
+            self.lbl_mixto_diff.setText("✅ Cuadra")
+            self.lbl_mixto_diff.setProperty("class", "text-success caption")
+            self.btn_aceptar.setEnabled(True)
+        elif diff > 0:
+            self.lbl_mixto_diff.setText(f"Sobran ${diff:.2f}")
+            self.lbl_mixto_diff.setProperty("class", "text-warning caption")
+            self.btn_aceptar.setEnabled(True)
+        else:
+            self.lbl_mixto_diff.setText(f"Faltan ${abs(diff):.2f}")
+            self.lbl_mixto_diff.setProperty("class", "text-danger caption")
+            self.btn_aceptar.setEnabled(False)
+
+    def _toggle_canje(self, checked: bool):
+        """v13.4 Fase 0 hotfix: Activa/desactiva el canje de puntos de fidelidad."""
+        if not hasattr(self, "_spin_puntos"):
+            return
+        self._spin_puntos.setEnabled(checked)
+        if checked:
+            self._recalcular_canje(self._spin_puntos.value())
+        else:
+            self.descuento_puntos = 0.0
+            self.puntos_a_canjear = 0
+            self.total_a_pagar = self.total_original
+            self._lbl_desc_puntos.setText("")
+            self.lbl_total.setText(f"Total a pagar: ${self.total_a_pagar:.2f}")
+            if hasattr(self, "txt_recibido"):
+                self.txt_recibido.setValue(self.total_a_pagar)
+            self.calcular_cambio()
+
+    def _recalcular_canje(self, value: int):
+        """v13.4 Fase 0 hotfix: Recalcula descuento al modificar puntos a canjear."""
+        if not hasattr(self, "_chk_canjear") or not self._chk_canjear.isChecked():
+            return
+        descuento = 0.0
+        if callable(self._loyalty_preview_provider):
+            try:
+                preview = self._loyalty_preview_provider(value, self.total_original) or {}
+                descuento = float(preview.get("descuento", 0.0))
+            except Exception:
+                descuento = 0.0
+        else:
+            descuento = 0.0
+        descuento = min(round(descuento, 2), self.total_original)
+        self.descuento_puntos = descuento
+        self.puntos_a_canjear = value
+        self.total_a_pagar = round(self.total_original - descuento, 2)
+        self._lbl_desc_puntos.setText(f"-${descuento:.2f}")
+        self.lbl_total.setText(f"Total a pagar: ${self.total_a_pagar:.2f}")
+        if hasattr(self, "txt_recibido"):
+            self.txt_recibido.setValue(self.total_a_pagar)
+        self.calcular_cambio()
+
+    def get_datos_pago(self) -> Dict[str, Any]:
+        try:
+            from core.services.sales.payment_policy import PaymentPolicy
+            payload = PaymentPolicy.build_payment_breakdown(
+                total=self.total_a_pagar,
+                method=self.forma_pago,
+                amount_paid=self.efectivo_recibido,
+                cash=self.spin_efectivo_mixto.value() if self.forma_pago == "Pago Mixto" else 0.0,
+                card=self.spin_tarjeta_mixto.value() if self.forma_pago == "Pago Mixto" else 0.0,
+                saldo_credito=self.txt_saldo_credito.value() if self.forma_pago == "Crédito" else 0.0,
+            )
+        except Exception:
+            payload = {
+                "forma_pago": self.forma_pago,
+                "total_pagado": self.total_a_pagar,
+                "efectivo_recibido": self.efectivo_recibido,
+                "monto_tarjeta_mixto": 0.0,
+                "cambio": self.cambio,
+                "saldo_credito": self.txt_saldo_credito.value() if self.forma_pago == "Crédito" else 0.0,
+            }
+        payload.update({
+            "puntos_canjeados": self.puntos_a_canjear,
+            "descuento_puntos": self.descuento_puntos,
+        })
+        return payload
+

--- a/pos_spj_v13.4/tests/test_phase10_sales_reversal_events.py
+++ b/pos_spj_v13.4/tests/test_phase10_sales_reversal_events.py
@@ -1,0 +1,12 @@
+from core.services.sales_reversal_service import SalesReversalService
+
+
+def test_phase10_event_names_present_for_compensations():
+    import inspect
+    src = inspect.getsource(SalesReversalService)
+    assert 'SALE_CANCELLED' in src
+    assert 'SALE_REFUNDED' in src
+    assert 'SALE_CREDIT_NOTE_ISSUED' in src
+    assert 'SALE_LOYALTY_REVERSED' in src
+    assert 'SALE_CASH_COMPENSATED' in src
+    assert 'SALE_INVENTORY_RESTORED' in src

--- a/pos_spj_v13.4/tests/test_phase11_payment_dialog_extraction.py
+++ b/pos_spj_v13.4/tests/test_phase11_payment_dialog_extraction.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_phase11_payment_dialog_extracted_and_used():
+    p = Path('pos_spj_v13.4/presentation/sales/dialogs/payment_dialog.py')
+    assert p.exists()
+    src_ui = Path('pos_spj_v13.4/modulos/ventas.py').read_text(encoding='utf-8')
+    assert 'from presentation.sales.dialogs.payment_dialog import DialogoPago as PaymentDialog' in src_ui
+    assert 'dialogo = PaymentDialog(' in src_ui

--- a/pos_spj_v13.4/tests/test_phase12_regression_matrix.py
+++ b/pos_spj_v13.4/tests/test_phase12_regression_matrix.py
@@ -1,0 +1,38 @@
+from core.services.sales.cart_calculator import CartCalculator
+from core.services.sales.payment_policy import PaymentPolicy
+from core.use_cases.venta import DatosPago
+
+
+def test_venta_metodos_pago_basicos_matrix():
+    methods = ["Efectivo", "Tarjeta", "Transferencia", "Crédito", "Pago Mixto", "Mercado Pago"]
+    normalized = [PaymentPolicy.normalize_payment_method(m) for m in methods]
+    assert normalized == methods
+
+
+def test_descuento_global_y_linea_y_puntos_preview():
+    items = [
+        {"cantidad": 2, "precio_unitario": 100, "total": 180},  # desc línea 20
+        {"cantidad": 1, "precio_unitario": 50, "total": 50},
+    ]
+    r = CartCalculator.calculate(items, global_discount=10, loyalty_discount=5)
+    assert r["descuento_lineas"] == 20
+    assert r["subtotal"] == 215
+    assert r["puntos_preview"] == 215
+
+
+def test_credito_sin_credito_suficiente_detectable_por_policy_hook():
+    # La policy indica si es crédito; el rechazo de límite lo hace customer_service en SalesService
+    assert PaymentPolicy.is_credit_sale("Crédito") is True
+
+
+def test_mercadopago_pendiente_no_genera_cambio():
+    r = PaymentPolicy.validate_payment(total=100, method="Mercado Pago", amount_paid=0)
+    assert r["ok"] is True
+    assert r["change"] == 0.0
+
+
+def test_datos_pago_operation_id_y_normalizacion():
+    dp = DatosPago(forma_pago="credito", monto_pagado=0, operation_id="op-xyz", puntos_canjeados=5)
+    assert dp.forma_pago in ("Crédito", "Credito")
+    assert dp.operation_id == "op-xyz"
+    assert dp.puntos_canjeados == 5

--- a/pos_spj_v13.4/tests/test_phase2_pos_venta_usa_uc.py
+++ b/pos_spj_v13.4/tests/test_phase2_pos_venta_usa_uc.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_pos_venta_usa_uc():
+    src = Path("pos_spj_v13.4/modulos/ventas.py").read_text(encoding="utf-8")
+    start = src.find("def _procesar_venta_via_uc")
+    assert start >= 0
+    end = src.find("\n    def ", start + 1)
+    block = src[start:end if end > start else None]
+
+    assert "_uc.ejecutar(" in block
+    assert "execute_sale(" not in block
+
+
+def test_pos_venta_falla_si_uc_no_disponible():
+    src = Path("pos_spj_v13.4/modulos/ventas.py").read_text(encoding="utf-8")
+    assert "ProcesarVentaUC no disponible" in src

--- a/pos_spj_v13.4/tests/test_phase2_procesar_venta_uc.py
+++ b/pos_spj_v13.4/tests/test_phase2_procesar_venta_uc.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+from core.use_cases.venta import ProcesarVentaUC, ItemCarrito, DatosPago
+
+
+class _Inv:
+    def __init__(self, stock=999):
+        self.stock = stock
+
+    def get_stock(self, producto_id, sucursal_id):
+        return self.stock
+
+
+class _Sales:
+    def __init__(self):
+        self.db = SimpleNamespace(execute=lambda *a, **k: SimpleNamespace(fetchone=lambda: [123]))
+
+    def execute_sale(self, **kwargs):
+        return ("F-UC", "<html></html>")
+
+
+def _uc(stock=999):
+    return ProcesarVentaUC(
+        sales_service=_Sales(),
+        inventory_service=_Inv(stock=stock),
+        finance_service=None,
+        loyalty_service=None,
+        ticket_engine=None,
+    )
+
+
+def test_procesar_venta_efectivo_ok():
+    uc = _uc()
+    r = uc.ejecutar(
+        items=[ItemCarrito(producto_id=1, cantidad=1, precio_unit=100.0, nombre="P")],
+        datos_pago=DatosPago(forma_pago="Efectivo", monto_pagado=100.0),
+        sucursal_id=1,
+        usuario="u",
+    )
+    assert r.ok is True
+
+
+def test_procesar_venta_credito_ok():
+    uc = _uc()
+    r = uc.ejecutar(
+        items=[ItemCarrito(producto_id=1, cantidad=1, precio_unit=100.0, nombre="P")],
+        datos_pago=DatosPago(forma_pago="Crédito", monto_pagado=100.0, cliente_id=3),
+        sucursal_id=1,
+        usuario="u",
+    )
+    assert r.ok is True
+
+
+def test_procesar_venta_con_puntos_ok():
+    uc = _uc()
+    r = uc.ejecutar(
+        items=[ItemCarrito(producto_id=1, cantidad=1, precio_unit=100.0, nombre="P")],
+        datos_pago=DatosPago(forma_pago="Efectivo", monto_pagado=100.0, puntos_canjeados=10),
+        sucursal_id=1,
+        usuario="u",
+    )
+    assert r.ok is True
+
+
+def test_procesar_venta_stock_insuficiente():
+    uc = _uc(stock=0)
+    r = uc.ejecutar(
+        items=[ItemCarrito(producto_id=1, cantidad=1, precio_unit=100.0, nombre="P")],
+        datos_pago=DatosPago(forma_pago="Efectivo", monto_pagado=100.0),
+        sucursal_id=1,
+        usuario="u",
+    )
+    assert r.ok is False
+    assert "Stock insuficiente" in r.error

--- a/pos_spj_v13.4/tests/test_phase3_query_services.py
+++ b/pos_spj_v13.4/tests/test_phase3_query_services.py
@@ -1,0 +1,43 @@
+import sqlite3
+
+from core.services.sales.product_catalog_query_service import ProductCatalogQueryService
+from core.services.sales.customer_lookup_service import CustomerLookupService
+
+
+def _db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE productos (id INTEGER, nombre TEXT, precio REAL, existencia REAL, unidad TEXT, categoria TEXT, stock_minimo REAL, imagen_path TEXT, es_compuesto INTEGER, es_subproducto INTEGER, codigo_barras TEXT, codigo TEXT, oculto INTEGER, activo INTEGER)")
+    conn.execute("CREATE TABLE branch_inventory (product_id INTEGER, branch_id INTEGER, quantity REAL)")
+    conn.execute("CREATE TABLE clientes (id INTEGER, nombre TEXT, telefono TEXT, email TEXT, direccion TEXT, rfc TEXT, puntos INTEGER, codigo_qr TEXT, saldo REAL, nivel_fidelidad TEXT, activo INTEGER)")
+    conn.execute("CREATE TABLE tarjetas_fidelidad (codigo TEXT, id_cliente INTEGER, activa INTEGER)")
+    return conn
+
+
+def test_product_catalog_query_service_lista_y_categorias():
+    db = _db()
+    db.execute("INSERT INTO productos VALUES (1,'Pollo',100,5,'kg','Carnes',1,'',0,0,'CB1','C1',0,1)")
+    db.execute("INSERT INTO branch_inventory VALUES (1,1,9)")
+    svc = ProductCatalogQueryService(db)
+
+    cats = svc.get_categories()
+    assert 'Carnes' in cats
+
+    rows = svc.list_visible_products(branch_id=1, filtro='Pollo', categoria='Carnes')
+    assert len(rows) == 1
+    assert rows[0]['nombre'] == 'Pollo'
+    assert rows[0]['existencia'] == 9.0
+
+
+def test_customer_lookup_service_busqueda_credito_loyalty():
+    db = _db()
+    db.execute("INSERT INTO clientes VALUES (7,'Ana','555','a@x.com','dir','RFC',25,'QR1',120.5,'Plata',1)")
+    db.execute("INSERT INTO tarjetas_fidelidad VALUES ('CARD7',7,1)")
+
+    svc = CustomerLookupService(db)
+    rows = svc.buscar_cliente('Ana', limit=1)
+    assert rows[0]['id'] == 7
+    assert svc.get_credit_balance(7) == 120.5
+    loyalty = svc.get_loyalty_status(7)
+    assert loyalty['puntos'] == 25
+    assert svc.get_by_loyalty_card('CARD7')['id'] == 7

--- a/pos_spj_v13.4/tests/test_phase4_cart_calculator.py
+++ b/pos_spj_v13.4/tests/test_phase4_cart_calculator.py
@@ -1,0 +1,35 @@
+from core.services.sales.cart_calculator import CartCalculator
+
+
+def test_item_simple():
+    r = CartCalculator.calculate([{'cantidad': 2, 'precio_unitario': 10, 'total': 20}])
+    assert r['subtotal'] == 20
+    assert r['total_final'] == 20
+
+
+def test_descuento_por_linea():
+    r = CartCalculator.calculate([{'cantidad': 2, 'precio_unitario': 10, 'total': 16}])
+    assert r['descuento_lineas'] == 4
+    assert r['total_final'] == 16
+
+
+def test_descuento_global():
+    r = CartCalculator.calculate([{'cantidad': 2, 'precio_unitario': 10, 'total': 20}], global_discount=5)
+    assert r['subtotal'] == 15
+
+
+def test_pago_mixto_cambio_preview():
+    r = CartCalculator.calculate([{'cantidad': 1, 'precio_unitario': 100, 'total': 100}], amount_paid=120)
+    assert r['cambio'] == 20
+
+
+def test_puntos_preview():
+    r = CartCalculator.calculate([{'cantidad': 1, 'precio_unitario': 99.9, 'total': 99.9}])
+    assert r['puntos_preview'] == 99
+
+
+def test_redondeos():
+    r = CartCalculator.calculate([{'cantidad': 1, 'precio_unitario': 10.555, 'total': 10.555}], iva_rate=0.16)
+    assert r['subtotal'] == 10.55
+    assert r['impuestos'] == 1.69
+    assert r['total_final'] == 12.24

--- a/pos_spj_v13.4/tests/test_phase4_cart_view_model.py
+++ b/pos_spj_v13.4/tests/test_phase4_cart_view_model.py
@@ -1,0 +1,15 @@
+from presentation.sales.cart_view_model import CartViewModel
+
+
+def test_cart_vm_add_update_remove_clear_and_payload():
+    vm = CartViewModel()
+    it = vm.add_item({'id': 1, 'nombre': 'Pollo', 'cantidad': 2, 'precio_unitario': 10})
+    uid = it['_uid']
+    assert len(vm.items) == 1
+    assert vm.update_quantity(uid, 3) is True
+    assert vm.selected(uid)['total'] == 30
+    payload = vm.to_item_carrito_payload()
+    assert payload[0]['producto_id'] == 1
+    assert vm.remove_by_uid(uid) is True
+    vm.clear()
+    assert vm.items == []

--- a/pos_spj_v13.4/tests/test_phase5_payment_policy.py
+++ b/pos_spj_v13.4/tests/test_phase5_payment_policy.py
@@ -1,0 +1,32 @@
+from core.services.sales.payment_policy import PaymentPolicy
+
+
+def test_normalize_payment_method():
+    assert PaymentPolicy.normalize_payment_method('credito') == 'Crédito'
+    assert PaymentPolicy.normalize_payment_method('mixto') == 'Pago Mixto'
+    assert PaymentPolicy.normalize_payment_method('mercadopago') == 'Mercado Pago'
+
+
+def test_validate_payment_efectivo_y_cambio():
+    v = PaymentPolicy.validate_payment(total=100, method='Efectivo', amount_paid=120)
+    assert v['ok'] is True
+    assert v['change'] == 20
+
+
+def test_validate_mixed_payment():
+    v = PaymentPolicy.validate_mixed_payment(total=100, cash=40, card=60)
+    assert v['ok'] is True
+    assert v['diff'] == 0
+
+
+def test_build_payment_breakdown_credito_y_mixto():
+    c = PaymentPolicy.build_payment_breakdown(total=200, method='Crédito', saldo_credito=200)
+    assert c['saldo_credito'] == 200
+    m = PaymentPolicy.build_payment_breakdown(total=100, method='Pago Mixto', cash=30, card=80)
+    assert m['monto_tarjeta_mixto'] == 80
+    assert m['cambio'] == 10
+
+
+def test_helpers_credit_pending():
+    assert PaymentPolicy.is_credit_sale('Crédito') is True
+    assert PaymentPolicy.is_pending_payment('Mercado Pago') is True

--- a/pos_spj_v13.4/tests/test_phase6_sale_loyalty_policy.py
+++ b/pos_spj_v13.4/tests/test_phase6_sale_loyalty_policy.py
@@ -1,0 +1,46 @@
+import sqlite3
+
+from core.services.sales.sale_loyalty_policy import SaleLoyaltyPolicy
+
+
+class _LoyaltyStub:
+    def preview_redemption(self, **kwargs):
+        return {"ok": True, "descuento": 10.0}
+
+    def apply_redemption(self, **kwargs):
+        return {"ok": True}
+
+    def process_loyalty_for_sale(self, **kwargs):
+        return {"puntos_ganados": 5, "puntos_totales": 15, "nivel": "Bronce"}
+
+
+def _db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE clientes(id INTEGER PRIMARY KEY, puntos INTEGER)")
+    db.execute("CREATE TABLE historico_puntos(cliente_id INTEGER, tipo TEXT, puntos INTEGER, descripcion TEXT, saldo_actual INTEGER, usuario TEXT, venta_id INTEGER)")
+    db.execute("INSERT INTO clientes(id,puntos) VALUES(1,20)")
+    return db
+
+
+def test_preview_apply_earn_reverse_idempotent():
+    db = _db()
+    p = SaleLoyaltyPolicy(db, loyalty_service=_LoyaltyStub())
+
+    prev = p.preview_redemption(cliente_id=1, puntos=10, subtotal=100)
+    assert prev["ok"] is True
+
+    a1 = p.apply_redemption(cliente_id=1, venta_id=10, puntos=10, operation_id="op:r")
+    a2 = p.apply_redemption(cliente_id=1, venta_id=10, puntos=10, operation_id="op:r")
+    assert a1["ok"] is True
+    assert a2.get("idempotent") is True
+
+    e1 = p.earn_points(cliente_id=1, venta_id=10, total=200, operation_id="op:e")
+    e2 = p.earn_points(cliente_id=1, venta_id=10, total=200, operation_id="op:e")
+    assert e1["ok"] is True
+    assert e2.get("idempotent") is True
+
+    r1 = p.reverse_points(cliente_id=1, venta_id=10, operation_id="op:v", puntos=5, usuario="u")
+    r2 = p.reverse_points(cliente_id=1, venta_id=10, operation_id="op:v", puntos=5, usuario="u")
+    assert r1["ok"] is True
+    assert r2.get("idempotent") is True

--- a/pos_spj_v13.4/tests/test_sales_phase1_dtos.py
+++ b/pos_spj_v13.4/tests/test_sales_phase1_dtos.py
@@ -1,0 +1,76 @@
+from core.use_cases.venta import (
+    DatosPago,
+    ClienteVentaDTO,
+    PaymentBreakdown,
+    LoyaltyRedemptionRequest,
+    LoyaltyRedemptionPreview,
+    SaleContext,
+    ItemCarrito,
+)
+
+
+def test_datos_pago_normaliza_metodos_basicos():
+    assert DatosPago(forma_pago="efectivo").forma_pago == "Efectivo"
+    assert DatosPago(forma_pago="Tarjeta").forma_pago == "Tarjeta"
+    assert DatosPago(forma_pago="transferencia").forma_pago == "Transferencia"
+    assert DatosPago(forma_pago="credito").forma_pago == "Crédito"
+
+
+def test_datos_pago_normaliza_mixto_mercadopago_y_montos():
+    dp = DatosPago(
+        forma_pago="pago mixto",
+        monto_pagado=100,
+        pago_mixto={"efectivo": 50, "tarjeta": 50},
+        puntos_canjeados="10",
+        descuento_global="2.5",
+        descuento_lineas="1.5",
+        mercado_pago_ref="mp-123",
+        operation_id="op-1",
+    )
+    assert dp.forma_pago == "Mixto"
+    assert dp.total_pagado == 100.0
+    assert dp.pago_mixto["efectivo"] == 50.0
+    assert dp.puntos_canjeados == 10
+    assert dp.descuento_global == 2.5
+    assert dp.descuento_lineas == 1.5
+
+
+def test_datos_pago_soporta_credito_y_operation_id_opcional():
+    dp = DatosPago(forma_pago="Crédito", cliente_id=None, operation_id="")
+    assert dp.forma_pago == "Crédito"
+    assert dp.cliente_id is None
+    assert dp.operation_id == ""
+
+
+def test_payment_breakdown_y_cliente_dto_construccion():
+    cli = ClienteVentaDTO(cliente_id=7, nombre="Cliente", saldo_credito=150.0, puntos=24)
+    pb = PaymentBreakdown(metodo="Mercado Pago", total=500.0, recibido=0.0, pendiente=500.0, operation_id="op-2")
+    assert cli.saldo_credito == 150.0
+    assert cli.puntos == 24
+    assert pb.metodo == "Mercado Pago"
+    assert pb.pendiente == 500.0
+
+
+def test_loyalty_request_preview_y_sale_context():
+    req = LoyaltyRedemptionRequest(cliente_id=1, puntos=30, subtotal=400.0, operation_id="op-3")
+    preview = LoyaltyRedemptionPreview(
+        cliente_id=1,
+        puntos_solicitados=30,
+        puntos_aplicables=20,
+        descuento_aplicable=20.0,
+        subtotal=400.0,
+        total_estimado=380.0,
+    )
+    ctx = SaleContext(
+        items=[ItemCarrito(producto_id=1, cantidad=1, precio_unit=100)],
+        datos_pago=DatosPago(forma_pago="efectivo", monto_pagado=100),
+        sucursal_id=2,
+        usuario="cajero",
+        operation_id="op-ctx",
+        loyalty_redemption=req,
+    )
+    assert req.puntos == 30
+    assert preview.total_estimado == 380.0
+    assert ctx.sucursal_id == 2
+    assert ctx.usuario == "cajero"
+    assert ctx.operation_id == "op-ctx"


### PR DESCRIPTION
### Motivation
- Reduce business logic in the POS UI and consolidate sale orchestration behind a canonical use case (`ProcesarVentaUC`) to avoid duplicate routes to `SalesService.execute_sale`.
- Introduce small, testable services for cart math, product/customer queries and payment normalization to centralize calculations and read-only DB access (`CartCalculator`, `ProductCatalogQueryService`, `CustomerLookupService`, `PaymentPolicy`).
- Harden loyalty and financial flows with idempotency and a single writer policy to mitigate duplicate CxC/fidelity effects (`SaleLoyaltyPolicy`, operation_id usage).
- Standardize event names and emit explicit post-compensation events for reversals to improve downstream wiring and observability (`SALE_CANCELLED`, `SALE_REFUNDED`, `SALE_CREDIT_NOTE_ISSUED`, etc.).

### Description
- Added documentation and migration plans: `docs/architecture/EVENT_CATALOG_SALES.md`, `docs/refactor/VENTAS_CXC_SINGLE_SOURCE_OF_TRUTH.md`, and `docs/refactor/VENTAS_REFACTOR_AUDIT.md` describing canonical events, CxC SOT and audit findings.
- New core services and utilities were added under `pos_spj_v13.4/core/services/sales/`: `cart_calculator.py`, `customer_lookup_service.py`, `payment_policy.py`, `product_catalog_query_service.py`, and `sale_loyalty_policy.py` to centralize math, reads and loyalty idempotency (`SaleLoyaltyPolicy` uses `operation_id`).
- Introduced presentation and UI improvements: extracted payment dialog to `presentation/sales/dialogs/payment_dialog.py`, added `presentation/sales/cart_view_model.py` and moved POS UI to consume the new dialog and services in `pos_spj_v13.4/modulos/ventas.py` (now calls `ProcesarVentaUC` via `_procesar_venta_via_uc`, uses `CartCalculator`, `ProductCatalogQueryService`, `CustomerLookupService`, and `PaymentPolicy`).
- Evolved core use case and DTOs in `core/use_cases/venta.py` to provide canonical DTOs (`ItemCarrito`, `DatosPago`, `SaleContext`, etc.) and normalization helpers for payment labels.
- Sales runtime changes: `pos_spj_v13.4/core/services/sales_service.py` now normalizes items/payment, integrates the `SaleLoyaltyPolicy` for redeem/earn/reverse flows, and enforces single-path loyalty handling; `pos_spj_v13.4/core/services/sales_reversal_service.py` now uses `SaleLoyaltyPolicy` when available and emits new English `SALE_*` events for cancel/refund/credit/inventory/cash/loyalty compensations.
- Added a comprehensive set of unit tests under `pos_spj_v13.4/tests/` to cover the new services, DTOs, UC usage from POS, loyalty idempotency and presence of event names.

### Testing
- Ran the new unit test suite with `pytest pos_spj_v13.4/tests`, which executed the added tests covering `CartCalculator`, `PaymentPolicy`, `SaleLoyaltyPolicy`, `ProductCatalogQueryService`, `CustomerLookupService`, `CartViewModel`, `ProcesarVentaUC` behavior and POS UI integration points; all tests passed.
- Executed focused tests verifying the `SalesReversalService` contains the new `SALE_*` event identifiers using `test_phase10_sales_reversal_events.py`, which passed.
- Verified extraction and usage of the payment dialog via `test_phase11_payment_dialog_extraction.py`, and POS enforcement of UC usage via `test_phase2_pos_venta_usa_uc.py`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1717b995c88328a7ed778beb87b85f)