### PR TITLE
Add SaleExecutionResult model and structured `execute_sale_result`; adapt services and UC

### DIFF
--- a/docs/refactor/VENTAS_BUGFIX_CONFLICT_CODE_AUDIT.md
+++ b/docs/refactor/VENTAS_BUGFIX_CONFLICT_CODE_AUDIT.md
@@ -1,0 +1,23 @@
+# VENTAS_BUGFIX_CONFLICT_CODE_AUDIT
+
+## Fase 0 — Mapeo de código conflictivo
+
+| Archivo | Método/Sección | Problema | Conflicto | Acción | Fase |
+|---|---|---|---|---|---|
+| `pos_spj_v13.4/modulos/ventas.py` | `calcular_totales` | UI recalcula subtotal/total/puntos preview | Duplica fuente de verdad backend | Reemplazar uso post-cobro por resultado canónico | 3 |
+| `pos_spj_v13.4/modulos/ventas.py` | `_on_checkout_success` | reconstruye `datos_ticket` desde `compra_actual`/`totales` snapshot | Puede no coincidir con venta persistida | Reemplazar por `ticket_payload` del backend | 3 |
+| `pos_spj_v13.4/modulos/ventas.py` | `_imprimir_ticket_consolidado`, `_imprimir_ticket_legacy_real` | rutas de impresión paralelas/legacy | Inconsistencia de errores y éxito | Consolidar vía PrinterService + resultado real | 4 |
+| `pos_spj_v13.4/modulos/ventas.py` | `guardar_ticket_pdf`, `_guardar_ticket_pdf_async` | PDF generado desde datos reconstruidos UI | Riesgo de divergencia | Generar desde `ticket_payload` canónico | 4 |
+| `pos_spj_v13.4/modulos/ventas.py` | `obtener_stock_producto`, `agregar_al_carrito`, `suspender_venta` | consulta/reserva stock dispersa en UI | Diferente fuente de stock | Mantener lectura UI, mover decisión transaccional al backend | 5 |
+| `pos_spj_v13.4/modulos/ventas.py` | `procesar_pago` validación crédito | validación previa en UI | potencial divergencia backend | mantener UX pero backend manda | 2 |
+| `pos_spj_v13.4/modulos/ventas.py` | `DialogoPago.get_datos_pago` | armado DTO pago en UI | mezcla reglas de dominio | normalizar y validar en backend | 2 |
+| `pos_spj_v13.4/modulos/ventas.py` | `cancelar_venta`/post-success | limpieza carrito acoplada a errores postventa | puede mostrar “fallida” tras commit | separar resultado de persistencia vs post-commit | 3 |
+| `pos_spj_v13.4/modulos/ventas.py` | varios `except ...: pass` (ej. 2692, 3818, 4166, 4496) | silencian fallos críticos | oculta bugs reales | reemplazar por warning/error explícito | 4 |
+| `pos_spj_v13.4/core/services/sales_service.py` | `execute_sale` | aplica normalizaciones/promos/puntos/eventos y retorna tuple incompleto | UI no recibe desglose real | introducir `execute_sale_result` canónico | 1-2 |
+| `pos_spj_v13.4/core/services/sales_service.py` | publicación de eventos | efectos postventa mezclados con retorno mínimo | trazabilidad parcial | mantener eventos pero enriquecer resultado | 2 |
+| `pos_spj_v13.4/core/use_cases/venta.py` | `ejecutar` | consulta `venta_id` por folio; no propaga operation_id/loyalty/payment breakdown | pérdida de datos reales | consumir `execute_sale_result` | 1-3 |
+| `pos_spj_v13.4/core/use_cases/venta.py` | fallback de ticket en UC | regenera ticket con totales estimados | posible mismatch vs venta guardada | usar ticket_html/payload real | 3 |
+| `pos_spj_v13.4/core/services/printer_service.py` | `print_ticket` + cola | validaciones blandas y múltiples `pass` en carga/config | errores no propagados uniformemente | endurecer contrato de error y status | 4 |
+| `pos_spj_v13.4/core/services/stock_reservation_service.py` + eventos `inventory_handler/wiring` | reserva enfocada a suspensión/confirmación diferida | semántica de confirmación/liberación ambigua | riesgo de stock inconsistente | formalizar estados de reserva y confirmación | 5 |
+
+> Nota: este documento es inventario técnico de conflictos detectados para guiar refactor seguro por fases.

--- a/pos_spj_v13.4/core/services/sales/sale_execution_result.py
+++ b/pos_spj_v13.4/core/services/sales/sale_execution_result.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class SaleExecutionItem:
+    product_id: int
+    nombre: str
+    cantidad: float
+    precio_unitario: float
+    subtotal: float
+    descuento: float
+    total: float
+    es_compuesto: int = 0
+
+
+@dataclass
+class SalePaymentResult:
+    forma_pago: str
+    total_pagado: float
+    efectivo_recibido: float
+    tarjeta: float
+    transferencia: float
+    credito: float
+    mercado_pago: float
+    cambio: float
+    saldo_credito: float
+    lineas: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class SaleLoyaltyResult:
+    cliente_id: Optional[int]
+    puntos_canjeados: int
+    descuento_puntos: float
+    puntos_ganados: int
+    puntos_totales: int
+    nivel: str
+    mensaje: str
+    operation_id: str
+
+
+@dataclass
+class SaleExecutionResult:
+    ok: bool
+    venta_id: int
+    folio: str
+    operation_id: str
+    subtotal: float
+    descuento_total: float
+    total: float
+    items: List[SaleExecutionItem] = field(default_factory=list)
+    payment: Optional[SalePaymentResult] = None
+    loyalty: Optional[SaleLoyaltyResult] = None
+    ticket_payload: Dict[str, Any] = field(default_factory=dict)
+    ticket_html: str = ""
+    warnings: List[str] = field(default_factory=list)
+    error: str = ""

--- a/pos_spj_v13.4/core/services/sales_service.py
+++ b/pos_spj_v13.4/core/services/sales_service.py
@@ -265,10 +265,10 @@ class SalesService:
             pass
         return folio_sale, ticket
 
-    def execute_sale(self, branch_id: int, user: str, items: list, payment_method: str,
+    def _execute_sale_core(self, branch_id: int, user: str, items: list, payment_method: str,
                      amount_paid: float, client_id: int = None, client_phone: str = None,
                      client_level: str = 'bronce', discount: float = 0.0, notes: str = "",
-                     loyalty_redemption_pts: int = 0) -> tuple:
+                     loyalty_redemption_pts: int = 0, return_details: bool = False):
         """
         Ejecuta la venta completa y devuelve el Folio y el Ticket HTML.
         
@@ -610,7 +610,159 @@ class SalesService:
         except Exception as e:
             logger.warning("No se pudo generar el ticket HTML: %s", e)
 
+        payment_breakdown = {
+            "efectivo": 0.0,
+            "tarjeta": 0.0,
+            "transferencia": 0.0,
+            "credito": 0.0,
+            "mercado_pago": 0.0,
+        }
+        _pm = self._normalize_payment_method(payment_method)
+        _map = {
+            "Efectivo": "efectivo",
+            "Tarjeta": "tarjeta",
+            "Transferencia": "transferencia",
+            "Credito": "credito",
+            "Mercado Pago": "mercado_pago",
+        }
+        payment_breakdown[_map.get(_pm, "efectivo")] = round(float(total_a_pagar), 2)
+        ticket_payload = dict(datos_venta)
+        ticket_payload["venta_id"] = sale_id
+        ticket_payload["operation_id"] = operation_id
+        ticket_payload["pago"] = {
+            "forma_pago": _pm,
+            "total_pagado": float(amount_paid or 0.0),
+            "efectivo_recibido": float(amount_paid or 0.0) if _pm == "Efectivo" else 0.0,
+            "tarjeta": payment_breakdown["tarjeta"],
+            "transferencia": payment_breakdown["transferencia"],
+            "credito": payment_breakdown["credito"],
+            "mercado_pago": payment_breakdown["mercado_pago"],
+            "cambio": (amount_paid - total_a_pagar) if _pm == "Efectivo" else 0.0,
+            "saldo_credito": max(round(float(total_a_pagar) - float(amount_paid or 0.0), 2), 0.0) if _pm == "Credito" else 0.0,
+            "lineas": payment_breakdown,
+        }
+        ticket_payload["loyalty"] = {
+            "cliente_id": client_id,
+            "puntos_canjeados": int(loyalty_redemption_pts or 0),
+            "descuento_puntos": float(loyalty_discount or 0.0),
+            "puntos_ganados": int((loyalty_result or {}).get("puntos_ganados", 0) or 0),
+            "puntos_totales": int((loyalty_result or {}).get("puntos_totales", 0) or 0),
+            "nivel": str((loyalty_result or {}).get("nivel", client_level or "Bronce")),
+            "mensaje": str((loyalty_result or {}).get("mensaje", "") or ""),
+            "operation_id": operation_id,
+        }
+        if return_details:
+            return {
+                "ok": True,
+                "venta_id": int(sale_id or 0),
+                "folio": str(folio),
+                "operation_id": str(operation_id),
+                "subtotal": round(float(subtotal), 2),
+                "descuento_total": round(float(discount), 2),
+                "total": round(float(total_a_pagar), 2),
+                "items": carrito_final,
+                "payment": ticket_payload["pago"],
+                "loyalty": ticket_payload["loyalty"],
+                "ticket_payload": ticket_payload,
+                "ticket_html": ticket_final_html or "",
+                "warnings": [],
+                "error": "",
+            }
         return folio, ticket_final_html
+
+
+    def execute_sale_result(self, branch_id: int, user: str, items: list, payment_method: str,
+                            amount_paid: float, client_id: int = None, client_phone: str = None,
+                            client_level: str = 'bronce', discount: float = 0.0, notes: str = "",
+                            loyalty_redemption_pts: int = 0):
+        from core.services.sales.sale_execution_result import (
+            SaleExecutionItem, SaleExecutionResult, SaleLoyaltyResult, SalePaymentResult,
+        )
+
+        warnings = []
+        details = self._execute_sale_core(
+            branch_id=branch_id, user=user, items=items, payment_method=payment_method,
+            amount_paid=amount_paid, client_id=client_id, client_phone=client_phone,
+            client_level=client_level, discount=discount, notes=notes,
+            loyalty_redemption_pts=loyalty_redemption_pts,
+            return_details=True,
+        )
+        if not details.get("operation_id"):
+            warnings.append("operation_id no disponible en el resultado interno de venta")
+        execution_items = [
+            SaleExecutionItem(
+                product_id=int(d.get("product_id", 0)),
+                nombre=str(d.get("nombre", d.get("name", "")) or ""),
+                cantidad=float(d.get("qty", d.get("cantidad", 0.0)) or 0.0),
+                precio_unitario=float(d.get("unit_price", d.get("precio_unitario", 0.0)) or 0.0),
+                subtotal=round(float(d.get("qty", d.get("cantidad", 0.0)) or 0.0) * float(d.get("unit_price", d.get("precio_unitario", 0.0)) or 0.0), 2),
+                descuento=0.0,
+                total=round(float(d.get("qty", d.get("cantidad", 0.0)) or 0.0) * float(d.get("unit_price", d.get("precio_unitario", 0.0)) or 0.0), 2),
+                es_compuesto=int(d.get("es_compuesto", 0) or 0),
+            ) for d in (details.get("items") or [])
+        ]
+        payment = SalePaymentResult(
+            forma_pago=str((details.get("payment") or {}).get("forma_pago", "Efectivo")),
+            total_pagado=float((details.get("payment") or {}).get("total_pagado", 0.0) or 0.0),
+            efectivo_recibido=float((details.get("payment") or {}).get("efectivo_recibido", 0.0) or 0.0),
+            tarjeta=float((details.get("payment") or {}).get("tarjeta", 0.0) or 0.0),
+            transferencia=float((details.get("payment") or {}).get("transferencia", 0.0) or 0.0),
+            credito=float((details.get("payment") or {}).get("credito", 0.0) or 0.0),
+            mercado_pago=float((details.get("payment") or {}).get("mercado_pago", 0.0) or 0.0),
+            cambio=float((details.get("payment") or {}).get("cambio", 0.0) or 0.0),
+            saldo_credito=float((details.get("payment") or {}).get("saldo_credito", 0.0) or 0.0),
+            lineas=dict((details.get("payment") or {}).get("lineas", {}) or {}),
+        )
+        loy_raw = details.get("loyalty") or {}
+        loyalty = SaleLoyaltyResult(
+            cliente_id=loy_raw.get("cliente_id", client_id),
+            puntos_canjeados=int(loy_raw.get("puntos_canjeados", 0) or 0),
+            descuento_puntos=float(loy_raw.get("descuento_puntos", 0.0) or 0.0),
+            puntos_ganados=int(loy_raw.get("puntos_ganados", 0) or 0),
+            puntos_totales=int(loy_raw.get("puntos_totales", 0) or 0),
+            nivel=str(loy_raw.get("nivel", client_level or "Bronce")),
+            mensaje=str(loy_raw.get("mensaje", "") or ""),
+            operation_id=str(loy_raw.get("operation_id", details.get("operation_id", "")) or ""),
+        )
+        return SaleExecutionResult(
+            ok=bool(details.get("ok", True)),
+            venta_id=int(details.get("venta_id", 0) or 0),
+            folio=str(details.get("folio", "")),
+            operation_id=str(details.get("operation_id", "") or ""),
+            subtotal=float(details.get("subtotal", 0.0) or 0.0),
+            descuento_total=float(details.get("descuento_total", 0.0) or 0.0),
+            total=float(details.get("total", 0.0) or 0.0),
+            items=execution_items,
+            payment=payment,
+            loyalty=loyalty,
+            ticket_payload=dict(details.get("ticket_payload", {}) or {}),
+            ticket_html=str(details.get("ticket_html", "") or ""),
+            warnings=list(details.get("warnings", []) or []) + warnings,
+            error=str(details.get("error", "") or ""),
+        )
+
+    def execute_sale(self, branch_id: int, user: str, items: list, payment_method: str,
+                     amount_paid: float, client_id: int = None, client_phone: str = None,
+                     client_level: str = 'bronce', discount: float = 0.0, notes: str = "",
+                     loyalty_redemption_pts: int = 0) -> tuple:
+        """
+        Adapter legacy: mantiene contrato histórico (folio, ticket_html).
+        La fuente real es execute_sale_result().
+        """
+        result = self.execute_sale_result(
+            branch_id=branch_id,
+            user=user,
+            items=items,
+            payment_method=payment_method,
+            amount_paid=amount_paid,
+            client_id=client_id,
+            client_phone=client_phone,
+            client_level=client_level,
+            discount=discount,
+            notes=notes,
+            loyalty_redemption_pts=loyalty_redemption_pts,
+        )
+        return result.folio, result.ticket_html
 
     # ── Compatibilidad legacy (tests v9 + módulos antiguos) ─────────────────
     def procesar_venta(self, items, datos_pago, usuario=None, **_kw):

--- a/pos_spj_v13.4/core/use_cases/venta.py
+++ b/pos_spj_v13.4/core/use_cases/venta.py
@@ -247,29 +247,44 @@ class ProcesarVentaUC:
 
         # ── 3. Ejecutar venta (transacción crítica) ───────────────────────────
         try:
-            # execute_sale returns (folio, ticket_html)
-            result = self._sales.execute_sale(
-                branch_id      = sucursal_id,
-                user           = usuario,
-                items          = items_svc,
-                payment_method = datos_pago.forma_pago,
-                amount_paid    = monto_pagado,
-                client_id      = datos_pago.cliente_id,
-                discount       = datos_pago.descuento_global,
-                loyalty_redemption_pts = int(datos_pago.puntos_canjeados or 0),
-                notes          = datos_pago.notas,
-            )
-            if isinstance(result, (tuple, list)) and len(result) >= 2:
-                folio        = result[0]
-                ticket_html  = result[1] if len(result) > 1 else ""
+            if hasattr(self._sales, "execute_sale_result"):
+                rich = self._sales.execute_sale_result(
+                    branch_id=sucursal_id,
+                    user=usuario,
+                    items=items_svc,
+                    payment_method=datos_pago.forma_pago,
+                    amount_paid=monto_pagado,
+                    client_id=datos_pago.cliente_id,
+                    discount=datos_pago.descuento_global,
+                    loyalty_redemption_pts=int(datos_pago.puntos_canjeados or 0),
+                    notes=datos_pago.notas,
+                )
+                folio = rich.folio
+                ticket_html = rich.ticket_html
+                venta_id = int(rich.venta_id or 0)
+                total = float(rich.total or total)
             else:
-                folio        = str(result)
-                ticket_html  = ""
-            # Get venta_id from DB (folio is unique)
-            row = self._sales.db.execute(
-                "SELECT id FROM ventas WHERE folio=? ORDER BY id DESC LIMIT 1", (folio,)
-            ).fetchone()
-            venta_id = row[0] if row else 0
+                result = self._sales.execute_sale(
+                    branch_id      = sucursal_id,
+                    user           = usuario,
+                    items          = items_svc,
+                    payment_method = datos_pago.forma_pago,
+                    amount_paid    = monto_pagado,
+                    client_id      = datos_pago.cliente_id,
+                    discount       = datos_pago.descuento_global,
+                    loyalty_redemption_pts = int(datos_pago.puntos_canjeados or 0),
+                    notes          = datos_pago.notas,
+                )
+                if isinstance(result, (tuple, list)) and len(result) >= 2:
+                    folio        = result[0]
+                    ticket_html  = result[1] if len(result) > 1 else ""
+                else:
+                    folio        = str(result)
+                    ticket_html  = ""
+                row = self._sales.db.execute(
+                    "SELECT id FROM ventas WHERE folio=? ORDER BY id DESC LIMIT 1", (folio,)
+                ).fetchone()
+                venta_id = row[0] if row else 0
         except Exception as e:
             logger.error("ProcesarVentaUC.execute_sale: %s", e)
             return ResultadoVenta(ok=False, error=str(e))

--- a/pos_spj_v13.4/tests/test_sale_execution_result.py
+++ b/pos_spj_v13.4/tests/test_sale_execution_result.py
@@ -1,0 +1,75 @@
+from core.services.sales.sale_execution_result import SaleExecutionResult
+from core.services.sales_service import SalesService
+
+
+class _DB:
+    def execute(self, q, p=()):
+        self._q = q
+        self._p = p
+        return self
+
+    def fetchone(self):
+        if "FROM ventas" in self._q:
+            return (101, 100.0, 5.0, 95.0, "Efectivo", 100.0, 5.0, "op-123")
+        if "FROM loyalty_cards" in self._q:
+            return (220, "Oro")
+        return None
+
+    def fetchall(self):
+        if "FROM detalle_ventas" in self._q:
+            return [(1, "Producto A", 2.0, 10.0, 20.0, 1.0, 19.0, 0)]
+        return []
+
+
+class _Svc(SalesService):
+    def _execute_sale_core(self, **kwargs):
+        if kwargs.get("return_details"):
+            return {
+                "ok": True,
+                "venta_id": 101,
+                "folio": "FOLIO-1",
+                "operation_id": "op-123",
+                "subtotal": 100.0,
+                "descuento_total": 5.0,
+                "total": 95.0,
+                "items": [{"product_id": 1, "nombre": "Producto A", "qty": 2.0, "unit_price": 10.0, "es_compuesto": 0}],
+                "payment": {"forma_pago": "Efectivo", "total_pagado": 100.0, "efectivo_recibido": 100.0, "cambio": 5.0, "lineas": {"efectivo": 95.0}},
+                "loyalty": {"cliente_id": kwargs.get("client_id"), "puntos_canjeados": 0, "descuento_puntos": 0.0, "puntos_ganados": 0, "puntos_totales": 220, "nivel": "Oro", "mensaje": "", "operation_id": "op-123"},
+                "ticket_payload": {"folio": "FOLIO-1"},
+                "ticket_html": "<html>ticket</html>",
+                "warnings": [],
+                "error": "",
+            }
+        return "FOLIO-1", "<html>ticket</html>"
+
+
+def _build_svc():
+    return _Svc(_DB(), None, None, None, None, None, None, None, None, None, None, None)
+
+
+def test_sale_execution_result_contains_real_total():
+    r = _build_svc().execute_sale_result(1, "cajero", [], "Efectivo", 100.0)
+    assert isinstance(r, SaleExecutionResult)
+    assert r.total == 95.0
+
+
+def test_sale_execution_result_contains_real_items():
+    r = _build_svc().execute_sale_result(1, "cajero", [], "Efectivo", 100.0)
+    assert len(r.items) == 1
+    assert r.items[0].nombre == "Producto A"
+
+
+def test_sale_execution_result_contains_operation_id():
+    r = _build_svc().execute_sale_result(1, "cajero", [], "Efectivo", 100.0)
+    assert r.operation_id == "op-123"
+
+
+def test_sale_execution_result_contains_loyalty_result():
+    r = _build_svc().execute_sale_result(1, "cajero", [], "Efectivo", 100.0, client_id=7)
+    assert r.loyalty is not None
+    assert r.loyalty.cliente_id == 7
+
+
+def test_sale_execution_result_contains_ticket_payload():
+    r = _build_svc().execute_sale_result(1, "cajero", [], "Efectivo", 100.0)
+    assert r.ticket_payload.get("folio") == "FOLIO-1"


### PR DESCRIPTION
### Motivation
- Create a canonical, rich result for sale execution to avoid UI-side reconstruction of ticket/payment/loyalty data and remove duplicated sources of truth.
- Provide a clear, typed payload that includes payment breakdown, loyalty info, operation id and ticket payload for downstream consumers and event handlers.
- Maintain backward compatibility with legacy callers that expect `execute_sale` returning `(folio, ticket_html)` while enabling new callers to consume the full result.

### Description
- Added `pos_spj_v13.4/core/services/sales/sale_execution_result.py` with dataclasses `SaleExecutionItem`, `SalePaymentResult`, `SaleLoyaltyResult`, and `SaleExecutionResult` to model canonical sale output.
- Refactored `SalesService` to split the internal flow into `_execute_sale_core(..., return_details=True)` and a new `execute_sale_result(...)` that returns a populated `SaleExecutionResult` instance, and adapted `execute_sale(...)` to act as a legacy adapter returning `(folio, ticket_html)`.
- Built a detailed `ticket_payload` and `payment` breakdown inside the sales execution flow and propagated `operation_id`, `venta_id`, `items`, `payment`, `loyalty`, `ticket_payload`, `ticket_html`, `warnings`, and `error` to the result.
- Updated `pos_spj_v13.4/core/use_cases/venta.py` to prefer `execute_sale_result` when available and consume `folio`, `ticket_html`, `venta_id` and `total` from the rich result while falling back to the legacy `execute_sale` contract.
- Added a documentation note file `docs/refactor/VENTAS_BUGFIX_CONFLICT_CODE_AUDIT.md` describing mapping of conflicting areas to guide phased refactor.

### Testing
- Added unit tests in `pos_spj_v13.4/tests/test_sale_execution_result.py` covering result fields, items, operation id, loyalty and ticket payload.
- The test file contains 5 unit tests exercising `execute_sale_result` behavior against a minimal stubbed `SalesService` and DB, and all tests passed locally.
- No other automated test suites were modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17b4e9044083288817e76a402911d9)