### PR TITLE
Harden sales pipeline: payment breakdown, MP reservations, loyalty handling, legacy paths blocked, and no-silent-fails

### DIFF
--- a/docs/refactor/VENTAS_CLEANUP_DELETE_LIST.md
+++ b/docs/refactor/VENTAS_CLEANUP_DELETE_LIST.md
@@ -1,0 +1,27 @@
+# Ventas cleanup delete list
+
+Inventario quirúrgico creado antes de aplicar cambios de fases 1-9.
+
+| Archivo | Función/método | Líneas aprox. | Problema | Acción | Prueba |
+|---|---|---:|---|---|---|
+| `pos_spj_v13.4/modulos/ventas.py` | `_aplicar_resultado_venta` | 4156-4240 | Reconstruía ticket postventa desde UI si faltaba `ticket_payload`, usando cliente/cache y totales derivados. | DELETE/REPLACE | `test_ticket_requires_backend_payload`, `test_no_ticket_from_compra_actual_after_sale` |
+| `pos_spj_v13.4/modulos/ventas.py` | `_aplicar_resultado_venta` | 4170-4182 | Convertía puntos faltantes a `0` y actualizaba `cliente_actual['puntos']` como saldo real. | REPLACE | `test_loyalty_none_does_not_display_zero`, `test_customer_cache_updated_only_with_real_balance` |
+| `pos_spj_v13.4/modulos/ventas.py` | `finalizar_venta` | 3975-4023 | Mercado Pago pendiente generaba link sin reserva y luego limpiaba carrito. | REPLACE | `test_mp_pending_creates_reservation` |
+| `pos_spj_v13.4/modulos/ventas.py` | `finalizar_venta` | 4080-4101 | Usaba `QThread` + `SaleCheckoutWorkerFactory` para venta transaccional con servicios clonados superficialmente. | BLOCK | `test_sale_does_not_use_shallow_cloned_worker` |
+| `pos_spj_v13.4/modulos/ventas.py` | `_aplicar_resultado_venta` | 4203-4216 | Confirmaba reserva después de imprimir y podía convertir venta exitosa en fallo. | REPLACE | `test_reservation_failure_after_sale_does_not_mark_sale_failed` |
+| `pos_spj_v13.4/modulos/ventas.py` / `core/services/sales_service.py` | `procesar_pago` / `_execute_sale_core` | 3860-3970 / 560-582 | `pass` silenciosos en validación de caja, crédito y margen/costo podían permitir vender sin guardrail confiable. | REPLACE/BLOCK | `test_cash_shift_validation_error_blocks_or_warns_explicitly`, `test_credit_validation_error_not_silent`, `test_margin_validation_error_blocks_sale_explicitly` |
+| `pos_spj_v13.4/core/use_cases/venta.py` | `ejecutar` | 210-223 | Normalización recreaba `DatosPago` y perdía `pago_mixto`, sucursal, usuario y metadatos. | REPLACE | `test_payment_breakdown_preserved_to_ticket_payload` |
+| `pos_spj_v13.4/core/use_cases/venta.py` | `ejecutar` | 302-321 | Ruta legacy `execute_sale` + SQL por folio para recuperar `venta_id`. | BLOCK | `test_legacy_venta_repository_write_blocked` |
+| `pos_spj_v13.4/core/use_cases/venta.py` | `ejecutar` | 351-384 | Fallback generaba ticket con `items` originales del UC. | DELETE | `test_no_ticket_from_uc_original_items` |
+| `pos_spj_v13.4/core/use_cases/venta.py` | `ejecutar` | 329-344 | Fallback de fidelidad convertía saldo no disponible a cero. | REPLACE | `test_loyalty_none_does_not_display_zero` |
+| `pos_spj_v13.4/core/services/sales_service.py` | `_execute_sale_core` | 421-438 | Comentario y comportamiento permitían `SALE_ITEMS_PROCESS` sin handlers como no-op. | BLOCK | `test_sale_fails_without_inventory_handler`, `test_sale_fails_without_finance_handler`, `test_sale_items_process_not_noop_in_production` |
+| `pos_spj_v13.4/core/services/sales_service.py` | `_execute_sale_core` | 499 | `loyalty_result` iniciaba ceros falsos como datos reales. | REPLACE | `test_ticket_does_not_print_fake_zero_points` |
+| `pos_spj_v13.4/core/services/sales_service.py` | `_execute_sale_core` | 613-646 | `Pago Mixto` caía a efectivo y método desconocido caía a efectivo con `_map.get`. | REPLACE | `test_pago_mixto_not_mapped_to_cash`, `test_unknown_payment_method_fails` |
+| `pos_spj_v13.4/core/services/sales_service.py` | `create_pending_payment_sale` | 178-225 | Intención Mercado Pago pendiente no reservaba stock. | REPLACE | `test_mp_pending_creates_reservation`, `test_mp_pending_cancel_releases_reservation` |
+| `pos_spj_v13.4/presentation/sales/workers/sale_checkout_worker_factory.py` | `_clone_uc` | 25-57 | `copy.copy` de servicios y reemplazo parcial de `db`; dependencias internas quedaban con conexión vieja. | DELETE/BLOCK | `test_sale_checkout_factory_disabled_or_removed` |
+| `pos_spj_v13.4/presentation/sales/workers/sale_checkout_worker.py` | `run` | 32-47 | Venta transaccional en QThread sin container por hilo real. | KEEP TEMPORARILY (no usado por UI) | `test_sale_transaction_uses_single_db_connection` |
+| `pos_spj_v13.4/repositories/ventas.py` | `VentaRepository.create_sale` | 117-130 | Ruta legacy directa para escribir ventas fuera de `SalesService`. | BLOCK | `test_legacy_venta_repository_write_blocked` |
+
+| `pos_spj_v13.4/core/services/sales_service.py` | `procesar_venta` | 1083-1165 | API legacy compatible con `UnifiedSalesService` mantenía ruta paralela fuera del UC oficial. | BLOCK | `test_sales_service_procesar_venta_legacy_blocked_by_default` |
+| `pos_spj_v13.4/core/services/sales_service.py` | `_procesar_venta_legacy_minimal` | 1270-1350 | Fallback escribía `ventas`, `detalles_venta`, caja, inventario y puntos directamente, generando ticket_data desde items originales. | BLOCK | `test_legacy_minimal_sale_write_blocked_by_default`, `test_no_legacy_ticket_path_active` |
+| `pos_spj_v13.4/core/services/sales/unified_sales_service.py` | `UnifiedSalesService.procesar_venta` | 73-126 | Servicio legacy rearmaba UC/servicios y mantenía entrada paralela a ventas. | BLOCK | `test_legacy_unified_sales_service_blocked_by_default` |

--- a/pos_spj_v13.4/core/events/event_bus.py
+++ b/pos_spj_v13.4/core/events/event_bus.py
@@ -266,6 +266,8 @@ class EventBus:
             handlers = list(self._handlers.get(event_type, []))
 
         if not handlers:
+            if strict:
+                raise RuntimeError(f"Handlers críticos no registrados para evento '{event_type}'.")
             logger.debug("Evento '%s' sin handlers registrados.", event_type)
             return
 
@@ -284,6 +286,10 @@ class EventBus:
     def handler_count(self, event_type: str) -> int:
         with self._lock:
             return len(self._handlers.get(event_type, []))
+
+    def handler_labels(self, event_type: str) -> List[str]:
+        with self._lock:
+            return [label for _, label, _ in self._handlers.get(event_type, [])]
 
     def registered_events(self) -> List[str]:
         with self._lock:

--- a/pos_spj_v13.4/core/events/event_factory.py
+++ b/pos_spj_v13.4/core/events/event_factory.py
@@ -24,6 +24,8 @@ def make_sale_payload(
     items: List[Dict[str, Any]],
     payment_method: str,
     operation_id: str,
+    amount_paid: float = 0.0,
+    payment_breakdown: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Build the canonical payload for SALE_ITEMS_PROCESS and VENTA_COMPLETADA events.
@@ -42,6 +44,8 @@ def make_sale_payload(
         "client_id":      client_id,
         "items":          items,
         "payment_method": payment_method,
+        "amount_paid":    amount_paid,
+        "payment_breakdown": dict(payment_breakdown or {}),
         "operation_id":   operation_id,
         # Spanish aliases (legacy handlers & WA bridge)
         "venta_id":       sale_id,

--- a/pos_spj_v13.4/core/services/loyalty_service.py
+++ b/pos_spj_v13.4/core/services/loyalty_service.py
@@ -381,8 +381,9 @@ class LoyaltyService:
         try:
             from repositories.loyalty_repository import LoyaltyRepository
             return LoyaltyRepository(self.db).get_balance(cliente_id)
-        except Exception:
-            return 0
+        except Exception as exc:
+            logger.warning("Saldo de fidelidad no disponible cliente=%s: %s", cliente_id, exc)
+            raise RuntimeError("loyalty_balance_unavailable") from exc
 
     def pasivo_financiero(self) -> Dict:
         """

--- a/pos_spj_v13.4/core/services/printer_service.py
+++ b/pos_spj_v13.4/core/services/printer_service.py
@@ -377,8 +377,8 @@ class PrintQueue:
             ))
             try:
                 self._db.commit()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("print_job_log commit failed: %s", exc)
         except Exception as exc:
             logger.debug("print_job_log insert failed: %s", exc)
 
@@ -409,8 +409,8 @@ class PrinterService:
         try:
             from core.events.event_bus import get_bus
             self.queue._bus = get_bus()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("PrinterService sin EventBus; eventos de impresión no se publicarán: %s", exc)
         # Conectar DB para bitácora de impresión (Fase 1)
         self.queue._db = db_conn
         self.queue.start()
@@ -436,8 +436,8 @@ class PrinterService:
                 if rows:
                     self._ticket_cfg = {r[0]: r[1] for r in rows}
                     break
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("No se pudo cargar configuración de impresora de tickets: %s", exc)
         try:
             # Label printer
             for key in ('etiquetas', 'impresora_etiquetas'):
@@ -448,8 +448,8 @@ class PrinterService:
                 if rows:
                     self._label_cfg = {r[0]: r[1] for r in rows}
                     break
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("No se pudo cargar configuración de impresora de etiquetas: %s", exc)
 
     def reload_configs(self):
         self._load_configs()
@@ -461,8 +461,8 @@ class PrinterService:
             baud = int(raw_value)
             if 1200 <= baud <= 115200:
                 return baud
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Baud rate de impresora inválido (%r); usando default %s: %s", raw_value, default, exc)
         return default
 
     @staticmethod
@@ -611,7 +611,8 @@ class PrinterService:
                 "SELECT valor FROM configuraciones WHERE clave=?", (key,)
             ).fetchone()
             return r[0] if r and r[0] else default
-        except Exception:
+        except Exception as exc:
+            logger.warning("No se pudo leer configuración %s; usando default: %s", key, exc)
             return default
 
     def has_ticket_printer(self) -> bool:

--- a/pos_spj_v13.4/core/services/sales/payment_policy.py
+++ b/pos_spj_v13.4/core/services/sales/payment_policy.py
@@ -58,24 +58,56 @@ class PaymentPolicy:
                                 cash: float = 0.0, card: float = 0.0,
                                 saldo_credito: float = 0.0) -> Dict[str, Any]:
         m = PaymentPolicy.normalize_payment_method(method)
-        data = {
-            "forma_pago": m,
-            "total_pagado": float(total or 0.0),
-            "efectivo_recibido": float(amount_paid or 0.0),
-            "monto_tarjeta_mixto": 0.0,
-            "cambio": 0.0,
-            "saldo_credito": 0.0,
+        total = round(float(total or 0.0), 2)
+        amount_paid = round(float(amount_paid or 0.0), 2)
+        lineas = {
+            "efectivo": 0.0,
+            "tarjeta": 0.0,
+            "transferencia": 0.0,
+            "credito": 0.0,
+            "mercado_pago": 0.0,
         }
-        if m == "Pago Mixto":
-            data["efectivo_recibido"] = float(cash or 0.0)
-            data["monto_tarjeta_mixto"] = float(card or 0.0)
-            v = PaymentPolicy.validate_mixed_payment(total, cash, card)
-            data["cambio"] = max(v["diff"], 0.0)
+        cambio = 0.0
+        amount_paid_real = 0.0
+
+        if m == "Efectivo":
+            lineas["efectivo"] = amount_paid
+            amount_paid_real = amount_paid
+            cambio = PaymentPolicy.calculate_change(total, amount_paid, m)
+        elif m == "Tarjeta":
+            lineas["tarjeta"] = total
+            amount_paid_real = total
+        elif m == "Transferencia":
+            lineas["transferencia"] = total
+            amount_paid_real = total
+        elif m == "Mercado Pago":
+            lineas["mercado_pago"] = total
+            amount_paid_real = total
         elif m == "Crédito":
-            data["saldo_credito"] = float(saldo_credito or total or 0.0)
-            data["efectivo_recibido"] = float(total or 0.0)
+            lineas["credito"] = float(saldo_credito or total or 0.0)
+            amount_paid_real = 0.0
+        elif m == "Pago Mixto":
+            lineas["efectivo"] = round(float(cash or 0.0), 2)
+            lineas["tarjeta"] = round(float(card or 0.0), 2)
+            v = PaymentPolicy.validate_mixed_payment(total, cash, card)
+            cambio = max(float(v.get("diff", 0.0)), 0.0)
+            amount_paid_real = round(lineas["efectivo"] + lineas["tarjeta"], 2)
         else:
-            data["cambio"] = PaymentPolicy.calculate_change(total, amount_paid, m)
-            if m != "Efectivo":
-                data["efectivo_recibido"] = float(total or 0.0)
-        return data
+            raise ValueError(f"Método de pago desconocido: {method}")
+
+        return {
+            "forma_pago": m,
+            "total_pagado": amount_paid_real,
+            "amount_paid": amount_paid_real,
+            "amount_paid_real": amount_paid_real,
+            "efectivo_recibido": lineas["efectivo"],
+            "monto_tarjeta_mixto": lineas["tarjeta"],
+            "tarjeta": lineas["tarjeta"],
+            "transferencia": lineas["transferencia"],
+            "credito": lineas["credito"],
+            "mercado_pago": lineas["mercado_pago"],
+            "cambio": cambio,
+            "saldo_credito": lineas["credito"],
+            "lineas": lineas,
+            "breakdown": lineas,
+        }

--- a/pos_spj_v13.4/core/services/sales/sale_execution_result.py
+++ b/pos_spj_v13.4/core/services/sales/sale_execution_result.py
@@ -28,6 +28,7 @@ class SalePaymentResult:
     cambio: float
     saldo_credito: float
     lineas: Dict[str, float] = field(default_factory=dict)
+    amount_paid_real: float = 0.0
 
 
 @dataclass
@@ -35,11 +36,12 @@ class SaleLoyaltyResult:
     cliente_id: Optional[int]
     puntos_canjeados: int
     descuento_puntos: float
-    puntos_ganados: int
-    puntos_totales: int
-    nivel: str
+    puntos_ganados: Optional[int]
+    puntos_totales: Optional[int]
+    nivel: Optional[str]
     mensaje: str
     operation_id: str
+    available: bool = False
 
 
 @dataclass

--- a/pos_spj_v13.4/core/services/sales/unified_sales_service.py
+++ b/pos_spj_v13.4/core/services/sales/unified_sales_service.py
@@ -1,11 +1,18 @@
 # core/services/sales/unified_sales_service.py — DEPRECADO en v13.1
 # Shim de compatibilidad → redirige a ProcesarVentaUC
-import warnings, logging
+import warnings, logging, os
 warnings.warn(
     "UnifiedSalesService está deprecado. Usa core.use_cases.ProcesarVentaUC.",
     DeprecationWarning, stacklevel=2
 )
 logger = logging.getLogger("spj.sales.unified")
+
+ALLOW_LEGACY_UNIFIED_SALES_SERVICE = "ALLOW_LEGACY_UNIFIED_SALES_SERVICE"
+LEGACY_UNIFIED_REMOVAL_DATE = "2026-06-30"
+
+
+def _legacy_unified_enabled() -> bool:
+    return str(os.getenv(ALLOW_LEGACY_UNIFIED_SALES_SERVICE, "0")).strip().lower() in {"1", "true", "yes", "on"}
 
 # Re-exportar DTOs para compatibilidad con tests y cotizacion_service
 from dataclasses import dataclass, field
@@ -71,6 +78,19 @@ class UnifiedSalesService:
         self.branch_id = branch_id
 
     def procesar_venta(self, items, datos_pago, usuario=None, **kw):
+        if not _legacy_unified_enabled():
+            logger.error(
+                "UnifiedSalesService.procesar_venta bloqueado; usa ProcesarVentaUC. "
+                "Eliminación planificada: %s. Para tests legacy aislados: %s=1",
+                LEGACY_UNIFIED_REMOVAL_DATE,
+                ALLOW_LEGACY_UNIFIED_SALES_SERVICE,
+            )
+            raise RuntimeError(
+                "UnifiedSalesService.procesar_venta() está bloqueado por seguridad. "
+                "Ruta oficial: ProcesarVentaUC.ejecutar() -> SalesService.execute_sale_result(). "
+                f"Eliminación planificada: {LEGACY_UNIFIED_REMOVAL_DATE}. "
+                f"Para pruebas legacy aisladas use {ALLOW_LEGACY_UNIFIED_SALES_SERVICE}=1."
+            )
         from core.use_cases.venta import ProcesarVentaUC, ItemCarrito, DatosPago as DP
         from core.services.inventory_service import InventoryService
         usr = usuario or self.usuario

--- a/pos_spj_v13.4/core/services/sales_service.py
+++ b/pos_spj_v13.4/core/services/sales_service.py
@@ -2,6 +2,7 @@ from core.services.auto_audit import audit_write
 
 # core/services/sales_service.py
 import uuid
+import os
 import logging
 from datetime import datetime
 
@@ -11,6 +12,15 @@ from core.events.event_factory import make_sale_payload
 from core.services.sales_fulfillment_service import SaleFulfillmentService
 
 logger = logging.getLogger(__name__)
+
+ALLOW_LEGACY_SALES_SERVICE_PROCESAR_VENTA = "ALLOW_LEGACY_SALES_SERVICE_PROCESAR_VENTA"
+ALLOW_LEGACY_MINIMAL_SALE_WRITE = "ALLOW_LEGACY_MINIMAL_SALE_WRITE"
+LEGACY_SALES_REMOVAL_DATE = "2026-06-30"
+
+
+def _legacy_flag_enabled(name: str) -> bool:
+    return str(os.getenv(name, "0")).strip().lower() in {"1", "true", "yes", "on"}
+
 
 class SalesService:
     """
@@ -39,7 +49,8 @@ class SalesService:
         try:
             from core.services.lote_service import LoteService
             self._lote_svc = LoteService(db_conn)
-        except Exception:
+        except Exception as exc:
+            logger.warning("LoteService no disponible para venta; FIFO queda desactivado explícitamente: %s", exc)
             self._lote_svc = None
         self.finance_service = finance_service
         self.loyalty_service = loyalty_service
@@ -67,8 +78,8 @@ class SalesService:
                 ).fetchone()
                 if not row:
                     return folio
-            except Exception:
-                # Si no se puede validar unicidad por esquema/tabla, retornar igual
+            except Exception as exc:
+                logger.warning("No se pudo validar unicidad de folio; usando folio generado: %s", exc)
                 return folio
         return f"V{base}-{uuid.uuid4().hex[:8].upper()}"
 
@@ -139,7 +150,8 @@ class SalesService:
             try:
                 from core.services.sales.sale_loyalty_policy import SaleLoyaltyPolicy
                 self._sale_loyalty_policy = SaleLoyaltyPolicy(self.db, loyalty_service=self.loyalty_service)
-            except Exception:
+            except Exception as exc:
+                logger.warning("SaleLoyaltyPolicy no disponible; usando LoyaltyService directo si existe: %s", exc)
                 self._sale_loyalty_policy = None
         return self._sale_loyalty_policy
 
@@ -147,7 +159,8 @@ class SalesService:
         try:
             from core.services.payment_normalization import normalize_payment_method as _npm
             return _npm(payment_method)
-        except Exception:
+        except Exception as exc:
+            logger.warning("No se pudo normalizar método de pago %r; se conserva valor original: %s", payment_method, exc)
             return payment_method
 
     def _normalize_items_payload(self, items: list) -> list:
@@ -166,63 +179,216 @@ class SalesService:
             })
         return normalized
 
-    def _validate_payment(self, payment_method: str, amount_paid: float, total_a_pagar: float, client_id: int = None):
+    def _validate_payment(
+        self,
+        payment_method: str,
+        total_a_pagar: float,
+        payment_lines: dict,
+        client_id: int = None,
+    ):
         from core.services.payment_normalization import is_credit_sale
-        if is_credit_sale(payment_method) and client_id and self.customer_service:
+
+        method = self._normalize_payment_method(payment_method)
+        total_a_pagar = round(float(total_a_pagar or 0.0), 2)
+        lines = dict(payment_lines or {})
+
+        if is_credit_sale(method) and client_id and self.customer_service:
             ok, msg = self.customer_service.validate_credit(client_id, total_a_pagar)
             if not ok:
                 raise ValueError(msg)
-        if amount_paid < total_a_pagar and not is_credit_sale(payment_method):
-            raise ValueError(f"El monto pagado (${amount_paid:,.2f}) es menor al total a cobrar (${total_a_pagar:,.2f})")
 
-    def create_pending_payment_sale(self, branch_id: int, user: str, items: list,
-                                    client_id: int = None, notes: str = "",
-                                    total: float = 0.0) -> dict:
-        """
-        Fase 7: crea una intención de pago MercadoPago sin ejecutar venta definitiva.
-        No descuenta stock, no registra caja, no publica VENTA_COMPLETADA.
-        """
-        folio = self._generate_unique_sale_folio()
-        subtotal = total or sum(float(i.get("qty", 0)) * float(i.get("unit_price", 0)) for i in (items or []))
-        self.db.execute("""
-            CREATE TABLE IF NOT EXISTS pending_sales_intents (
+        if method == "Efectivo":
+            efectivo = round(float(lines.get("efectivo", 0.0) or 0.0), 2)
+            if efectivo < total_a_pagar:
+                raise ValueError(
+                    f"El efectivo recibido (${efectivo:,.2f}) es menor al total a cobrar (${total_a_pagar:,.2f})"
+                )
+        elif method in {"Pago Mixto", "Mixto"}:
+            pagado = round(
+                float(lines.get("efectivo", 0.0) or 0.0)
+                + float(lines.get("tarjeta", 0.0) or 0.0)
+                + float(lines.get("transferencia", 0.0) or 0.0),
+                2,
+            )
+            if pagado < total_a_pagar:
+                raise ValueError(
+                    f"Pago mixto insuficiente (${pagado:,.2f}) para total ${total_a_pagar:,.2f}"
+                )
+        elif method in {"Tarjeta", "Transferencia", "Mercado Pago"}:
+            key = {"Tarjeta": "tarjeta", "Transferencia": "transferencia", "Mercado Pago": "mercado_pago"}[method]
+            if round(float(lines.get(key, 0.0) or 0.0), 2) < total_a_pagar:
+                raise ValueError(f"Pago {method} incompleto para total ${total_a_pagar:,.2f}")
+        elif is_credit_sale(method):
+            if round(float(lines.get("credito", 0.0) or 0.0), 2) < total_a_pagar:
+                raise ValueError(f"Pago a crédito incompleto para total ${total_a_pagar:,.2f}")
+        else:
+            raise ValueError(f"Método de pago desconocido: {method}")
+
+    def _amount_paid_for_storage(self, payment_method: str, payment_lines: dict, total: float) -> float:
+        method = self._normalize_payment_method(payment_method)
+        lines = dict(payment_lines or {})
+        total = round(float(total or 0.0), 2)
+        if method == "Efectivo":
+            return round(float(lines.get("efectivo", 0.0) or 0.0), 2)
+        if method in {"Crédito", "Credito"}:
+            return 0.0
+        if method in {"Tarjeta", "Transferencia", "Mercado Pago", "Pago Mixto", "Mixto"}:
+            return round(
+                float(lines.get("efectivo", 0.0) or 0.0)
+                + float(lines.get("tarjeta", 0.0) or 0.0)
+                + float(lines.get("transferencia", 0.0) or 0.0)
+                + float(lines.get("mercado_pago", 0.0) or 0.0),
+                2,
+            )
+        raise ValueError(f"Método de pago desconocido: {method}")
+
+    def _ensure_pending_sales_intents_table(self) -> None:
+        self.db.execute(
+            """CREATE TABLE IF NOT EXISTS pending_sales_intents (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 folio TEXT UNIQUE NOT NULL,
                 payload_json TEXT NOT NULL,
                 estado TEXT NOT NULL DEFAULT 'pendiente_pago',
+                reservation_id INTEGER,
                 payment_id TEXT DEFAULT '',
+                payment_url TEXT DEFAULT '',
                 created_at TEXT DEFAULT (datetime('now')),
+                expires_at TEXT DEFAULT (datetime('now', '+30 minutes')),
                 confirmed_at TEXT
+            )"""
+        )
+        for stmt in (
+            "ALTER TABLE pending_sales_intents ADD COLUMN reservation_id INTEGER",
+            "ALTER TABLE pending_sales_intents ADD COLUMN payment_url TEXT DEFAULT ''",
+            "ALTER TABLE pending_sales_intents ADD COLUMN expires_at TEXT",
+        ):
+            try:
+                self.db.execute(stmt)
+            except Exception as exc:
+                logger.debug("pending_sales_intents migration skipped: %s", exc)
+        try:
+            self.db.execute(
+                "UPDATE pending_sales_intents "
+                "SET expires_at=datetime('now', '+30 minutes') "
+                "WHERE expires_at IS NULL AND estado='pendiente_pago'"
             )
-        """)
+        except Exception as exc:
+            logger.debug("pending_sales_intents expires_at backfill skipped: %s", exc)
+
+    def create_pending_payment_sale(self, branch_id: int, user: str, items: list,
+                                    client_id: int = None, notes: str = "",
+                                    total: float = 0.0) -> dict:
+        """Crea intención Mercado Pago pendiente y reserva stock temporalmente."""
+        if not items:
+            raise ValueError("Mercado Pago pendiente requiere items para reservar stock.")
+
+        self._ensure_pending_sales_intents_table()
+        branch_id = int(branch_id or 1)
+        folio = f"MP-{uuid.uuid4().hex[:12].upper()}"
+        normalized_items = self._normalize_items_payload(items)
+        reservation_items = [
+            {"id": int(item["product_id"]), "cantidad": float(item["qty"])}
+            for item in normalized_items
+        ]
+        from core.services.stock_reservation_service import StockReservationService
+        reservation_id = StockReservationService(self.db, branch_id=branch_id).reservar(
+            folio,
+            reservation_items,
+        )
         payload = {
             "branch_id": branch_id,
-            "user": user,
+            "user": str(user or "sistema"),
             "client_id": client_id,
-            "items": items or [],
-            "total": round(float(subtotal), 2),
-            "notes": notes or "",
+            "items": normalized_items,
+            "total": round(float(total or 0.0), 2),
+            "notes": str(notes or ""),
+            "reservation_id": int(reservation_id),
+            "payment_method": "Mercado Pago",
         }
+        try:
+            self.db.execute(
+                """INSERT INTO pending_sales_intents
+                   (folio, payload_json, estado, reservation_id, expires_at)
+                   VALUES (?, ?, 'pendiente_pago', ?, datetime('now', '+30 minutes'))""",
+                (folio, json.dumps(payload, ensure_ascii=False), int(reservation_id)),
+            )
+        except Exception as exc:
+            logger.warning("No se pudo persistir intención MP; liberando reserva_id=%s: %s", reservation_id, exc)
+            try:
+                StockReservationService(self.db, branch_id=branch_id).liberar(
+                    reservation_id,
+                    motivo="cancelada",
+                )
+            except Exception as cleanup_exc:
+                logger.warning(
+                    "No se pudo liberar reserva MP tras fallo de intención: reserva_id=%s error=%s",
+                    reservation_id,
+                    cleanup_exc,
+                )
+            raise
+        try:
+            self.db.commit()
+        except Exception as exc:
+            logger.debug("commit intención MP pendiente omitido: %s", exc)
+        return {
+            "folio": folio,
+            "estado": "pendiente_pago",
+            "reservation_id": int(reservation_id),
+            "items": normalized_items,
+            "total": payload["total"],
+        }
+
+    def attach_pending_payment_link(self, folio: str, url: str) -> None:
+        self._ensure_pending_sales_intents_table()
         self.db.execute(
-            "INSERT OR REPLACE INTO pending_sales_intents(folio, payload_json, estado) VALUES (?,?, 'pendiente_pago')",
-            (folio, json.dumps(payload)),
+            "UPDATE pending_sales_intents SET payment_url=? WHERE folio=? AND estado='pendiente_pago'",
+            (str(url or ""), str(folio)),
         )
         try:
             self.db.commit()
-        except Exception:
-            pass
-        return {
-            "ok": True,
-            "estado": "pendiente_pago",
-            "folio": folio,
-            "branch_id": branch_id,
-            "usuario": user,
-            "client_id": client_id,
-            "subtotal": round(float(subtotal), 2),
-            "notes": notes or "",
-            "items": items or [],
-            "todo": "Implementar confirmación por webhook para convertir a venta definitiva.",
-        }
+        except Exception as exc:
+            logger.debug("commit link MP pendiente omitido: %s", exc)
+
+    def cancel_pending_payment_sale(self, folio: str, motivo: str = "cancelada") -> None:
+        self._ensure_pending_sales_intents_table()
+        row = self.db.execute(
+            "SELECT payload_json, reservation_id FROM pending_sales_intents WHERE folio=? LIMIT 1",
+            (str(folio),),
+        ).fetchone()
+        if not row:
+            return
+        payload_json = row[0] if isinstance(row, tuple) else row["payload_json"]
+        reservation_id = row[1] if isinstance(row, tuple) else row["reservation_id"]
+        data = json.loads(payload_json or "{}")
+        reservation_id = int(reservation_id or data.get("reservation_id") or 0)
+        estado = "expirada" if str(motivo).strip().lower() == "expirada" else "cancelada"
+        if reservation_id:
+            from core.services.stock_reservation_service import StockReservationService
+            StockReservationService(self.db, branch_id=int(data.get("branch_id", 1))).liberar(
+                reservation_id,
+                motivo=estado,
+            )
+        self.db.execute(
+            "UPDATE pending_sales_intents SET estado=? WHERE folio=? AND estado='pendiente_pago'",
+            (estado, str(folio)),
+        )
+        try:
+            self.db.commit()
+        except Exception as exc:
+            logger.debug("commit cancelación MP pendiente omitido: %s", exc)
+
+    def expire_pending_payment_sales(self) -> int:
+        self._ensure_pending_sales_intents_table()
+        rows = self.db.execute(
+            """SELECT folio FROM pending_sales_intents
+               WHERE estado='pendiente_pago'
+                 AND expires_at IS NOT NULL
+                 AND expires_at < datetime('now')"""
+        ).fetchall()
+        for row in rows:
+            folio = row[0] if isinstance(row, tuple) else row["folio"]
+            self.cancel_pending_payment_sale(str(folio), motivo="expirada")
+        return len(rows)
 
     def confirm_pending_payment_sale(self, folio: str, payment_id: str = "") -> tuple:
         """
@@ -239,6 +405,8 @@ class SalesService:
         if estado == "confirmada":
             # idempotencia: no reprocesar
             return str(folio), ""
+        if estado != "pendiente_pago":
+            raise RuntimeError(f"Intento Mercado Pago no confirmable: {folio} estado={estado}")
         data = json.loads(payload_json or "{}")
         total = float(data.get("total", 0.0))
         items = data.get("items") or []
@@ -246,35 +414,72 @@ class SalesService:
         user = str(data.get("user", "sistema"))
         client_id = data.get("client_id")
         notes = str(data.get("notes", "")) + f" [MP payment_id={payment_id}]"
-        folio_sale, ticket = self.execute_sale(
+        reservation_id = int(data.get("reservation_id") or 0)
+        rich = self.execute_sale_result(
             branch_id=branch_id,
             user=user,
             items=items,
             payment_method="Mercado Pago",
             amount_paid=total,
+            payment_breakdown={"mercado_pago": total},
             client_id=client_id,
             notes=notes,
+            reservation_id=reservation_id,
         )
+        folio_sale, ticket = rich.folio, rich.ticket_html
         self.db.execute(
             "UPDATE pending_sales_intents SET estado='confirmada', payment_id=?, confirmed_at=datetime('now') WHERE folio=?",
             (str(payment_id or ""), str(folio)),
         )
         try:
             self.db.commit()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("No se pudo confirmar commit de intención MP confirmada folio=%s: %s", folio, exc)
         return folio_sale, ticket
+
+
+    def _sale_handler_labels(self, bus, event_type: str) -> set[str]:
+        if hasattr(bus, "handler_labels"):
+            return {str(label) for label in (bus.handler_labels(event_type) or [])}
+        handlers = getattr(bus, "_handlers", {}).get(event_type, [])
+        return {str(label) for _, label, _ in handlers}
+
+    def _validate_critical_sale_handlers(self, bus, event_type: str, payment_method: str) -> None:
+        labels = self._sale_handler_labels(bus, event_type)
+        missing: list[str] = []
+
+        def _has(fragment: str) -> bool:
+            return any(fragment in label for label in labels)
+
+        if not _has("sale_inventory"):
+            missing.append("inventario")
+        if not _has("sale_finance"):
+            missing.append("finanzas/caja")
+        from core.services.payment_normalization import is_credit_sale
+        if is_credit_sale(payment_method) and not _has("sale_credit"):
+            missing.append("crédito")
+
+        if missing:
+            registered = ", ".join(sorted(labels)) or "sin handlers etiquetados"
+            raise RuntimeError(
+                "Handlers críticos de venta no registrados: "
+                + ", ".join(missing)
+                + f". Registrados: {registered}"
+            )
 
     def _execute_sale_core(self, branch_id: int, user: str, items: list, payment_method: str,
                      amount_paid: float, client_id: int = None, client_phone: str = None,
                      client_level: str = 'bronce', discount: float = 0.0, notes: str = "",
-                     loyalty_redemption_pts: int = 0, return_details: bool = False):
+                     loyalty_redemption_pts: int = 0, return_details: bool = False,
+                     payment_breakdown: dict | None = None, reservation_id: int | None = None):
         """
         Ejecuta la venta completa y devuelve el Folio y el Ticket HTML.
         
         :param items: Lista de diccionarios [{'product_id': 1, 'qty': 1.12, 'unit_price': 100, 'es_compuesto': 0, 'name': 'Pollo'}, ...]
         """
         operation_id = str(uuid.uuid4())
+        reservation_id = int(reservation_id or 0)
+        reservation_confirmed = False
 
         payment_method = self._normalize_payment_method(payment_method)
         items = self._normalize_items_payload(items)
@@ -362,7 +567,14 @@ class SalesService:
             total_a_pagar = round(total_a_pagar - loyalty_discount, 2)
             discount = round(discount + loyalty_discount, 2)
 
-        self._validate_payment(payment_method, amount_paid, total_a_pagar, client_id=client_id)
+        payment_breakdown = self._build_payment_breakdown(
+            payment_method=payment_method,
+            total=total_a_pagar,
+            amount_paid=amount_paid,
+            payment_breakdown=payment_breakdown,
+        )
+        amount_paid_real = self._amount_paid_for_storage(payment_method, payment_breakdown, total_a_pagar)
+        self._validate_payment(payment_method, total_a_pagar, payment_breakdown, client_id=client_id)
 
         # Guardia de margen v13.4 — no bloquea la venta, solo registra en audit
         if self.finance_service and hasattr(self.finance_service, 'validar_margen'):
@@ -375,8 +587,12 @@ class SalesService:
                             "VENTA_BAJO_MARGEN: producto=%s precio=%.2f usuario=%s",
                             _item.get('product_id'), _item.get('unit_price'), user
                         )
-                except Exception:
-                    pass  # guardia no crítica
+                except Exception as exc:
+                    logger.error(
+                        "Validación de margen/costo falló antes de venta producto=%s usuario=%s: %s",
+                        _item.get('product_id'), user, exc
+                    )
+                    raise RuntimeError("Validación de margen/costo no disponible; venta bloqueada.") from exc
 
         # =========================================================
         # 2. TRANSACCIÓN CRÍTICA DE BASE DE DATOS
@@ -401,10 +617,19 @@ class SalesService:
                 discount=discount,
                 total=total_a_pagar,
                 payment_method=payment_method,
-                amount_paid=amount_paid,
+                amount_paid=amount_paid_real,
                 operation_id=operation_id,
                 notes=notes
             )
+
+            if reservation_id:
+                from core.services.stock_reservation_service import StockReservationService
+                StockReservationService(self.db, branch_id=branch_id).confirmar(
+                    reservation_id,
+                    venta_id=sale_id,
+                    folio=folio,
+                )
+                reservation_confirmed = True
 
             # B. Guardar detalles de línea (sin lógica de inventario)
             for item in carrito_final:
@@ -417,8 +642,8 @@ class SalesService:
                 )
 
             # C. Inventario + Finanzas vía evento SALE_ITEMS_PROCESS (sync, dentro del SAVEPOINT).
-            #    SaleInventoryHandler y SaleFinanceHandler están registrados en wiring.py.
-            #    Si no hay handlers activos (tests sin AppContainer), la emisión es no-op.
+            #    SaleInventoryHandler y SaleFinanceHandler deben estar registrados;
+            #    vender sin handlers críticos queda bloqueado.
             resolved_items = self._resolve_sale_items(carrito_final, branch_id)
             _sale_evt_payload = make_sale_payload(
                 sale_id=sale_id,
@@ -429,11 +654,15 @@ class SalesService:
                 client_id=client_id,
                 items=resolved_items,
                 payment_method=payment_method,
+                amount_paid=amount_paid_real,
+                payment_breakdown=payment_breakdown,
                 operation_id=operation_id,
             )
             try:
                 from core.events.event_bus import get_bus
-                get_bus().publish(SALE_ITEMS_PROCESS, _sale_evt_payload, strict=True)
+                _bus = get_bus()
+                self._validate_critical_sale_handlers(_bus, SALE_ITEMS_PROCESS, payment_method)
+                _bus.publish(SALE_ITEMS_PROCESS, _sale_evt_payload, strict=True)
             except Exception as _evt_err:
                 logger.error("SALE_ITEMS_PROCESS dispatch failed (venta %s): %s", operation_id, _evt_err)
                 raise  # propagate so SAVEPOINT rolls back
@@ -496,7 +725,7 @@ class SalesService:
             # register_credit_sale() here would create a duplicate CxC row.
 
             # ── Acreditación postventa idempotente antes del ticket ───────────
-            loyalty_result = {"puntos_ganados": 0, "puntos_totales": 0, "nivel": "Bronce", "mensaje": ""}
+            loyalty_result = {"puntos_ganados": None, "puntos_totales": None, "nivel": None, "mensaje": "", "available": False}
             if client_id and self.loyalty_service:
                 try:
                     _lp = self._loyalty_policy()
@@ -518,6 +747,8 @@ class SalesService:
                             usuario=str(user),
                         )
                     ) or loyalty_result
+                    loyalty_result = dict(loyalty_result or {})
+                    loyalty_result["available"] = loyalty_result.get("puntos_totales") not in (None, "")
                 except Exception as _lyl_aw_err:
                     logger.warning("loyalty accrual venta=%s: %s", sale_id, _lyl_aw_err)
 
@@ -563,6 +794,8 @@ class SalesService:
                     "usuario":       user,
                     "cliente_id":    client_id,
                     "payment_method": payment_method,
+                    "amount_paid": amount_paid_real,
+                    "payment_breakdown": payment_breakdown,
                     "items": carrito_final,
                     "sale_datetime": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                     "loyalty_already_processed": True,
@@ -576,8 +809,10 @@ class SalesService:
         except Exception as e:
             # Rollback to savepoint if still active
             if _sp:
-                try: self.db.execute(f"ROLLBACK TO SAVEPOINT {_sp}")
-                except Exception: pass
+                try:
+                    self.db.execute(f"ROLLBACK TO SAVEPOINT {_sp}")
+                except Exception as _rollback_err:
+                    logger.warning("Rollback de venta falló savepoint=%s: %s", _sp, _rollback_err)
             logger.error("Fallo en venta %s: %s", operation_id, e)
             raise RuntimeError(
                 f"Operación cancelada. El inventario y caja están intactos: {e}"
@@ -592,12 +827,28 @@ class SalesService:
         ticket_final_html = ""
         try:
             datos_venta = {
-                'folio': folio, 'fecha': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                'cajero': user, 'total': total_a_pagar, 'pago': amount_paid,
-                'cambio': (amount_paid - total_a_pagar) if payment_method == 'Efectivo' else 0,
+                'venta_id': sale_id,
+                'sale_id': sale_id,
+                'folio': folio,
+                'operation_id': operation_id,
+                'reservation_id': reservation_id or None,
+                'reservation_confirmed': reservation_confirmed,
+                'fecha': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                'cajero': user,
+                'subtotal': round(float(subtotal), 2),
+                'descuento': round(float(discount), 2),
+                'total': round(float(total_a_pagar), 2),
+                'total_final': round(float(total_a_pagar), 2),
+                'totales': {
+                    'subtotal': round(float(subtotal), 2),
+                    'descuento': round(float(discount), 2),
+                    'total_final': round(float(total_a_pagar), 2),
+                },
+                'pago': amount_paid_real,
+                'cambio': self._calculate_change(payment_method, payment_breakdown, total_a_pagar),
                 'items': carrito_final,
-                'puntos_ganados': (loyalty_result or {}).get('puntos_ganados', 0),
-                'puntos_totales': (loyalty_result or {}).get('puntos_totales', 0),
+                'puntos_ganados': (loyalty_result or {}).get('puntos_ganados'),
+                'puntos_totales': (loyalty_result or {}).get('puntos_totales'),
                 'raffle_tickets_snapshot': raffle_tickets_snapshot,
                 'raffle_tickets_lines': [f"🎟️ Rifas/Sorteos\nRifa: {t.get('raffle','')}\nBoletos: {t.get('numero_boleto','')}" for t in (raffle_tickets_snapshot or [])],
             }
@@ -610,46 +861,45 @@ class SalesService:
         except Exception as e:
             logger.warning("No se pudo generar el ticket HTML: %s", e)
 
-        payment_breakdown = {
-            "efectivo": 0.0,
-            "tarjeta": 0.0,
-            "transferencia": 0.0,
-            "credito": 0.0,
-            "mercado_pago": 0.0,
-        }
         _pm = self._normalize_payment_method(payment_method)
-        _map = {
-            "Efectivo": "efectivo",
-            "Tarjeta": "tarjeta",
-            "Transferencia": "transferencia",
-            "Crédito": "credito",
-            "Credito": "credito",
-            "Pago Mixto": "efectivo",
-            "Mercado Pago": "mercado_pago",
-        }
-        payment_breakdown[_map.get(_pm, "efectivo")] = round(float(total_a_pagar), 2)
         ticket_payload = dict(datos_venta)
         ticket_payload["venta_id"] = sale_id
+        ticket_payload["sale_id"] = sale_id
         ticket_payload["operation_id"] = operation_id
+        ticket_payload["reservation_id"] = reservation_id or None
+        ticket_payload["reservation_confirmed"] = reservation_confirmed
+        ticket_payload["folio"] = str(folio)
+        ticket_payload["items"] = list(carrito_final)
+        ticket_payload["total"] = round(float(total_a_pagar), 2)
+        ticket_payload["total_final"] = round(float(total_a_pagar), 2)
+        ticket_payload["totales"] = {
+            "subtotal": round(float(subtotal), 2),
+            "descuento": round(float(discount), 2),
+            "total_final": round(float(total_a_pagar), 2),
+        }
         ticket_payload["pago"] = {
             "forma_pago": _pm,
-            "total_pagado": float(amount_paid or 0.0),
-            "efectivo_recibido": float(amount_paid or 0.0) if _pm == "Efectivo" else 0.0,
+            "total_pagado": round(sum(float(v or 0.0) for v in payment_breakdown.values()), 2),
+            "efectivo_recibido": payment_breakdown["efectivo"],
             "tarjeta": payment_breakdown["tarjeta"],
             "transferencia": payment_breakdown["transferencia"],
             "credito": payment_breakdown["credito"],
             "mercado_pago": payment_breakdown["mercado_pago"],
-            "cambio": (amount_paid - total_a_pagar) if _pm == "Efectivo" else 0.0,
-            "saldo_credito": max(round(float(total_a_pagar) - float(amount_paid or 0.0), 2), 0.0) if _pm in {"Credito", "Crédito"} else 0.0,
+            "cambio": self._calculate_change(_pm, payment_breakdown, total_a_pagar),
+            "saldo_credito": round(float(total_a_pagar), 2) if _pm in {"Credito", "Crédito"} else 0.0,
+            "amount_paid": amount_paid_real,
+            "amount_paid_real": amount_paid_real,
             "lineas": payment_breakdown,
+            "breakdown": payment_breakdown,
         }
         ticket_payload["loyalty"] = {
             "cliente_id": client_id,
             "puntos_canjeados": int(loyalty_redemption_pts or 0),
             "descuento_puntos": float(loyalty_discount or 0.0),
-            "puntos_ganados": int((loyalty_result or {}).get("puntos_ganados", 0) or 0),
-            "puntos_totales": int((loyalty_result or {}).get("puntos_totales", 0) or 0),
-            "nivel": str((loyalty_result or {}).get("nivel", client_level or "Bronce")),
+            "puntos_ganados": (loyalty_result or {}).get("puntos_ganados"),
+            "puntos_totales": (loyalty_result or {}).get("puntos_totales"),
+            "nivel": (loyalty_result or {}).get("nivel"),
+            "available": bool((loyalty_result or {}).get("available", False)),
             "mensaje": str((loyalty_result or {}).get("mensaje", "") or ""),
             "operation_id": operation_id,
         }
@@ -673,10 +923,78 @@ class SalesService:
         return folio, ticket_final_html
 
 
+
+    def _calculate_change(self, payment_method: str, payment_lines: dict, total: float) -> float:
+        method = self._normalize_payment_method(payment_method)
+        total = round(float(total or 0.0), 2)
+        lines = dict(payment_lines or {})
+        if method == "Efectivo":
+            return round(max(float(lines.get("efectivo", 0.0) or 0.0) - total, 0.0), 2)
+        if method in {"Pago Mixto", "Mixto"}:
+            paid = (
+                float(lines.get("efectivo", 0.0) or 0.0)
+                + float(lines.get("tarjeta", 0.0) or 0.0)
+                + float(lines.get("transferencia", 0.0) or 0.0)
+            )
+            return round(max(paid - total, 0.0), 2)
+        return 0.0
+
+
+
+    def _build_payment_breakdown(self, payment_method: str, total: float, amount_paid: float, payment_breakdown: dict | None = None) -> dict:
+        method = self._normalize_payment_method(payment_method)
+        total = round(float(total or 0.0), 2)
+        amount_paid = round(float(amount_paid or 0.0), 2)
+        lineas = {
+            "efectivo": 0.0,
+            "tarjeta": 0.0,
+            "transferencia": 0.0,
+            "credito": 0.0,
+            "mercado_pago": 0.0,
+        }
+        allowed_methods = {"Efectivo", "Tarjeta", "Transferencia", "Credito", "Crédito", "Mercado Pago", "Pago Mixto", "Mixto"}
+        if method not in allowed_methods:
+            raise ValueError(f"Método de pago desconocido: {method}")
+        aliases = {
+            "efectivo": "efectivo",
+            "cash": "efectivo",
+            "tarjeta": "tarjeta",
+            "card": "tarjeta",
+            "monto_tarjeta_mixto": "tarjeta",
+            "transferencia": "transferencia",
+            "transfer": "transferencia",
+            "credito": "credito",
+            "crédito": "credito",
+            "saldo_credito": "credito",
+            "mercado_pago": "mercado_pago",
+            "mercado pago": "mercado_pago",
+        }
+        if payment_breakdown:
+            for raw_key, raw_value in payment_breakdown.items():
+                key = aliases.get(str(raw_key).strip().lower())
+                if key is None:
+                    raise ValueError(f"Método de pago desconocido en desglose: {raw_key}")
+                lineas[key] += round(float(raw_value or 0.0), 2)
+            return lineas
+        if method == "Efectivo":
+            lineas["efectivo"] = amount_paid
+        elif method == "Tarjeta":
+            lineas["tarjeta"] = total
+        elif method == "Transferencia":
+            lineas["transferencia"] = total
+        elif method in {"Crédito", "Credito"}:
+            lineas["credito"] = total
+        elif method == "Mercado Pago":
+            lineas["mercado_pago"] = total
+        elif method in {"Mixto", "Pago Mixto"}:
+            raise ValueError("Pago mixto requiere payment_breakdown explícito.")
+        return lineas
+
     def execute_sale_result(self, branch_id: int, user: str, items: list, payment_method: str,
                             amount_paid: float, client_id: int = None, client_phone: str = None,
                             client_level: str = 'bronce', discount: float = 0.0, notes: str = "",
-                            loyalty_redemption_pts: int = 0):
+                            loyalty_redemption_pts: int = 0, payment_breakdown: dict | None = None,
+                            reservation_id: int | None = None):
         from core.services.sales.sale_execution_result import (
             SaleExecutionItem, SaleExecutionResult, SaleLoyaltyResult, SalePaymentResult,
         )
@@ -688,6 +1006,8 @@ class SalesService:
             client_level=client_level, discount=discount, notes=notes,
             loyalty_redemption_pts=loyalty_redemption_pts,
             return_details=True,
+            payment_breakdown=payment_breakdown,
+            reservation_id=reservation_id,
         )
         if not details.get("operation_id"):
             warnings.append("operation_id no disponible en el resultado interno de venta")
@@ -704,7 +1024,7 @@ class SalesService:
             ) for d in (details.get("items") or [])
         ]
         payment = SalePaymentResult(
-            forma_pago=str((details.get("payment") or {}).get("forma_pago", "Efectivo")),
+            forma_pago=str((details.get("payment") or {}).get("forma_pago", "")),
             total_pagado=float((details.get("payment") or {}).get("total_pagado", 0.0) or 0.0),
             efectivo_recibido=float((details.get("payment") or {}).get("efectivo_recibido", 0.0) or 0.0),
             tarjeta=float((details.get("payment") or {}).get("tarjeta", 0.0) or 0.0),
@@ -714,17 +1034,19 @@ class SalesService:
             cambio=float((details.get("payment") or {}).get("cambio", 0.0) or 0.0),
             saldo_credito=float((details.get("payment") or {}).get("saldo_credito", 0.0) or 0.0),
             lineas=dict((details.get("payment") or {}).get("lineas", {}) or {}),
+            amount_paid_real=float((details.get("payment") or {}).get("amount_paid_real", (details.get("payment") or {}).get("amount_paid", 0.0)) or 0.0),
         )
         loy_raw = details.get("loyalty") or {}
         loyalty = SaleLoyaltyResult(
             cliente_id=loy_raw.get("cliente_id", client_id),
             puntos_canjeados=int(loy_raw.get("puntos_canjeados", 0) or 0),
             descuento_puntos=float(loy_raw.get("descuento_puntos", 0.0) or 0.0),
-            puntos_ganados=int(loy_raw.get("puntos_ganados", 0) or 0),
-            puntos_totales=int(loy_raw.get("puntos_totales", 0) or 0),
-            nivel=str(loy_raw.get("nivel", client_level or "Bronce")),
+            puntos_ganados=loy_raw.get("puntos_ganados"),
+            puntos_totales=loy_raw.get("puntos_totales"),
+            nivel=loy_raw.get("nivel"),
             mensaje=str(loy_raw.get("mensaje", "") or ""),
             operation_id=str(loy_raw.get("operation_id", details.get("operation_id", "")) or ""),
+            available=bool(loy_raw.get("available", False)),
         )
         return SaleExecutionResult(
             ok=bool(details.get("ok", True)),
@@ -746,7 +1068,7 @@ class SalesService:
     def execute_sale(self, branch_id: int, user: str, items: list, payment_method: str,
                      amount_paid: float, client_id: int = None, client_phone: str = None,
                      client_level: str = 'bronce', discount: float = 0.0, notes: str = "",
-                     loyalty_redemption_pts: int = 0) -> tuple:
+                     loyalty_redemption_pts: int = 0, reservation_id: int | None = None) -> tuple:
         """
         Adapter legacy: mantiene contrato histórico (folio, ticket_html).
         La fuente real es execute_sale_result().
@@ -763,15 +1085,31 @@ class SalesService:
             discount=discount,
             notes=notes,
             loyalty_redemption_pts=loyalty_redemption_pts,
+            reservation_id=reservation_id,
         )
         return result.folio, result.ticket_html
 
     # ── Compatibilidad legacy (tests v9 + módulos antiguos) ─────────────────
     def procesar_venta(self, items, datos_pago, usuario=None, **_kw):
         """
-        API legacy compatible con UnifiedSalesService.
-        Mantiene retrocompatibilidad sin romper `execute_sale`.
+        API legacy bloqueada por defecto.
+
+        Fecha de eliminación planificada: 2026-06-30.
+        Ruta oficial: ProcesarVentaUC.ejecutar() -> SalesService.execute_sale_result().
         """
+        if not _legacy_flag_enabled(ALLOW_LEGACY_SALES_SERVICE_PROCESAR_VENTA):
+            logger.error(
+                "SalesService.procesar_venta legacy bloqueado; usa ProcesarVentaUC -> "
+                "execute_sale_result. Eliminación planificada: %s. Para tests legacy aislados: %s=1",
+                LEGACY_SALES_REMOVAL_DATE,
+                ALLOW_LEGACY_SALES_SERVICE_PROCESAR_VENTA,
+            )
+            raise RuntimeError(
+                "SalesService.procesar_venta() legacy está bloqueado por seguridad. "
+                "Ruta oficial: ProcesarVentaUC.ejecutar() -> SalesService.execute_sale_result(). "
+                f"Eliminación planificada: {LEGACY_SALES_REMOVAL_DATE}. "
+                f"Para pruebas legacy aisladas use {ALLOW_LEGACY_SALES_SERVICE_PROCESAR_VENTA}=1."
+            )
         from core.services.sales.unified_sales_service import (
             ResultadoVenta, CarritoVacioError, PagoInsuficienteError, StockError, VentaError
         )
@@ -781,7 +1119,18 @@ class SalesService:
 
         usr = usuario or "cajero"
         payment_method = getattr(datos_pago, "forma_pago", "Efectivo")
-        amount_paid = float(getattr(datos_pago, "efectivo_recibido", 0.0) or 0.0)
+        payment_breakdown = dict(
+            getattr(datos_pago, "payment_breakdown", None)
+            or getattr(datos_pago, "pago_mixto", None)
+            or getattr(datos_pago, "lineas", None)
+            or {}
+        )
+        if getattr(datos_pago, "amount_paid_real", None) is not None:
+            amount_paid = float(getattr(datos_pago, "amount_paid_real") or 0.0)
+        elif payment_breakdown:
+            amount_paid = float(sum(float(v or 0.0) for v in payment_breakdown.values()))
+        else:
+            amount_paid = float(getattr(datos_pago, "efectivo_recibido", 0.0) or 0.0)
         client_id = getattr(datos_pago, "cliente_id", None)
         discount = float(getattr(datos_pago, "descuento_global", 0.0) or 0.0)
 
@@ -803,8 +1152,9 @@ class SalesService:
 
         try:
             ventas_cols = {r[1] for r in self.db.execute("PRAGMA table_info(ventas)").fetchall()}
-        except Exception:
-            ventas_cols = set()
+        except Exception as exc:
+            logger.warning("No se pudo inspeccionar esquema de ventas; ruta legacy mínima bloqueada: %s", exc)
+            raise VentaError("No se pudo validar esquema de ventas para procesar venta.") from exc
         if "operation_id" not in ventas_cols or "observations" not in ventas_cols:
             return self._procesar_venta_legacy_minimal(
                 items_payload=items_payload,
@@ -816,15 +1166,17 @@ class SalesService:
             )
 
         try:
-            folio, ticket_html = self.execute_sale(
+            rich = self.execute_sale_result(
                 branch_id=1,
                 user=usr,
                 items=items_payload,
                 payment_method=payment_method,
                 amount_paid=amount_paid,
+                payment_breakdown=payment_breakdown,
                 client_id=client_id,
                 discount=discount,
             )
+            folio, ticket_html = rich.folio, rich.ticket_html
             row = self.db.execute(
                 "SELECT id,total,cambio FROM ventas WHERE folio=? ORDER BY id DESC LIMIT 1",
                 (folio,)
@@ -909,7 +1261,8 @@ class SalesService:
                         "UPDATE ventas SET estado='cancelada', notas=? WHERE id=?",
                         (motivo, int(venta_id))
                     )
-                except Exception:
+                except Exception as exc:
+                    logger.warning("Cancelación de venta sin columna notas; usando fallback estado-only venta_id=%s: %s", venta_id, exc)
                     self.db.execute(
                         "UPDATE ventas SET estado='cancelada' WHERE id=?",
                         (int(venta_id),)
@@ -942,16 +1295,31 @@ class SalesService:
     def _procesar_venta_legacy_minimal(
         self, *, items_payload, payment_method, amount_paid, client_id, discount, usuario
     ):
+        if not _legacy_flag_enabled(ALLOW_LEGACY_MINIMAL_SALE_WRITE):
+            logger.error(
+                "_procesar_venta_legacy_minimal bloqueado; escribe ventas fuera de "
+                "execute_sale_result. Eliminación planificada: %s. Para tests legacy aislados: %s=1",
+                LEGACY_SALES_REMOVAL_DATE,
+                ALLOW_LEGACY_MINIMAL_SALE_WRITE,
+            )
+            raise RuntimeError(
+                "_procesar_venta_legacy_minimal() está bloqueado por seguridad: "
+                "escribe ventas/caja/inventario fuera de SalesService.execute_sale_result(). "
+                f"Eliminación planificada: {LEGACY_SALES_REMOVAL_DATE}. "
+                f"Para pruebas legacy aisladas use {ALLOW_LEGACY_MINIMAL_SALE_WRITE}=1."
+            )
         from datetime import datetime
         from core.services.sales.unified_sales_service import (
             ResultadoVenta, PagoInsuficienteError, StockError, VentaError
         )
         subtotal = round(sum(float(i["qty"]) * float(i["unit_price"]) for i in items_payload), 2)
         total = round(max(subtotal - float(discount or 0), 0.0), 2)
-        if payment_method.lower() not in {"tarjeta", "credito"}:
-            # Hardening Fase 0: efectivo debe cubrir el total neto de la venta.
-            if float(amount_paid or 0) < total:
-                raise PagoInsuficienteError("El monto pagado es menor al total.")
+        try:
+            payment_lines = self._build_payment_breakdown(payment_method, total, amount_paid, None)
+            amount_paid_real = self._amount_paid_for_storage(payment_method, payment_lines, total)
+            self._validate_payment(payment_method, total, payment_lines, client_id=client_id)
+        except ValueError as exc:
+            raise PagoInsuficienteError(str(exc)) from exc
 
         try:
             for i in items_payload:
@@ -961,7 +1329,7 @@ class SalesService:
                     raise StockError(f"Stock insuficiente para producto {i['product_id']}")
 
             folio = self._generate_unique_sale_folio()
-            cambio = round(max(float(amount_paid or 0) - total, 0.0), 2)
+            cambio = self._calculate_change(payment_method, payment_lines, total)
             cur = self.db.execute(
                 """
                 INSERT INTO ventas(
@@ -970,7 +1338,7 @@ class SalesService:
                 ) VALUES (?,1,?,?,?,?,?,?,?,?, 'completada', datetime('now'))
                 """,
                 (folio, usuario, client_id, subtotal, float(discount or 0), total,
-                 payment_method, float(amount_paid or 0), cambio)
+                 payment_method, amount_paid_real, cambio)
             )
             venta_id = int(cur.lastrowid)
 
@@ -1008,12 +1376,12 @@ class SalesService:
         except (PagoInsuficienteError, StockError):
             try:
                 self.db.rollback()
-            except Exception:
-                pass
+            except Exception as rb_exc:
+                logger.warning("Rollback legacy de venta falló tras error controlado: %s", rb_exc)
             raise
         except Exception as exc:
             try:
                 self.db.rollback()
-            except Exception:
-                pass
+            except Exception as rb_exc:
+                logger.warning("Rollback legacy de venta falló: %s", rb_exc)
             raise VentaError(str(exc)) from exc

--- a/pos_spj_v13.4/core/services/stock_reservation_service.py
+++ b/pos_spj_v13.4/core/services/stock_reservation_service.py
@@ -52,8 +52,8 @@ class StockReservationService:
         for stmt in stmts:
             try:
                 self.db.execute(stmt)
-            except Exception:
-                pass  # columna ya existe, tabla ya existe — ignorar
+            except Exception as exc:
+                logger.debug("stock_reservas schema ensure omitido para sentencia idempotente: %s", exc)
 
     def expirar_huerfanas(self) -> int:
         """
@@ -79,11 +79,19 @@ class StockReservationService:
 
     def stock_disponible(self, producto_id: int) -> float:
         self.expirar_huerfanas()
-        row = self.db.execute(
-            "SELECT COALESCE(quantity,0) FROM branch_inventory "
-            "WHERE branch_id=? AND product_id=?",
-            (self.branch_id, producto_id),
-        ).fetchone()
+        try:
+            row = self.db.execute(
+                "SELECT COALESCE(quantity,0) FROM branch_inventory "
+                "WHERE branch_id=? AND product_id=?",
+                (self.branch_id, producto_id),
+            ).fetchone()
+        except Exception as exc:
+            logger.debug("branch_inventory no disponible, usando inventory: %s", exc)
+            row = self.db.execute(
+                "SELECT COALESCE(stock,0) FROM inventory "
+                "WHERE branch_id=? AND product_id=?",
+                (self.branch_id, producto_id),
+            ).fetchone()
         fisico = float(row[0]) if row else 0.0
         row2 = self.db.execute(
             "SELECT COALESCE(SUM(d.cantidad),0) "
@@ -146,8 +154,8 @@ class StockReservationService:
             try:
                 self.db.execute(f"ROLLBACK TO SAVEPOINT {sp}")
                 self.db.execute(f"RELEASE SAVEPOINT {sp}")
-            except Exception:
-                pass
+            except Exception as rb_exc:
+                logger.warning("Rollback de reserva falló savepoint=%s: %s", sp, rb_exc)
             raise RuntimeError(f"reservar() falló: {exc}") from exc
 
         get_bus().publish(AJUSTE_INVENTARIO, {
@@ -170,11 +178,13 @@ class StockReservationService:
         })
 
     def confirmar(self, reserva_id: int, venta_id: int, folio: str) -> None:
-        self.db.execute(
+        cur = self.db.execute(
             "UPDATE stock_reservas SET estado='confirmada', updated_at=datetime('now') "
             "WHERE id=? AND estado='activa'",
             (reserva_id,),
         )
+        if getattr(cur, "rowcount", 0) != 1:
+            raise RuntimeError(f"Reserva {reserva_id} no está activa para confirmar.")
         get_bus().publish(AJUSTE_INVENTARIO, {
             "motivo": "stock_reserva_confirmada",
             "reserva_id": reserva_id,
@@ -182,3 +192,11 @@ class StockReservationService:
             "folio": str(folio or ""),
             "branch_id": self.branch_id,
         })
+
+    def marcar_revision(self, reserva_id: int, motivo: str = "postventa_warning") -> None:
+        self.db.execute(
+            "UPDATE stock_reservas SET estado='revision', updated_at=datetime('now') "
+            "WHERE id=? AND estado='activa'",
+            (reserva_id,),
+        )
+        logger.warning("stock_reservas: reserva_id=%s quedó en revisión (%s)", reserva_id, motivo)

--- a/pos_spj_v13.4/core/ticket_escpos_renderer.py
+++ b/pos_spj_v13.4/core/ticket_escpos_renderer.py
@@ -211,14 +211,15 @@ class TicketESCPOSRenderer:
                 buf += self._text(f"Recibido: ${recibido:.2f}")
                 buf += self._text(f"Cambio: ${cambio:.2f}")
 
-        # 8. Puntos fidelidad
-        puntos_ganados = ticket_data.get('puntos_ganados', 0)
-        if puntos_ganados:
+        # 8. Puntos fidelidad: no imprimir saldo 0 si no fue confirmado.
+        loyalty_info = dict(ticket_data.get('loyalty') or {})
+        puntos_ganados = loyalty_info.get('puntos_ganados', ticket_data.get('puntos_ganados'))
+        if puntos_ganados not in (None, "", 0):
             buf += self._separator(w, char='-')
             buf += ALIGN_CENTER
             buf += self._text(f"Puntos ganados: +{puntos_ganados}")
-            puntos_total = ticket_data.get('puntos_totales', 0)
-            if puntos_total:
+            puntos_total = loyalty_info.get('puntos_totales', ticket_data.get('puntos_totales'))
+            if loyalty_info.get('available', False) and puntos_total not in (None, ""):
                 buf += self._text(f"Saldo total: {puntos_total} puntos")
 
         # 9. QR code

--- a/pos_spj_v13.4/core/tickets/ticket_message_engine.py
+++ b/pos_spj_v13.4/core/tickets/ticket_message_engine.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+
+
+logger = logging.getLogger("spj.tickets.message_engine")
 
 
 @dataclass
@@ -57,21 +61,21 @@ class TicketMessageEngine:
         result = TicketMessageResult()
 
         max_fomo = int(self._cfg("ticket_fomo_max_messages", "2") or 2)
-        points_gained = int(sale_context.get("puntos_ganados", 0) or 0)
-        points_total = int(sale_context.get("puntos_totales", 0) or 0)
+        raw_points_gained = sale_context.get("puntos_ganados")
+        raw_points_total = sale_context.get("puntos_totales")
+        points_gained = int(raw_points_gained or 0) if raw_points_gained not in (None, "") else 0
+        points_total = int(raw_points_total or 0) if raw_points_total not in (None, "") else None
         cliente_id = ctx.get("cliente_id") or sale_context.get("cliente_id")
 
         # Complementar contextos desde servicios de negocio si falta data.
-        if cliente_id and points_total <= 0 and self.loyalty_service:
+        if cliente_id and points_total is None and self.loyalty_service:
             try:
                 if hasattr(self.loyalty_service, "saldo_cliente"):
-                    points_total = int(self.loyalty_service.saldo_cliente(int(cliente_id)) or 0)
-                elif hasattr(self.loyalty_service, "process_loyalty_for_sale"):
-                    total_sale = float(sale_context.get("total", 0) or 0)
-                    data = self.loyalty_service.process_loyalty_for_sale(int(cliente_id), total_sale)
-                    points_total = int(data.get("puntos_totales", 0) or 0)
-            except Exception:
-                pass
+                    points_total = int(self.loyalty_service.saldo_cliente(int(cliente_id)))
+                elif hasattr(self.loyalty_service, "saldo"):
+                    points_total = int(self.loyalty_service.saldo(int(cliente_id)))
+            except Exception as exc:
+                logger.warning("Saldo de puntos no disponible para ticket cliente=%s: %s", cliente_id, exc)
 
         if cliente_id and "goal_remaining" not in ctx and self.growth_engine:
             try:
@@ -102,7 +106,7 @@ class TicketMessageEngine:
 
         if points_gained > 0:
             result.loyalty_messages.append(TicketMessage("points_gained", f"Ganaste {points_gained} puntos.", 100, "loyalty"))
-        if points_total > 0:
+        if (points_total or 0) > 0:
             result.loyalty_messages.append(TicketMessage("points_total", f"Tu saldo actual es {points_total} puntos.", 90, "loyalty"))
 
         goal_remaining = ctx.get("goal_remaining")
@@ -120,7 +124,7 @@ class TicketMessageEngine:
             tpl = self._cfg("ticket_msg_promo_expiring", "Últimos {days} días de {promo}.")
             result.fomo_messages.append(TicketMessage("promo_expiring", tpl.format(days=int(promo_days_left), promo=promo_name), 98, "fomo"))
 
-        if points_total > 0 and ctx.get("can_redeem", False):
+        if (points_total or 0) > 0 and ctx.get("can_redeem", False):
             tpl = self._cfg("ticket_msg_points_available", "Ya puedes canjear tus puntos en tu próxima compra.")
             result.cta_messages.append(TicketMessage("points_available", tpl, 80, "cta"))
 

--- a/pos_spj_v13.4/core/tickets/ticket_print_model.py
+++ b/pos_spj_v13.4/core/tickets/ticket_print_model.py
@@ -42,9 +42,10 @@ class TicketBranding:
 
 @dataclass
 class TicketLoyaltyInfo:
-    puntos_ganados: int = 0
-    puntos_totales: int = 0
+    puntos_ganados: Optional[int] = None
+    puntos_totales: Optional[int] = None
     nivel: str = ""
+    available: bool = False
 
 
 @dataclass
@@ -115,8 +116,9 @@ class TicketPrintModel:
         data["direccion"] = data.get("branding", {}).get("address", "")
         data["telefono"] = data.get("branding", {}).get("phone", "")
         loyalty = data.get("loyalty") or {}
-        data["puntos_ganados"] = loyalty.get("puntos_ganados", 0)
-        data["puntos_totales"] = loyalty.get("puntos_totales", 0)
+        data["puntos_ganados"] = loyalty.get("puntos_ganados")
+        data["puntos_totales"] = loyalty.get("puntos_totales") if loyalty.get("available", False) else None
+        data["puntos_disponibles"] = bool(loyalty.get("available", False))
         if self.qr and self.qr.enabled:
             data["qr_content"] = self.qr.content
         return data
@@ -139,10 +141,16 @@ class TicketPrintModel:
         layout_src = src.get("layout") or {}
 
         loyalty = None
-        if src.get("puntos_ganados") or src.get("puntos_totales"):
+        loyalty_src = src.get("loyalty") or {}
+        puntos_ganados = loyalty_src.get("puntos_ganados", src.get("puntos_ganados"))
+        puntos_totales = loyalty_src.get("puntos_totales", src.get("puntos_totales"))
+        loyalty_available = bool(loyalty_src.get("available", src.get("puntos_disponibles", False)))
+        if puntos_ganados not in (None, "") or loyalty_available:
             loyalty = TicketLoyaltyInfo(
-                puntos_ganados=int(src.get("puntos_ganados", 0) or 0),
-                puntos_totales=int(src.get("puntos_totales", 0) or 0),
+                puntos_ganados=None if puntos_ganados in (None, "") else int(puntos_ganados or 0),
+                puntos_totales=None if not loyalty_available or puntos_totales in (None, "") else int(puntos_totales or 0),
+                nivel=str(loyalty_src.get("nivel", src.get("nivel", "")) or ""),
+                available=loyalty_available and puntos_totales not in (None, ""),
             )
 
         qr = None

--- a/pos_spj_v13.4/core/use_cases/venta.py
+++ b/pos_spj_v13.4/core/use_cases/venta.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("spj.use_cases.venta")
 
@@ -61,7 +61,9 @@ class DatosPago:
     descuento_lineas: float = 0.0
     mercado_pago_ref: str = ""
     pago_mixto:       Dict[str, float] = field(default_factory=dict)
+    payment_breakdown: Dict[str, float] = field(default_factory=dict)
     total_pagado:     float = 0.0
+    reserva_id:       Optional[int] = None
 
     def __post_init__(self) -> None:
         self.forma_pago = _normalize_payment_label(self.forma_pago)
@@ -72,6 +74,7 @@ class DatosPago:
         self.puntos_canjeados = int(self.puntos_canjeados or 0)
         self.descuento_puntos = float(self.descuento_puntos or 0.0)
         self.pago_mixto = {str(k): float(v or 0.0) for k, v in (self.pago_mixto or {}).items()}
+        self.payment_breakdown = {str(k): float(v or 0.0) for k, v in (self.payment_breakdown or self.pago_mixto or {}).items()}
 
 
 @dataclass
@@ -136,9 +139,9 @@ class ResultadoVenta:
     folio:         str        = ""
     total:         float      = 0.0
     cambio:        float      = 0.0
-    puntos_ganados:int        = 0
-    puntos_totales:int        = 0
-    nivel_cliente: str        = "Bronce"
+    puntos_ganados:Optional[int] = None
+    puntos_totales:Optional[int] = None
+    nivel_cliente: Optional[str] = None
     ticket_html:   str        = ""
     error:         str        = ""
     operation_id:  str        = ""
@@ -219,20 +222,9 @@ class ProcesarVentaUC:
         if stock_error:
             return ResultadoVenta(ok=False, error=stock_error)
 
-        # ── 2. Normalizar método de pago y construir payload ─────────────────
-        try:
-            from core.services.payment_normalization import normalize_payment_method as _npm
-            datos_pago = type(datos_pago)(
-                forma_pago       = _npm(datos_pago.forma_pago),
-                monto_pagado     = datos_pago.monto_pagado,
-                cliente_id       = datos_pago.cliente_id,
-                descuento_global = datos_pago.descuento_global,
-                puntos_canjeados = int(datos_pago.puntos_canjeados or 0),
-                descuento_puntos = float(datos_pago.descuento_puntos or 0.0),
-                notas            = datos_pago.notas,
-            )
-        except Exception:
-            pass  # non-critical normalization
+        # ── 2. Normalizar método de pago sin perder estructura ────────────────
+        from core.services.payment_normalization import normalize_payment_method as _npm
+        datos_pago.forma_pago = _npm(datos_pago.forma_pago)
         # ── Construir payload para SalesService ──────────────────────────────
         items_svc = [
             {
@@ -264,10 +256,12 @@ class ProcesarVentaUC:
                     items=items_svc,
                     payment_method=datos_pago.forma_pago,
                     amount_paid=monto_pagado,
+                    payment_breakdown=dict(datos_pago.payment_breakdown or datos_pago.pago_mixto or {}),
                     client_id=datos_pago.cliente_id,
                     discount=datos_pago.descuento_global,
                     loyalty_redemption_pts=int(datos_pago.puntos_canjeados or 0),
                     notes=datos_pago.notas,
+                    reservation_id=datos_pago.reserva_id,
                 )
                 folio = rich.folio
                 ticket_html = rich.ticket_html
@@ -278,10 +272,19 @@ class ProcesarVentaUC:
                 _payment = getattr(rich, "payment", None)
                 if _payment is not None:
                     payment_breakdown = {
-                        "method": getattr(_payment, "method", ""),
-                        "amount_paid": float(getattr(_payment, "amount_paid", 0.0) or 0.0),
-                        "change": float(getattr(_payment, "change", 0.0) or 0.0),
-                        "breakdown": dict(getattr(_payment, "breakdown", {}) or {}),
+                        "forma_pago": getattr(_payment, "forma_pago", getattr(_payment, "method", "")),
+                        "total_pagado": float(getattr(_payment, "total_pagado", getattr(_payment, "amount_paid", 0.0)) or 0.0),
+                        "efectivo_recibido": float(getattr(_payment, "efectivo_recibido", 0.0) or 0.0),
+                        "tarjeta": float(getattr(_payment, "tarjeta", 0.0) or 0.0),
+                        "transferencia": float(getattr(_payment, "transferencia", 0.0) or 0.0),
+                        "credito": float(getattr(_payment, "credito", 0.0) or 0.0),
+                        "mercado_pago": float(getattr(_payment, "mercado_pago", 0.0) or 0.0),
+                        "cambio": float(getattr(_payment, "cambio", getattr(_payment, "change", 0.0)) or 0.0),
+                        "saldo_credito": float(getattr(_payment, "saldo_credito", 0.0) or 0.0),
+                        "amount_paid": float(getattr(_payment, "amount_paid_real", getattr(_payment, "amount_paid", 0.0)) or 0.0),
+                        "amount_paid_real": float(getattr(_payment, "amount_paid_real", getattr(_payment, "amount_paid", 0.0)) or 0.0),
+                        "lineas": dict(getattr(_payment, "lineas", getattr(_payment, "breakdown", {})) or {}),
+                        "breakdown": dict(getattr(_payment, "lineas", getattr(_payment, "breakdown", {})) or {}),
                     }
                 _loyalty = getattr(rich, "loyalty", None)
                 if _loyalty is not None:
@@ -289,59 +292,31 @@ class ProcesarVentaUC:
                         "cliente_id": getattr(_loyalty, "cliente_id", None),
                         "puntos_canjeados": int(getattr(_loyalty, "puntos_canjeados", 0) or 0),
                         "descuento_puntos": float(getattr(_loyalty, "descuento_puntos", 0.0) or 0.0),
-                        "puntos_ganados": int(getattr(_loyalty, "puntos_ganados", 0) or 0),
-                        "puntos_totales": int(getattr(_loyalty, "puntos_totales", 0) or 0),
-                        "nivel": str(getattr(_loyalty, "nivel", "") or ""),
+                        "puntos_ganados": getattr(_loyalty, "puntos_ganados", None),
+                        "puntos_totales": getattr(_loyalty, "puntos_totales", None),
+                        "nivel": getattr(_loyalty, "nivel", None),
+                        "available": bool(getattr(_loyalty, "available", False)),
                         "mensaje": str(getattr(_loyalty, "mensaje", "") or ""),
                         "operation_id": str(getattr(_loyalty, "operation_id", "") or ""),
                     }
                 warnings.extend(list(getattr(rich, "warnings", []) or []))
             else:
-                result = self._sales.execute_sale(
-                    branch_id      = sucursal_id,
-                    user           = usuario,
-                    items          = items_svc,
-                    payment_method = datos_pago.forma_pago,
-                    amount_paid    = monto_pagado,
-                    client_id      = datos_pago.cliente_id,
-                    discount       = datos_pago.descuento_global,
-                    loyalty_redemption_pts = int(datos_pago.puntos_canjeados or 0),
-                    notes          = datos_pago.notas,
-                )
-                if isinstance(result, (tuple, list)) and len(result) >= 2:
-                    folio        = result[0]
-                    ticket_html  = result[1] if len(result) > 1 else ""
-                else:
-                    folio        = str(result)
-                    ticket_html  = ""
-                row = self._sales.db.execute(
-                    "SELECT id FROM ventas WHERE folio=? ORDER BY id DESC LIMIT 1", (folio,)
-                ).fetchone()
-                venta_id = row[0] if row else 0
-                warnings.append("legacy_execute_sale_result_incomplete")
+                raise RuntimeError("Ruta legacy SalesService.execute_sale bloqueada: use execute_sale_result")
 
-            if loyalty_result:
-                puntos_ganados = int(loyalty_result.get("puntos_ganados", 0) or 0)
-                puntos_totales = int(loyalty_result.get("puntos_totales", 0) or 0)
-                nivel_cliente = str(loyalty_result.get("nivel", "") or "Bronce")
-                if (
-                    datos_pago.cliente_id
-                    and self._loyalty
-                    and getattr(self._loyalty, "enabled", True)
-                    and ("puntos_totales" not in loyalty_result or loyalty_result.get("puntos_totales") in (None, ""))
-                ):
+            puntos_ganados = loyalty_result.get("puntos_ganados") if loyalty_result else None
+            puntos_totales = loyalty_result.get("puntos_totales") if loyalty_result else None
+            nivel_cliente = loyalty_result.get("nivel") if loyalty_result else None
+            if datos_pago.cliente_id and self._loyalty and getattr(self._loyalty, "enabled", True):
+                if puntos_totales in (None, "") or not (loyalty_result or {}).get("available", False):
                     try:
-                        puntos_totales = int(self._loyalty.saldo(datos_pago.cliente_id) or 0)
+                        puntos_totales = int(self._loyalty.saldo(datos_pago.cliente_id))
+                        loyalty_result = dict(loyalty_result or {})
                         loyalty_result["puntos_totales"] = puntos_totales
+                        loyalty_result["available"] = True
                         warnings.append("loyalty_result_incomplete_saldo_consultado")
                     except Exception as _ly_exc:
-                        logger.warning("Loyalty saldo fallback failed cliente=%s: %s", datos_pago.cliente_id, _ly_exc)
-            elif datos_pago.cliente_id and self._loyalty and getattr(self._loyalty, "enabled", True):
-                try:
-                    puntos_totales = int(self._loyalty.saldo(datos_pago.cliente_id) or 0)
-                    loyalty_result = {"puntos_ganados": 0, "puntos_totales": puntos_totales, "nivel": "Bronce"}
-                except Exception:
-                    pass
+                        warnings.append("loyalty_balance_unavailable")
+                        logger.warning("Loyalty saldo unavailable cliente=%s: %s", datos_pago.cliente_id, _ly_exc)
         except Exception as e:
             logger.error("ProcesarVentaUC.execute_sale: %s", e)
             return ResultadoVenta(ok=False, error=str(e))
@@ -349,44 +324,16 @@ class ProcesarVentaUC:
         # ── 4. Post-venta: fidelidad ──────────────────────────────────────────
         # Fase 2: la acreditación ocurre exclusivamente en wiring.py -> loyalty_venta
         # al recibir VENTA_COMPLETADA. El UC no acredita puntos directamente.
-        puntos_ganados = int(locals().get("puntos_ganados", 0) or 0)
-        puntos_totales = int(locals().get("puntos_totales", 0) or 0)
-        nivel_cliente  = str(locals().get("nivel_cliente", "Bronce") or "Bronce")
+        puntos_ganados = locals().get("puntos_ganados", None)
+        puntos_totales = locals().get("puntos_totales", None)
+        nivel_cliente  = locals().get("nivel_cliente", None)
 
-        # ── 5. Post-venta: ticket (execute_sale ya generó uno; re-gen si no hay) ──
-        if not ticket_html and self._ticket:
-            try:
-                ticket_html = self._ticket.generar_ticket(
-                    template_db = "",
-                    venta_data  = {
-                        "venta_id":          venta_id,
-                        "fecha":             _now(),
-                        "cajero":            usuario,
-                        "cliente":           "Público General",
-                        "totales": {
-                            "subtotal":      subtotal,
-                            "descuento":     datos_pago.descuento_global,
-                            "total_final":   total,
-                        },
-                        "efectivo_recibido": monto_pagado,
-                        "cambio":            cambio,
-                        "forma_pago":        datos_pago.forma_pago,
-                        "puntos_ganados":    puntos_ganados,
-                        "puntos_totales":    puntos_totales,
-                        "items": [
-                            {
-                                "nombre":          it.nombre,
-                                "cantidad":        it.cantidad,
-                                "precio_unitario": it.precio_unit,
-                                "total":           it.subtotal,
-                            }
-                            for it in items
-                        ],
-                    },
-                    mensaje_psicologico = "¡Gracias por tu compra!",
-                )
-            except Exception as e:
-                logger.warning("Ticket post-venta venta_id=%s: %s", venta_id, e)
+        # ── 5. Post-venta: ticket ──────────────────────────────────────────
+        # El UC no reconstruye tickets desde items de entrada. La única fuente
+        # válida es SalesService/SaleExecutionResult.ticket_payload.
+        if not ticket_payload:
+            ticket_html = ""
+            warnings.append("ticket_html_missing_from_sales_service")
 
         logger.info(
             "Venta %s OK — total=$%.2f puntos=%d sucursal=%s usuario=%s",

--- a/pos_spj_v13.4/modulos/ventas.py
+++ b/pos_spj_v13.4/modulos/ventas.py
@@ -41,8 +41,6 @@ from PyQt5.QtGui import QIcon, QDoubleValidator, QPixmap, QImage, QColor, QFont,
 
 # Importación de la clase base y utilidades
 from .base import ModuloBase
-from presentation.sales.workers.sale_checkout_worker import SaleCheckoutWorker
-from presentation.sales.workers.sale_checkout_worker_factory import SaleCheckoutWorkerFactory
 from presentation.sales.workers.ticket_output_worker import TicketOutputWorker
 
 logger = logging.getLogger("spj.ventas") 
@@ -1279,13 +1277,14 @@ class ModuloVentas(ModuloBase):
         # v13.4: Recargar productos con stock de la sucursal correcta
         try:
             self.cargar_productos_interactivos()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("No se pudieron recargar productos al cambiar sucursal: %s", exc)
         logger.info(f"✅ Ventas → sucursal activa: {sucursal_nombre} (id={sucursal_id})")
 
     def inicializar_completer(self):
         """Completer removed — real-time search handles this without popup."""
-        pass
+        logger.debug("Completer legacy deshabilitado; búsqueda en tiempo real activa.")
+        return None
 
     def actualizar_completer_model(self):
         try:
@@ -1338,7 +1337,7 @@ class ModuloVentas(ModuloBase):
                 self.main_window.registrar_evento('producto_eliminado', self.on_productos_actualizados)
                 self.main_window.registrar_evento('inventario_actualizado', self.on_productos_actualizados)
         except Exception as e:
-            pass
+            logger.warning("No se pudieron registrar eventos de actualización de ventas: %s", e)
 
     def desconectar_eventos_sistema(self):
         try:
@@ -1347,7 +1346,8 @@ class ModuloVentas(ModuloBase):
                 self.main_window.desregistrar_evento('producto_actualizado', self.on_productos_actualizados)
                 self.main_window.desregistrar_evento('producto_eliminado', self.on_productos_actualizados)
                 self.main_window.desregistrar_evento('inventario_actualizado', self.on_productos_actualizados)
-        except Exception: pass
+        except Exception as exc:
+            logger.warning("No se pudieron desregistrar eventos de actualización de ventas: %s", exc)
             
     def on_productos_actualizados(self, datos):
         self.cargar_productos_interactivos()
@@ -3658,8 +3658,12 @@ class ModuloVentas(ModuloBase):
             self.lbl_nombre_cliente.setText(self.cliente_actual['nombre'])
             self.lbl_telefono_cliente.setText(f"Tel: {self.cliente_actual['telefono'] or '—'}")
             self.lbl_email_cliente.setText(self.cliente_actual.get('email') or '')
-            puntos = self.cliente_actual.get('puntos', 0)
-            self.lbl_puntos_cliente.setText(f"+ {puntos} pts")
+            puntos = self.cliente_actual.get('puntos')
+            try:
+                puntos_texto = f"+ {int(puntos)} pts" if puntos not in (None, "") else "Puntos no disponibles"
+            except (TypeError, ValueError):
+                puntos_texto = "Puntos no disponibles"
+            self.lbl_puntos_cliente.setText(puntos_texto)
             # Update loyalty tier badge
             if hasattr(self, '_lbl_loyalty_tier'):
                 nivel = (self.cliente_actual.get('nivel_fidelidad', '')
@@ -3770,7 +3774,7 @@ class ModuloVentas(ModuloBase):
         self.lbl_nombre_cliente.setText("Público General")
         self.lbl_telefono_cliente.setText("Tel: —")
         self.lbl_email_cliente.setText("")
-        self.lbl_puntos_cliente.setText("+ 0 pts")
+        self.lbl_puntos_cliente.setText("Puntos no disponibles")
         self.txt_cliente.clear()
         if hasattr(self, '_lbl_loyalty_tier'):
             self._lbl_loyalty_tier.hide()
@@ -3818,8 +3822,8 @@ class ModuloVentas(ModuloBase):
             from core.events.domain_events import VENTA_SUSPENDIDA, STOCK_RESERVADO
             get_bus().publish(VENTA_SUSPENDIDA, {"venta_id": venta_id, "reserva_id": reserva_id, "sucursal_id": self.sucursal_id})
             get_bus().publish(STOCK_RESERVADO, {"venta_id": venta_id, "reserva_id": reserva_id, "sucursal_id": self.sucursal_id})
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Venta suspendida con reserva, pero falló publicación de eventos: %s", exc)
         self.btn_reanudar.setText(f"▶️ Reanudar ({len(self.ventas_en_espera)})")
         self.mostrar_mensaje("Éxito", f"Venta '{nombre_venta}' suspendida.")
         self.cancelar_venta(silent=True)
@@ -3869,8 +3873,14 @@ class ModuloVentas(ModuloBase):
                         "No hay un turno de caja abierto para este usuario.\n\n"
                         "Ve al módulo de Caja y abre tu turno antes de vender.")
                     return
-        except Exception:
-            pass  # If check fails, allow sale (graceful degradation)
+        except Exception as exc:
+            logger.exception("Validación de turno de caja falló; venta bloqueada: %s", exc)
+            QMessageBox.critical(
+                self,
+                "Caja no validada",
+                "No se pudo validar el turno de caja. La venta fue bloqueada para evitar inconsistencias.",
+            )
+            return
 
         total_a_pagar = self.totales['total_final']
         loyalty_preview = {}
@@ -3929,7 +3939,13 @@ class ModuloVentas(ModuloBase):
                             )
                             return
                     except Exception as _cv_e:
-                        logger.warning("validate_credit: %s", _cv_e)
+                        logger.exception("Validación de crédito falló; venta a crédito bloqueada: %s", _cv_e)
+                        QMessageBox.critical(
+                            self,
+                            "Crédito no validado",
+                            "No se pudo validar el crédito del cliente. La venta a crédito fue bloqueada.",
+                        )
+                        return
                 elif not _ccs:
                     # Fallback: read credit fields via ClienteRepository
                     try:
@@ -3948,12 +3964,18 @@ class ModuloVentas(ModuloBase):
                                 )
                                 return
                     except Exception as _fbe:
-                        logger.warning("credit fallback check: %s", _fbe)
+                        logger.exception("Validación de crédito fallback falló; venta a crédito bloqueada: %s", _fbe)
+                        QMessageBox.critical(
+                            self,
+                            "Crédito no validado",
+                            "No se pudo validar el crédito del cliente. La venta a crédito fue bloqueada.",
+                        )
+                        return
 
             self.finalizar_venta(datos_pago)
 
     def finalizar_venta(self, datos_pago: Dict[str, Any]):
-        """Procesa venta en background para evitar congelamiento de UI."""
+        """Procesa la venta en hilo principal; solo ticket/PDF queda asíncrono."""
         if getattr(self, "_venta_checkout_running", False):
             return
         self._venta_checkout_running = True
@@ -3961,11 +3983,10 @@ class ModuloVentas(ModuloBase):
         if hasattr(self, "btn_cobrar"):
             self.btn_cobrar.setEnabled(False)
             self.btn_cobrar.setText("Procesando venta...")
-        _worker_started = False
         try:
             usuario = self.obtener_usuario_actual()
             cliente_id = self.cliente_actual['id'] if self.cliente_actual else None
-            from core.services.payment_normalization import is_mercado_pago
+            from core.services.payment_normalization import is_credit_sale, is_mercado_pago
 
             carrito_limpio = [
                 {
@@ -4001,11 +4022,15 @@ class ModuloVentas(ModuloBase):
                 link = result.get('link') if isinstance(result, dict) else result
                 link = link or (result.get('url', '') if isinstance(result, dict) else "")
                 if not link:
+                    sales_svc.cancel_pending_payment_sale(folio_pend, motivo="link_failed")
                     raise RuntimeError("No se pudo generar link de pago MercadoPago.")
+                if hasattr(sales_svc, "attach_pending_payment_link"):
+                    sales_svc.attach_pending_payment_link(folio_pend, link)
 
                 self._ultimo_mp_pending = {
                     "estado": "pendiente_pago",
                     "folio": folio_pend,
+                    "reservation_id": pending.get("reservation_id"),
                     "url_pago": link,
                     "cliente_id": cliente_id,
                     "cliente": dict(self.cliente_actual or {}),
@@ -4016,10 +4041,11 @@ class ModuloVentas(ModuloBase):
                 QMessageBox.information(
                     self,
                     "Mercado Pago pendiente",
-                    f"Se generó link de pago para la venta pendiente {folio_pend}.\n\n{link}\n\n"
-                    "La venta no se marcó como completada hasta confirmar el pago.\n"
-                    "Mercado Pago pendiente no reserva stock todavía."
+                    "Link de pago generado y stock reservado. "
+                    "La venta se confirmará automáticamente al aprobarse el pago.\n\n"
+                    f"Folio pendiente: {folio_pend}\n{link}",
                 )
+                self._reserva_activa_id = None
                 self.cancelar_venta(silent=True)
                 return
 
@@ -4048,20 +4074,31 @@ class ModuloVentas(ModuloBase):
                         )
                         if resp != QMessageBox.Yes:
                             return
-            except Exception:
-                pass  # No bloquea la venta si la validación falla
+            except Exception as exc:
+                logger.warning("Validación bajo costo no disponible: %s", exc)
+                QMessageBox.warning(
+                    self,
+                    "Validación no disponible",
+                    "No se pudo validar venta bajo costo. Revise configuración antes de continuar."
+                )
+                return
 
             from core.use_cases.venta import ItemCarrito, DatosPago as _DP
             _uc = getattr(self.container, 'uc_venta', None)
             if _uc is None:
                 raise RuntimeError("ProcesarVentaUC no disponible en AppContainer.")
             _items_uc = [ItemCarrito(producto_id=it['product_id'], cantidad=float(it['qty']), precio_unit=float(it['unit_price']), nombre=it.get('name', ''), es_compuesto=int(it.get('es_compuesto', 0))) for it in carrito_limpio]
-            _monto_pagado_real = float(
-                datos_pago.get('total_pagado')
-                or datos_pago.get('efectivo_recibido')
-                or 0.0
-            )
-            _lineas_pago = dict(datos_pago.get("lineas", {}) or {})
+            _lineas_pago = dict(datos_pago.get("lineas") or datos_pago.get("breakdown") or {})
+            if datos_pago.get('amount_paid_real') is not None:
+                _monto_pagado_real = float(datos_pago.get('amount_paid_real') or 0.0)
+            elif datos_pago.get('amount_paid') is not None:
+                _monto_pagado_real = float(datos_pago.get('amount_paid') or 0.0)
+            elif _lineas_pago:
+                _monto_pagado_real = float(sum(float(v or 0.0) for v in _lineas_pago.values()))
+            elif is_credit_sale(datos_pago.get('forma_pago')):
+                _monto_pagado_real = 0.0
+            else:
+                _monto_pagado_real = float(datos_pago.get('total_pagado') or datos_pago.get('efectivo_recibido') or 0.0)
             _dp = _DP(
                 forma_pago=datos_pago['forma_pago'],
                 monto_pagado=_monto_pagado_real,
@@ -4074,27 +4111,11 @@ class ModuloVentas(ModuloBase):
                 notas=f"Venta POS Mostrador. Cajero: {usuario}.",
                 sucursal_id=self.sucursal_id,
                 usuario=usuario,
+                reserva_id=self._reserva_activa_id,
             )
             self._venta_timing["t_uc_start"] = time.perf_counter()
-            self._venta_worker_thread = QThread(self)
-            self._sale_checkout_worker_factory = getattr(
-                self,
-                "_sale_checkout_worker_factory",
-                SaleCheckoutWorkerFactory(self.container),
-            )
-            self._venta_worker = self._sale_checkout_worker_factory.build(
-                _uc, _items_uc, _dp, self.sucursal_id, usuario
-            )
-            self._venta_worker.moveToThread(self._venta_worker_thread)
-            self._venta_worker_thread.started.connect(self._venta_worker.run)
-            self._venta_worker.success.connect(lambda r: self._on_checkout_success(r, datos_pago, usuario, cliente_id))
-            self._venta_worker.failed.connect(self._on_checkout_failed)
-            self._venta_worker.finished.connect(self._on_checkout_finished)
-            self._venta_worker.finished.connect(self._venta_worker_thread.quit)
-            self._venta_worker_thread.finished.connect(self._venta_worker.deleteLater)
-            self._venta_worker_thread.finished.connect(self._venta_worker_thread.deleteLater)
-            self._venta_worker_thread.start()
-            _worker_started = True
+            result = _uc.ejecutar(_items_uc, _dp, self.sucursal_id, usuario)
+            self._on_checkout_success(result, datos_pago, usuario, cliente_id)
             return
         except PermissionError as e:
             QMessageBox.warning(self, "Acceso Denegado", str(e))
@@ -4107,10 +4128,7 @@ class ModuloVentas(ModuloBase):
             QMessageBox.critical(self, "Error al procesar venta", str(e))
             self._on_checkout_finished()
         finally:
-            # Si no se lanzó worker asíncrono (retornos tempranos / MP / validaciones),
-            # garantizar desbloqueo de UI inmediatamente.
-            if not _worker_started:
-                self._on_checkout_finished()
+            self._on_checkout_finished()
 
     def _on_checkout_success(self, _r, datos_pago, usuario, cliente_id):
         self._venta_timing["t_uc_done"] = time.perf_counter()
@@ -4161,59 +4179,84 @@ class ModuloVentas(ModuloBase):
         self._ultima_venta_id = getattr(result, "venta_id", 0)
         self.btn_factura.setEnabled(bool(self._ultima_venta_id))
         self.btn_reimprimir.setEnabled(bool(self._ultima_venta_id))
-        if getattr(result, "ticket_html", ""):
-            self._ticket_html_cache = result.ticket_html
         self._abrir_cajon()
 
         loyalty_result = dict(getattr(result, "loyalty_result", {}) or {})
-        puntos_ganados = int(loyalty_result.get("puntos_ganados", getattr(result, "puntos_ganados", 0)) or 0)
-        puntos_totales = loyalty_result.get("puntos_totales", getattr(result, "puntos_totales", 0))
-        if (puntos_totales in (None, "")) and cliente_id:
+        puntos_ganados_raw = loyalty_result.get("puntos_ganados", getattr(result, "puntos_ganados", None))
+        puntos_ganados = int(puntos_ganados_raw or 0)
+        puntos_totales = loyalty_result.get("puntos_totales", getattr(result, "puntos_totales", None))
+        saldo_confiable = bool(loyalty_result.get("available", False)) and puntos_totales not in (None, "")
+        if not saldo_confiable and cliente_id:
             ls = getattr(self.container, 'loyalty_service', None) if hasattr(self, 'container') else None
             if ls:
                 try:
-                    puntos_totales = int(ls.saldo(cliente_id) or 0)
+                    puntos_totales = int(ls.saldo(cliente_id))
+                    saldo_confiable = True
                 except Exception as exc:
-                    logger.warning("Loyalty saldo post-venta fallback: %s", exc)
-        puntos_totales = int(puntos_totales or 0)
-        self.lbl_puntos_venta.setText(f"⭐ +{puntos_ganados} | Saldo: {puntos_totales}" if puntos_ganados > 0 else f"⭐ Saldo: {puntos_totales}")
-        if cliente_id and isinstance(getattr(self, "cliente_actual", None), dict):
-            self.cliente_actual["puntos"] = puntos_totales
+                    logger.warning("Loyalty saldo post-venta no disponible: %s", exc)
+        if saldo_confiable:
+            puntos_totales = int(puntos_totales)
+            self.lbl_puntos_venta.setText(f"⭐ +{puntos_ganados} | Saldo: {puntos_totales}" if puntos_ganados > 0 else f"⭐ Saldo: {puntos_totales}")
+            if cliente_id and isinstance(getattr(self, "cliente_actual", None), dict):
+                self.cliente_actual["puntos"] = puntos_totales
+        else:
+            self.lbl_puntos_venta.setText("⭐ Saldo de puntos no disponible")
 
         datos_ticket = dict(getattr(result, "ticket_payload", {}) or {})
-        if not datos_ticket:
-            datos_ticket = {
-                "folio": folio,
-                "venta_id": getattr(result, "venta_id", 0),
-                "fecha": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                "cajero": usuario,
-                "cliente": self.cliente_actual["nombre"] if self.cliente_actual else "Público General",
-                "totales": {"total_final": float(getattr(result, "total", 0.0) or 0.0)},
-                "pago": dict(getattr(result, "payment_breakdown", {}) or {}),
-                "logo_path": LOGO_TICKET_PATH,
-                "empresa": getattr(self.container, "_nombre_empresa", "SPJ POS"),
-                "puntos_ganados": puntos_ganados,
-                "puntos_totales": puntos_totales,
-                "mensaje_psicologico": loyalty_result.get("mensaje") or "¡Gracias por su compra!",
-            }
-        self._venta_timing["t_ticket_start"] = time.perf_counter()
-        self._imprimir_ticket_consolidado(datos_ticket)
+        if self._reserva_activa_id:
+            if datos_ticket.get("reservation_confirmed") is True:
+                self._reserva_activa_id = None
+            else:
+                reserva_pendiente_id = self._reserva_activa_id
+                logger.warning(
+                    "Venta completada, pero la reserva quedó pendiente de revisión: reserva_id=%s",
+                    reserva_pendiente_id,
+                )
+                try:
+                    self._stock_reservas.marcar_revision(
+                        reserva_pendiente_id,
+                        motivo="postventa_warning",
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "No se pudo marcar la reserva pendiente en revisión: reserva_id=%s error=%s",
+                        reserva_pendiente_id,
+                        exc,
+                    )
+                self._reserva_activa_id = None
+                Toast.warning(self, "Reserva", "Venta completada, pero la reserva quedó pendiente de revisión.")
+
+        try:
+            payload_venta_id = int(datos_ticket.get("venta_id") or datos_ticket.get("sale_id") or 0)
+        except (TypeError, ValueError):
+            payload_venta_id = 0
+        result_venta_id = int(getattr(result, "venta_id", 0) or 0)
+        payload_total = None
+        if datos_ticket:
+            payload_total = (datos_ticket.get("totales") or {}).get(
+                "total_final",
+                datos_ticket.get("total_final", datos_ticket.get("total")),
+            )
+        if (
+            not datos_ticket
+            or not payload_venta_id
+            or payload_venta_id != result_venta_id
+            or payload_total in (None, "")
+        ):
+            self._ticket_html_cache = ""
+            QMessageBox.warning(
+                self,
+                "Ticket no generado",
+                "Venta completada, pero no se generó payload de ticket. Use reimpresión desde venta_id."
+            )
+        else:
+            if getattr(result, "ticket_html", ""):
+                self._ticket_html_cache = result.ticket_html
+            self._venta_timing["t_ticket_start"] = time.perf_counter()
+            self._imprimir_ticket_consolidado(datos_ticket)
         Toast.success(self, f"✅ Venta #{folio} completada", f"Total: ${float(getattr(result, 'total', 0.0) or 0.0):.2f}")
 
-        if self._reserva_activa_id:
-            self._stock_reservas.confirmar(
-                self._reserva_activa_id,
-                venta_id=getattr(result, "venta_id", 0),
-                folio=folio,
-            )
-            try:
-                from core.events.event_bus import get_bus
-                from core.events.domain_events import VENTA_CONFIRMADA_RESERVA, STOCK_DESCONTADO_RESERVA
-                get_bus().publish(VENTA_CONFIRMADA_RESERVA, {"reserva_id": self._reserva_activa_id, "sucursal_id": self.sucursal_id, "folio": folio})
-                get_bus().publish(STOCK_DESCONTADO_RESERVA, {"reserva_id": self._reserva_activa_id, "sucursal_id": self.sucursal_id, "folio": folio})
-            except Exception as exc:
-                logger.warning("Venta completada, pero reserva requiere revisión: %s", exc)
-            self._reserva_activa_id = None
+
 
         QTimer.singleShot(0, self.cargar_productos_interactivos)
         self.cancelar_venta(silent=True)
@@ -4319,8 +4362,8 @@ class ModuloVentas(ModuloBase):
                     buf = _io.BytesIO(); img.save(buf, format='PNG')
                     qr_b64 = _b64.b64encode(buf.getvalue()).decode()
                     qr_html = f'<div style="text-align:center;margin:4px 0;"><img src="data:image/png;base64,{qr_b64}" width="{qr_size}px"></div>'
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning("No se pudo generar QR de ticket; se continúa sin QR: %s", exc)
 
             # Barcode
             if _cfg('ticket_bc_enabled', '0') == '1':
@@ -4331,14 +4374,16 @@ class ModuloVentas(ModuloBase):
             font_family = _cfg('ticket_font_family', 'Courier New')
             try:
                 font_size = int(_cfg('ticket_font_size', '12'))
-            except Exception:
+            except Exception as exc:
+                logger.warning("Config ticket_font_size inválida; usando default 12: %s", exc)
                 font_size = 12
             try:
                 paper_w = int(_cfg('ticket_paper_width', '80'))
-            except Exception:
+            except Exception as exc:
+                logger.warning("Config ticket_paper_width inválida; usando default 80: %s", exc)
                 paper_w = 80
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Configuración visual de ticket no disponible; se usan defaults: %s", exc)
 
         # ── Construir items_html ──────────────────────────────────────────
         filas = ""
@@ -4359,6 +4404,13 @@ class ModuloVentas(ModuloBase):
         elif 'dito' in forma_pago:
             pago_extra = f"Saldo adeudado: ${float(pago.get('saldo_credito', total_final)):.2f}"
 
+        loyalty_info = dict(ticket_data.get('loyalty') or {})
+        ticket_points_total = loyalty_info.get('puntos_totales', ticket_data.get('puntos_totales'))
+        ticket_points_available = bool(loyalty_info.get('available', False)) and ticket_points_total not in (None, "")
+        ticket_points_earned = loyalty_info.get('puntos_ganados', ticket_data.get('puntos_ganados'))
+        puntos_ganados_txt = "" if ticket_points_earned in (None, "") else str(ticket_points_earned)
+        puntos_totales_txt = str(ticket_points_total) if ticket_points_available else "Saldo de puntos no disponible"
+
         # ── Sustitución de variables en plantilla ─────────────────────────
         if plantilla:
             variables = {
@@ -4371,8 +4423,8 @@ class ModuloVentas(ModuloBase):
                 'descuento': f"${float(totales.get('descuento', 0)):.2f}",
                 'forma_pago': forma_pago,
                 'cambio': f"${cambio:.2f}",
-                'puntos_ganados': str(ticket_data.get('puntos_ganados', 0)),
-                'puntos_totales': str(ticket_data.get('puntos_totales', 0)),
+                'puntos_ganados': puntos_ganados_txt,
+                'puntos_totales': puntos_totales_txt,
                 'mensaje_psicologico': ticket_data.get('mensaje_psicologico', '¡Gracias por su compra!'),
                 'logo': logo_html,
                 'qr_code': qr_html,
@@ -4444,8 +4496,10 @@ class ModuloVentas(ModuloBase):
                 from core.events.domain_events import VENTA_SUSPENDIDA_CANCELADA, STOCK_RESERVA_LIBERADA
                 get_bus().publish(VENTA_SUSPENDIDA_CANCELADA, {"reserva_id": self._reserva_activa_id, "sucursal_id": self.sucursal_id})
                 get_bus().publish(STOCK_RESERVA_LIBERADA, {"reserva_id": self._reserva_activa_id, "sucursal_id": self.sucursal_id})
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("No se pudo liberar reserva activa al cancelar venta: reserva_id=%s error=%s", self._reserva_activa_id, exc)
+                if not silent:
+                    Toast.warning(self, "Reserva", "No se pudo liberar la reserva; quedó pendiente de revisión.")
             self._reserva_activa_id = None
         self.limpiar_seleccion_producto()
         self.limpiar_cliente()
@@ -4459,8 +4513,8 @@ class ModuloVentas(ModuloBase):
         try:
             self.txt_busqueda.setFocus()
             self.txt_busqueda.selectAll()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("No se pudo enfocar búsqueda al mostrar ventas: %s", exc)
 
     def _generar_factura(self) -> None:
         """Abre el diálogo para generar CFDI de la última venta."""

--- a/pos_spj_v13.4/presentation/sales/workers/sale_checkout_worker.py
+++ b/pos_spj_v13.4/presentation/sales/workers/sale_checkout_worker.py
@@ -1,13 +1,20 @@
-import traceback
-import threading
-import sqlite3
+from __future__ import annotations
+
 import logging
+
 from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
 
 logger = logging.getLogger("spj.sales.checkout_worker")
 
+_DISABLED_MESSAGE = (
+    "SaleCheckoutWorker deshabilitado: la venta transaccional debe ejecutarse "
+    "en el hilo principal con ProcesarVentaUC.ejecutar(); solo impresión/PDF puede ir en background."
+)
+
 
 class SaleCheckoutWorker(QObject):
+    """Bloqueado: no ejecutar ventas en QThread con servicios/SQLite del contenedor UI."""
+
     started = pyqtSignal()
     progress = pyqtSignal(str)
     success = pyqtSignal(object)
@@ -16,39 +23,11 @@ class SaleCheckoutWorker(QObject):
 
     def __init__(self, uc_venta, items, datos_pago, sucursal_id, usuario):
         super().__init__()
-        self._uc_venta = uc_venta
-        self._items = items
-        self._datos_pago = datos_pago
-        self._sucursal_id = sucursal_id
-        self._usuario = usuario
-        self._ui_thread_id = threading.get_ident()
-
-    def _db_conn_id(self):
-        try:
-            sales = getattr(self._uc_venta, "_sales", None)
-            db = getattr(sales, "db", None)
-            return id(db) if db is not None else 0
-        except Exception:
-            return 0
+        logger.error(_DISABLED_MESSAGE)
+        raise RuntimeError(_DISABLED_MESSAGE)
 
     @pyqtSlot()
     def run(self):
-        self.started.emit()
-        self.progress.emit("Procesando venta...")
-        worker_tid = threading.get_ident()
-        logger.info(
-            "SaleCheckoutWorker start ui_tid=%s worker_tid=%s db_conn_id=%s",
-            self._ui_thread_id,
-            worker_tid,
-            self._db_conn_id(),
-        )
-        try:
-            result = self._uc_venta.ejecutar(self._items, self._datos_pago, self._sucursal_id, self._usuario)
-            self.success.emit(result)
-        except sqlite3.ProgrammingError as exc:
-            logger.exception("SQLite thread error in checkout worker")
-            self.failed.emit(str(exc), traceback.format_exc())
-        except Exception as exc:
-            self.failed.emit(str(exc), traceback.format_exc())
-        finally:
-            self.finished.emit()
+        logger.error(_DISABLED_MESSAGE)
+        self.failed.emit(_DISABLED_MESSAGE, "")
+        self.finished.emit()

--- a/pos_spj_v13.4/presentation/sales/workers/sale_checkout_worker_factory.py
+++ b/pos_spj_v13.4/presentation/sales/workers/sale_checkout_worker_factory.py
@@ -1,64 +1,16 @@
 from __future__ import annotations
 
-import copy
-import sqlite3
 from typing import Any
-
-from core.use_cases.venta import ProcesarVentaUC
-from presentation.sales.workers.sale_checkout_worker import SaleCheckoutWorker
 
 
 class SaleCheckoutWorkerFactory:
-    """Crea workers con UC aislado por hilo usando conexión SQLite dedicada."""
+    """Bloqueada: la venta transaccional no puede clonarse superficialmente a QThread."""
 
     def __init__(self, container):
         self._container = container
 
-    def _new_thread_db(self):
-        db = getattr(self._container, "db", None)
-        if db is None:
-            return None
-        row = db.execute("PRAGMA database_list").fetchone()
-        db_path = row[2] if row and len(row) > 2 else ""
-        if not db_path:
-            return None
-        conn = sqlite3.connect(db_path, timeout=5.0, isolation_level=None, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
-        return conn
-
-    def _clone_uc(self, base_uc, db_conn):
-        if db_conn is None:
-            return base_uc
-
-        sales = copy.copy(getattr(base_uc, "_sales", None))
-        inventory = copy.copy(getattr(base_uc, "_inventory", None))
-        finance = copy.copy(getattr(base_uc, "_finance", None))
-        loyalty = copy.copy(getattr(base_uc, "_loyalty", None))
-        ticket = getattr(base_uc, "_ticket", None)
-        sync = getattr(base_uc, "_sync", None)
-        bus = getattr(base_uc, "_bus", None)
-        cfdi = getattr(base_uc, "_cfdi", None)
-
-        for svc in (sales, inventory, finance, loyalty):
-            if svc is not None and hasattr(svc, "db"):
-                try:
-                    svc.db = db_conn
-                except Exception:
-                    pass
-
-        return ProcesarVentaUC(
-            sales_service=sales,
-            inventory_service=inventory,
-            finance_service=finance,
-            loyalty_service=loyalty,
-            ticket_engine=ticket,
-            sync_service=sync,
-            event_bus=bus,
-            cfdi_service=cfdi,
+    def build(self, uc_venta: Any, items, datos_pago, sucursal_id, usuario):
+        raise RuntimeError(
+            "SaleCheckoutWorkerFactory deshabilitado: ejecutar ProcesarVentaUC.ejecutar() "
+            "en el hilo principal hasta tener WorkerAppContainer real."
         )
-
-    def build(self, uc_venta: Any, items, datos_pago, sucursal_id, usuario) -> SaleCheckoutWorker:
-        thread_db = self._new_thread_db()
-        uc = self._clone_uc(uc_venta, thread_db)
-        return SaleCheckoutWorker(uc, items, datos_pago, sucursal_id, usuario)
-

--- a/pos_spj_v13.4/repositories/ventas.py
+++ b/pos_spj_v13.4/repositories/ventas.py
@@ -127,8 +127,9 @@ class VentaRepository:
         if str(os.getenv("ALLOW_LEGACY_VENTA_REPOSITORY_WRITES", "0")).strip() != "1":
             raise RuntimeError(
                 "VentaRepository.create_sale() está bloqueado por seguridad. "
-                "Usa SalesService.execute_sale() o habilita explícitamente "
-                "ALLOW_LEGACY_VENTA_REPOSITORY_WRITES=1 para flujos legacy controlados."
+                "Ruta oficial: ProcesarVentaUC.ejecutar() -> SalesService.execute_sale_result(). "
+                "Eliminación planificada: 2026-06-30. Habilita explícitamente "
+                "ALLOW_LEGACY_VENTA_REPOSITORY_WRITES=1 solo para flujos legacy controlados."
             )
 
         operation_id = sale_data.get("operation_id") or str(uuid.uuid4())

--- a/pos_spj_v13.4/services/mercado_pago_service.py
+++ b/pos_spj_v13.4/services/mercado_pago_service.py
@@ -28,7 +28,8 @@ class MercadoPagoService:
             row = self.conn.execute(
                 "SELECT valor FROM configuraciones WHERE clave='mp_access_token'").fetchone()
             return row[0] if row else ""
-        except Exception:
+        except Exception as exc:
+            logger.warning("MP: no se pudo leer access token: %s", exc)
             return ""
 
     def _headers(self) -> dict:
@@ -100,7 +101,8 @@ class MercadoPagoService:
                 VALUES(?,?,?,?,'pendiente')""",
                 (pedido_id, monto, preference_id, url))
             self.conn.commit()
-        except Exception: pass
+        except Exception as exc:
+            logger.warning("MP: no se pudo guardar link de pago pedido=%s: %s", pedido_id, exc)
 
     # ── Verificar pago ──────────────────────────────────────────────
     def verificar_pago(self, payment_id: str) -> dict:
@@ -156,8 +158,8 @@ class MercadoPagoService:
                                 WHERE id=?""", (pedido_id,))
                         logger.info("MP pago aprobado (legacy pedido): pedido=%d payment=%s",
                                     pedido_id, payment_id)
-                    except Exception:
-                        logger.info("MP pago aprobado sin confirmador inyectado: ref=%s", external_ref)
+                    except Exception as exc:
+                        logger.info("MP pago aprobado sin confirmador legacy aplicable: ref=%s error=%s", external_ref, exc)
                     return True
                 except Exception as e:
                     logger.error("procesar_webhook BD: %s", e)
@@ -168,7 +170,8 @@ class MercadoPagoService:
             row = self.conn.execute(
                 "SELECT valor FROM configuraciones WHERE clave='mp_webhook_url'").fetchone()
             return row[0] if row else ""
-        except Exception:
+        except Exception as exc:
+            logger.warning("MP: no se pudo leer webhook URL: %s", exc)
             return ""
 
     def _get_return_url(self, status: str) -> str:
@@ -177,7 +180,8 @@ class MercadoPagoService:
                 "SELECT valor FROM configuraciones WHERE clave='mp_return_url'").fetchone()
             base = row[0] if row else "http://localhost:8765"
             return f"{base}/pago/{status}"
-        except Exception:
+        except Exception as exc:
+            logger.warning("MP: no se pudo leer return URL status=%s: %s", status, exc)
             return f"http://localhost:8765/pago/{status}"
 
 
@@ -185,7 +189,8 @@ class MPWebhookHandler(BaseHTTPRequestHandler):
     svc: MercadoPagoService = None
     on_pago_aprobado = None   # callback(pedido_id)
 
-    def log_message(self, *a): pass
+    def log_message(self, *a):
+        logger.debug("MP webhook HTTP: %s", a)
 
     def do_POST(self):
         length = int(self.headers.get("Content-Length", 0))
@@ -198,7 +203,8 @@ class MPWebhookHandler(BaseHTTPRequestHandler):
                 try:
                     ext = str(data.get("data", {}).get("id", ""))
                     self.on_pago_aprobado(ext)
-                except Exception: pass
+                except Exception as exc:
+                    logger.warning("MP webhook handler: callback post-aprobación falló: %s", exc)
         except Exception as e:
             logger.error("MP webhook handler: %s", e)
 

--- a/pos_spj_v13.4/tests/test_fase1_procesar_venta_uc_rich_mapping.py
+++ b/pos_spj_v13.4/tests/test_fase1_procesar_venta_uc_rich_mapping.py
@@ -37,6 +37,7 @@ class _SalesRich:
                 nivel="Oro",
                 mensaje="ok",
                 operation_id="op-101",
+                available=True,
             ),
             warnings=["w1"],
         )
@@ -89,6 +90,9 @@ def test_uc_no_returns_fake_zero_points_when_rich_has_loyalty():
     assert r.nivel_cliente == "Oro"
 
 
-def test_uc_legacy_adds_warning():
+def test_uc_legacy_route_is_blocked_without_ticket_fallback():
     r = _uc(_SalesLegacy()).ejecutar(_items(), _dp(), 1, "cajero")
-    assert "legacy_execute_sale_result_incomplete" in r.warnings
+    assert r.ok is False
+    assert "execute_sale_result" in r.error
+    assert r.ticket_html == ""
+    assert r.ticket_payload == {}

--- a/pos_spj_v13.4/tests/test_fase4_payment_mapping.py
+++ b/pos_spj_v13.4/tests/test_fase4_payment_mapping.py
@@ -3,18 +3,23 @@ from pathlib import Path
 from core.services.sales.payment_policy import PaymentPolicy
 
 
-SRC_SALES = Path('pos_spj_v13.4/core/services/sales_service.py').read_text(encoding='utf-8')
-SRC_UI = Path('pos_spj_v13.4/modulos/ventas.py').read_text(encoding='utf-8')
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_SALES = (REPO_ROOT / 'core/services/sales_service.py').read_text(encoding='utf-8')
+SRC_UI = (REPO_ROOT / 'modulos/ventas.py').read_text(encoding='utf-8')
 
 
 def test_credit_with_accent_maps_to_credit_not_cash():
     assert PaymentPolicy.normalize_payment_method("Crédito") == "Crédito"
-    assert '"Crédito": "credito"' in SRC_SALES
+    data = PaymentPolicy.build_payment_breakdown(total=100.0, method="Crédito", saldo_credito=100.0)
+    assert data["lineas"]["credito"] == 100.0
+    assert data["efectivo_recibido"] == 0.0
 
 
 def test_credit_without_accent_maps_to_credit_not_cash():
     assert PaymentPolicy.normalize_payment_method("Credito") == "Crédito"
-    assert '"Credito": "credito"' in SRC_SALES
+    data = PaymentPolicy.build_payment_breakdown(total=100.0, method="Credito", saldo_credito=100.0)
+    assert data["lineas"]["credito"] == 100.0
+    assert data["amount_paid_real"] == 0.0
 
 
 def test_mixed_payment_preserves_cash_and_card():
@@ -26,7 +31,7 @@ def test_mixed_payment_preserves_cash_and_card():
 
 
 def test_points_discount_affects_backend_total():
-    assert "total_a_pagar = round(total_a_pagar - loyalty_discount, 2)" in Path('pos_spj_v13.4/core/services/sales_service.py').read_text(encoding='utf-8')
+    assert "total_a_pagar = round(total_a_pagar - loyalty_discount, 2)" in (REPO_ROOT / 'core/services/sales_service.py').read_text(encoding='utf-8')
 
 
 def test_ui_total_equals_result_total_after_points():
@@ -34,4 +39,7 @@ def test_ui_total_equals_result_total_after_points():
 
 
 def test_ticket_payment_breakdown_matches_backend():
-    assert '"pago": dict(getattr(result, "payment_breakdown", {}) or {})' in SRC_UI
+    assert 'datos_ticket = dict(getattr(result, "ticket_payload", {}) or {})' in SRC_UI
+    assert '_imprimir_ticket_consolidado(datos_ticket)' in SRC_UI
+    assert 'ticket_payload["pago"]' in SRC_SALES
+    assert '"lineas": payment_breakdown' in SRC_SALES

--- a/pos_spj_v13.4/tests/test_fase5_stock_reservations.py
+++ b/pos_spj_v13.4/tests/test_fase5_stock_reservations.py
@@ -1,6 +1,8 @@
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from core.services.stock_reservation_service import StockReservationService
 
 
@@ -53,7 +55,88 @@ def test_no_liberada_confirmada_status_string():
     assert "liberada:" not in st
 
 
-def test_ui_confirma_reserva_en_venta_reanudada():
-    src = Path("pos_spj_v13.4/modulos/ventas.py").read_text(encoding="utf-8")
-    assert "self._stock_reservas.confirmar(" in src
+def _src(path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+
+
+def test_ui_no_confirma_reserva_postventa():
+    src = _src("modulos/ventas.py")
+    aplicar = src.split("def _aplicar_resultado_venta", 1)[1].split("def _on_checkout_failed", 1)[0]
+    assert "self._stock_reservas.confirmar(" not in aplicar
+    assert "VENTA_CONFIRMADA_RESERVA" not in aplicar
+    assert "STOCK_DESCONTADO_RESERVA" not in aplicar
     assert 'motivo="confirmada"' not in src
+
+
+def test_ui_pasa_reserva_id_al_uc_antes_de_aplicar_resultado():
+    src = _src("modulos/ventas.py")
+    finalizar = src.split("def finalizar_venta", 1)[1].split("def _on_checkout_success", 1)[0]
+    assert "reserva_id=self._reserva_activa_id" in finalizar
+    assert "result = _uc.ejecutar" in finalizar
+
+
+def test_sales_service_confirma_reserva_en_flujo_transaccional():
+    src = _src("core/services/sales_service.py")
+    core = src.split("def _execute_sale_core", 1)[1].split("# B. Guardar detalles", 1)[0]
+    assert "reservation_id" in core
+    assert "StockReservationService(self.db, branch_id=branch_id).confirmar" in core
+    assert "reservation_confirmed = True" in core
+
+
+def test_confirmar_reserva_inactiva_falla_explicito():
+    db = _db()
+    svc = StockReservationService(db, branch_id=1)
+    rid = svc.reservar("SUSP-X", [{"id": 1, "cantidad": 1.0}])
+    svc.liberar(rid, motivo="cancelada")
+    with pytest.raises(RuntimeError, match="no está activa"):
+        svc.confirmar(rid, venta_id=300, folio="F300")
+
+
+def test_reservation_failure_after_sale_does_not_mark_sale_failed():
+    src = _src("modulos/ventas.py")
+    aplicar = src.split("def _aplicar_resultado_venta", 1)[1].split("def _on_checkout_failed", 1)[0]
+    assert "self._stock_reservas.confirmar(" not in aplicar
+    assert "self._on_checkout_failed" not in aplicar
+
+
+def test_confirm_reservation_called_before_print_or_non_blocking():
+    sales_src = _src("core/services/sales_service.py")
+    core = sales_src.split("def _execute_sale_core", 1)[1].split("# B. Guardar detalles", 1)[0]
+    assert "StockReservationService(self.db, branch_id=branch_id).confirmar" in core
+
+    ui_src = _src("modulos/ventas.py")
+    aplicar = ui_src.split("def _aplicar_resultado_venta", 1)[1].split("def _on_checkout_failed", 1)[0]
+    assert aplicar.find("reservation_confirmed") < aplicar.find("_imprimir_ticket_consolidado(datos_ticket)")
+
+
+def test_no_liberada_confirmada_status():
+    db = _db()
+    svc = StockReservationService(db, branch_id=1)
+    rid = svc.reservar("SUSP-NO-LIB", [{"id": 1, "cantidad": 1.0}])
+    svc.confirmar(rid, venta_id=400, folio="F400")
+    st = db.execute("SELECT estado FROM stock_reservas WHERE id=?", (rid,)).fetchone()[0]
+    assert st == "confirmada"
+    assert "liberada:confirmada" not in st
+
+
+def test_sale_success_even_if_reservation_warning():
+    src = _src("modulos/ventas.py")
+    aplicar = src.split("def _aplicar_resultado_venta", 1)[1].split("def _on_checkout_failed", 1)[0]
+    warning_idx = aplicar.find("Venta completada, pero la reserva quedó pendiente de revisión")
+    toast_idx = aplicar.find("Toast.warning", warning_idx)
+    fail_idx = aplicar.find("_on_checkout_failed", warning_idx)
+    assert warning_idx != -1
+    assert toast_idx != -1
+    assert fail_idx == -1
+
+
+def test_ui_warning_marks_reservation_for_review_without_canceling_sale():
+    src = _src("modulos/ventas.py")
+    aplicar = src.split("def _aplicar_resultado_venta", 1)[1].split("def _on_checkout_failed", 1)[0]
+    warning_idx = aplicar.find("Venta completada, pero la reserva quedó pendiente de revisión")
+    revision_idx = aplicar.find("self._stock_reservas.marcar_revision", warning_idx)
+    clear_idx = aplicar.find("self._reserva_activa_id = None", revision_idx)
+    fail_idx = aplicar.find("_on_checkout_failed", warning_idx)
+    assert revision_idx != -1
+    assert clear_idx != -1
+    assert fail_idx == -1

--- a/pos_spj_v13.4/tests/test_fase6_mercadopago_cleanup.py
+++ b/pos_spj_v13.4/tests/test_fase6_mercadopago_cleanup.py
@@ -1,11 +1,28 @@
 from pathlib import Path
+import sqlite3
 
-SRC = Path("pos_spj_v13.4/modulos/ventas.py").read_text(encoding="utf-8")
+from core.services.sales_service import SalesService
+
+SRC = (Path(__file__).resolve().parents[1] / "modulos" / "ventas.py").read_text(encoding="utf-8")
+SALES_SRC = (Path(__file__).resolve().parents[1] / "core" / "services" / "sales_service.py").read_text(encoding="utf-8")
+
+
+def _service_with_stock(stock=5.0):
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE branch_inventory(branch_id INTEGER, product_id INTEGER, quantity REAL)")
+    db.execute(
+        "INSERT INTO branch_inventory(branch_id, product_id, quantity) VALUES(1,1,?)",
+        (float(stock),),
+    )
+    svc = SalesService.__new__(SalesService)
+    svc.db = db
+    return svc, db
 
 
 def test_mp_pending_reenables_cobrar_button():
     assert "finally:" in SRC
-    assert "if not _worker_started:" in SRC
+    assert "_worker_started" not in SRC
     assert "self._on_checkout_finished()" in SRC
 
 
@@ -13,17 +30,72 @@ def test_mp_pending_does_not_leave_checkout_running_true():
     assert "self._venta_checkout_running = False" in SRC
 
 
-def test_mp_link_failure_does_not_clear_cart():
+def test_mp_link_failure_releases_pending_reservation_before_raising():
     start = SRC.find("if is_mercado_pago(datos_pago.get('forma_pago')):")
     end = SRC.find("# ── Guardrail: detectar ítems por debajo del costo", start)
     block = SRC[start:end]
+    assert 'sales_svc.cancel_pending_payment_sale(folio_pend, motivo="link_failed")' in block
     assert "raise RuntimeError(\"No se pudo generar link de pago MercadoPago.\")" in block
     fail_idx = block.find("raise RuntimeError(\"No se pudo generar link de pago MercadoPago.\")")
     clear_idx = block.find("self.cancelar_venta(silent=True)")
-    assert clear_idx != -1 and clear_idx > fail_idx
+    assert clear_idx == -1 or clear_idx > fail_idx
 
 
 def test_mp_pending_has_recoverable_context():
+    assert '"estado": "pendiente_pago"' in SRC
+    assert '"folio": folio_pend' in SRC
+    assert '"reservation_id": pending.get("reservation_id")' in SRC
     assert '"compra": list(self.compra_actual)' in SRC
     assert '"totales": dict(self.totales)' in SRC
     assert '"datos_pago": dict(datos_pago or {})' in SRC
+
+
+def test_mp_pending_creates_reservation():
+    svc, db = _service_with_stock(stock=5.0)
+    pending = svc.create_pending_payment_sale(
+        branch_id=1,
+        user="u",
+        items=[{"product_id": 1, "qty": 2, "unit_price": 10}],
+        client_id=None,
+        total=20.0,
+    )
+    assert pending["estado"] == "pendiente_pago"
+    assert pending["reservation_id"] > 0
+    estado = db.execute(
+        "SELECT estado FROM stock_reservas WHERE id=?",
+        (pending["reservation_id"],),
+    ).fetchone()[0]
+    assert estado == "activa"
+    intent = db.execute(
+        "SELECT estado, reservation_id FROM pending_sales_intents WHERE folio=?",
+        (pending["folio"],),
+    ).fetchone()
+    assert intent["estado"] == "pendiente_pago"
+    assert int(intent["reservation_id"]) == pending["reservation_id"]
+
+
+def test_mp_pending_cancel_releases_reservation():
+    svc, db = _service_with_stock(stock=5.0)
+    pending = svc.create_pending_payment_sale(
+        branch_id=1,
+        user="u",
+        items=[{"product_id": 1, "qty": 1, "unit_price": 10}],
+        total=10.0,
+    )
+    svc.cancel_pending_payment_sale(pending["folio"], motivo="cancelada")
+    reserva_estado = db.execute(
+        "SELECT estado FROM stock_reservas WHERE id=?",
+        (pending["reservation_id"],),
+    ).fetchone()[0]
+    intent_estado = db.execute(
+        "SELECT estado FROM pending_sales_intents WHERE folio=?",
+        (pending["folio"],),
+    ).fetchone()[0]
+    assert reserva_estado == "cancelada"
+    assert intent_estado == "cancelada"
+
+
+def test_mp_pending_confirm_uses_reserved_stock():
+    assert "reservation_id = int(data.get(\"reservation_id\") or 0)" in SALES_SRC
+    assert "payment_breakdown={\"mercado_pago\": total}" in SALES_SRC
+    assert "reservation_id=reservation_id" in SALES_SRC

--- a/pos_spj_v13.4/tests/test_fase7_checkout_worker_sqlite_threading.py
+++ b/pos_spj_v13.4/tests/test_fase7_checkout_worker_sqlite_threading.py
@@ -1,55 +1,23 @@
-import sqlite3
+from pathlib import Path
+
+import pytest
 
 from presentation.sales.workers.sale_checkout_worker import SaleCheckoutWorker
 
 
 class _UCOK:
-    class _Sales:
-        db = object()
-
-    _sales = _Sales()
-
     def ejecutar(self, *args, **kwargs):
         return {"ok": True}
 
 
-class _UCThreadErr:
-    class _Sales:
-        db = object()
-
-    _sales = _Sales()
-
-    def ejecutar(self, *args, **kwargs):
-        raise sqlite3.ProgrammingError("SQLite objects created in a thread can only be used in that same thread")
+def test_checkout_worker_blocked_before_any_sqlite_thread_use():
+    with pytest.raises(RuntimeError, match="deshabilitado"):
+        SaleCheckoutWorker(_UCOK(), [], {}, 1, "u")
 
 
-class _UCGenericErr:
-    class _Sales:
-        db = object()
-
-    _sales = _Sales()
-
-    def ejecutar(self, *args, **kwargs):
-        raise RuntimeError("boom")
-
-
-def test_checkout_worker_reports_sqlite_thread_error():
-    w = SaleCheckoutWorker(_UCThreadErr(), [], {}, 1, "u")
-    got = {}
-    w.failed.connect(lambda m, tb: got.update({"m": m, "tb": tb}))
-    w.run()
-    assert "SQLite objects created" in got.get("m", "")
-
-
-def test_checkout_worker_success_with_threadsafe_connection():
-    w = SaleCheckoutWorker(_UCOK(), [], {}, 1, "u")
-    got = {}
-    w.success.connect(lambda r: got.update({"r": r}))
-    w.run()
-    assert got.get("r") == {"ok": True}
-
-
-def test_checkout_worker_does_not_use_main_thread_sqlite_connection_if_not_threadsafe():
-    src = open("pos_spj_v13.4/presentation/sales/workers/sale_checkout_worker.py", encoding="utf-8").read()
-    assert "SQLite thread error in checkout worker" in src
-    assert "db_conn_id" in src
+def test_checkout_worker_source_has_no_sqlite_thread_execution_path():
+    repo_root = Path(__file__).resolve().parents[1]
+    src = (repo_root / "presentation" / "sales" / "workers" / "sale_checkout_worker.py").read_text(encoding="utf-8")
+    assert "SQLite thread error in checkout worker" not in src
+    assert "self._uc_venta.ejecutar" not in src
+    assert "raise RuntimeError(_DISABLED_MESSAGE)" in src

--- a/pos_spj_v13.4/tests/test_fase7_critical_handlers.py
+++ b/pos_spj_v13.4/tests/test_fase7_critical_handlers.py
@@ -1,0 +1,72 @@
+from concurrent.futures import ThreadPoolExecutor
+import threading
+
+import pytest
+
+from core.events.domain_events import SALE_ITEMS_PROCESS
+from core.events.event_bus import EventBus
+from core.services.sales_service import SalesService
+
+
+class _Bus:
+    def __init__(self, labels):
+        self._labels = labels
+
+    def handler_labels(self, _event_type):
+        return list(self._labels)
+
+
+def _svc():
+    return SalesService.__new__(SalesService)
+
+
+def test_sale_fails_without_inventory_handler():
+    with pytest.raises(RuntimeError, match="inventario"):
+        _svc()._validate_critical_sale_handlers(
+            _Bus(["sale_finance_income"]),
+            SALE_ITEMS_PROCESS,
+            "Efectivo",
+        )
+
+
+def test_sale_fails_without_finance_handler():
+    with pytest.raises(RuntimeError, match="finanzas/caja"):
+        _svc()._validate_critical_sale_handlers(
+            _Bus(["sale_inventory_deduct"]),
+            SALE_ITEMS_PROCESS,
+            "Efectivo",
+        )
+
+
+def test_credit_sale_fails_without_credit_handler():
+    with pytest.raises(RuntimeError, match="crédito"):
+        _svc()._validate_critical_sale_handlers(
+            _Bus(["sale_inventory_deduct", "sale_finance_income"]),
+            SALE_ITEMS_PROCESS,
+            "Credito",
+        )
+
+
+
+
+def test_sale_all_critical_handlers_registered_passes():
+    _svc()._validate_critical_sale_handlers(
+        _Bus([
+            "sale_inventory_deduct",
+            "sale_finance_income",
+            "sale_credit_cxc",
+        ]),
+        SALE_ITEMS_PROCESS,
+        "Credito",
+    )
+
+def test_sale_items_process_not_noop_in_production():
+    bus = object.__new__(EventBus)
+    bus._handlers = {}
+    bus._lock = threading.RLock()
+    bus._executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        with pytest.raises(RuntimeError, match="Handlers críticos"):
+            bus.publish(SALE_ITEMS_PROCESS, {"sale_id": 1}, strict=True)
+    finally:
+        bus._executor.shutdown(wait=False)

--- a/pos_spj_v13.4/tests/test_fase7_mp_pending_context_recovery_e2e.py
+++ b/pos_spj_v13.4/tests/test_fase7_mp_pending_context_recovery_e2e.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-SRC = Path("pos_spj_v13.4/modulos/ventas.py").read_text(encoding="utf-8")
+SRC = (Path(__file__).resolve().parents[1] / "modulos" / "ventas.py").read_text(encoding="utf-8")
 
 
 def test_mp_pending_context_keeps_required_fields_for_recovery():
@@ -20,5 +20,5 @@ def test_mp_pending_context_keeps_required_fields_for_recovery():
 
 def test_mp_pending_cleanup_path_unblocks_ui_even_on_early_return():
     assert "finally:" in SRC
-    assert "if not _worker_started:" in SRC
+    assert "_worker_started" not in SRC
     assert "self._on_checkout_finished()" in SRC

--- a/pos_spj_v13.4/tests/test_fase7_worker_factory_db_isolation.py
+++ b/pos_spj_v13.4/tests/test_fase7_worker_factory_db_isolation.py
@@ -1,5 +1,6 @@
-import sqlite3
 from pathlib import Path
+
+import pytest
 
 from core.use_cases.venta import ProcesarVentaUC
 from presentation.sales.workers.sale_checkout_worker_factory import SaleCheckoutWorkerFactory
@@ -19,19 +20,45 @@ class _Container:
         self.db = db
 
 
-def test_worker_factory_creates_dedicated_db_connection(tmp_path):
-    dbp = tmp_path / "t.db"
-    db = sqlite3.connect(str(dbp), check_same_thread=False)
-    db.row_factory = sqlite3.Row
-    db.execute("CREATE TABLE IF NOT EXISTS x(id INTEGER)")
-    c = _Container(db)
-    f = SaleCheckoutWorkerFactory(c)
-    w = f.build(_uc(db), [], {}, 1, "u")
-    ucw = w._uc_venta
-    assert getattr(ucw, "_sales").db is not db
+def test_worker_factory_disabled_or_removed():
+    f = SaleCheckoutWorkerFactory(_Container(object()))
+    with pytest.raises(RuntimeError, match="deshabilitado"):
+        f.build(_uc(object()), [], {}, 1, "u")
 
 
-def test_modulo_ventas_uses_worker_factory():
-    src = Path("pos_spj_v13.4/modulos/ventas.py").read_text(encoding="utf-8")
-    assert "SaleCheckoutWorkerFactory" in src
-    assert "self._sale_checkout_worker_factory.build(" in src
+def test_modulo_ventas_does_not_use_worker_factory_for_sale_transaction():
+    repo_root = Path(__file__).resolve().parents[1]
+    src = (repo_root / "modulos" / "ventas.py").read_text(encoding="utf-8")
+    assert "self._sale_checkout_worker_factory.build(" not in src
+    assert "SaleCheckoutWorkerFactory" not in src
+    assert "result = _uc.ejecutar(_items_uc, _dp, self.sucursal_id, usuario)" in src
+
+
+def test_sale_does_not_use_shallow_cloned_worker():
+    repo_root = Path(__file__).resolve().parents[1]
+    factory_src = (repo_root / "presentation" / "sales" / "workers" / "sale_checkout_worker_factory.py").read_text(encoding="utf-8")
+    assert "copy.copy" not in factory_src
+    assert "_clone_uc" not in factory_src
+    assert "deshabilitado" in factory_src
+
+
+def test_sale_checkout_factory_disabled_or_removed():
+    with pytest.raises(RuntimeError, match="deshabilitado"):
+        SaleCheckoutWorkerFactory(_Container(object())).build(_uc(object()), [], {}, 1, "u")
+
+
+def test_sale_transaction_uses_single_db_connection():
+    repo_root = Path(__file__).resolve().parents[1]
+    src = (repo_root / "modulos" / "ventas.py").read_text(encoding="utf-8")
+    fn = src.split("def finalizar_venta", 1)[1].split("def _on_checkout_success", 1)[0]
+    assert "moveToThread" not in fn
+    assert "QThread" not in fn
+    assert "result = _uc.ejecutar(_items_uc, _dp, self.sucursal_id, usuario)" in fn
+
+
+def test_printing_still_async_after_sale():
+    repo_root = Path(__file__).resolve().parents[1]
+    src = (repo_root / "modulos" / "ventas.py").read_text(encoding="utf-8")
+    pdf_fn = src.split("def _guardar_ticket_pdf_async", 1)[1].split("def generar_html_ticket", 1)[0]
+    assert "TicketOutputWorker" in pdf_fn
+    assert "moveToThread" in pdf_fn

--- a/pos_spj_v13.4/tests/test_fase8_no_silent_passes.py
+++ b/pos_spj_v13.4/tests/test_fase8_no_silent_passes.py
@@ -1,0 +1,70 @@
+from concurrent.futures import ThreadPoolExecutor
+import threading
+from pathlib import Path
+
+import pytest
+
+from core.events.domain_events import SALE_ITEMS_PROCESS
+from core.events.event_bus import EventBus
+
+ROOT = Path(__file__).resolve().parents[1]
+VENTAS_SRC = (ROOT / "modulos" / "ventas.py").read_text(encoding="utf-8")
+SALES_SRC = (ROOT / "core" / "services" / "sales_service.py").read_text(encoding="utf-8")
+PRINTER_SRC = (ROOT / "core" / "services" / "printer_service.py").read_text(encoding="utf-8")
+RESERVATION_SRC = (ROOT / "core" / "services" / "stock_reservation_service.py").read_text(encoding="utf-8")
+MP_SRC = (ROOT / "services" / "mercado_pago_service.py").read_text(encoding="utf-8")
+
+
+def _between(src: str, start: str, end: str) -> str:
+    i = src.index(start)
+    j = src.index(end, i)
+    return src[i:j]
+
+
+def test_cash_shift_validation_error_blocks_or_warns_explicitly():
+    block = _between(VENTAS_SRC, "# ── Validar que la caja esté abierta", "total_a_pagar =")
+    assert "logger.exception" in block
+    assert "QMessageBox.critical" in block
+    assert "return" in block
+    assert "pass  # If check fails" not in block
+
+
+def test_credit_validation_error_not_silent():
+    block = _between(VENTAS_SRC, "if is_credit_sale(datos_pago.get('forma_pago')):", "self.finalizar_venta(datos_pago)")
+    assert "Validación de crédito falló" in block
+    assert "Validación de crédito fallback falló" in block
+    assert block.count("QMessageBox.critical") >= 3
+    assert "logger.warning(\"validate_credit" not in block
+
+
+def test_ticket_generation_error_warning_not_pass():
+    assert "logger.warning(\"No se pudo generar el ticket HTML" in SALES_SRC
+    assert "PrinterService sin EventBus" in PRINTER_SRC
+    assert "print_job_log commit failed" in PRINTER_SRC
+
+
+def test_eventbus_critical_error_not_silent():
+    bus = object.__new__(EventBus)
+    bus._handlers = {}
+    bus._lock = threading.RLock()
+    bus._executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        with pytest.raises(RuntimeError, match="Handlers críticos"):
+            bus.publish(SALE_ITEMS_PROCESS, {"sale_id": 1}, strict=True)
+    finally:
+        bus._executor.shutdown(wait=False)
+
+
+def test_margin_validation_error_blocks_sale_explicitly():
+    block = _between(SALES_SRC, "# Guardia de margen v13.4", "# 2. TRANSACCIÓN CRÍTICA")
+    assert "Validación de margen/costo falló" in block
+    assert "venta bloqueada" in block
+    assert "raise RuntimeError" in block
+    assert "pass  # guardia no crítica" not in block
+
+
+def test_mp_pending_and_reservation_errors_are_logged_not_passed():
+    assert "No se pudo persistir intención MP; liberando reserva_id" in SALES_SRC
+    assert "Rollback de reserva falló" in RESERVATION_SRC
+    assert "MP: no se pudo guardar link de pago" in MP_SRC
+    assert "callback post-aprobación falló" in MP_SRC

--- a/pos_spj_v13.4/tests/test_fase9_legacy_sales_blocked.py
+++ b/pos_spj_v13.4/tests/test_fase9_legacy_sales_blocked.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import pytest
+
+from core.services.sales_service import SalesService
+from core.services.sales.unified_sales_service import DatosPago, UnifiedSalesService
+
+ROOT = Path(__file__).resolve().parents[1]
+SALES_SRC = (ROOT / "core" / "services" / "sales_service.py").read_text(encoding="utf-8")
+VENTAS_UI_SRC = (ROOT / "modulos" / "ventas.py").read_text(encoding="utf-8")
+UNIFIED_SRC = (ROOT / "core" / "services" / "sales" / "unified_sales_service.py").read_text(encoding="utf-8")
+
+
+class _Item:
+    producto_id = 1
+    cantidad = 1.0
+    precio_unitario = 10.0
+    nombre = "P"
+
+
+def test_sales_service_procesar_venta_legacy_blocked_by_default(monkeypatch):
+    monkeypatch.delenv("ALLOW_LEGACY_SALES_SERVICE_PROCESAR_VENTA", raising=False)
+    svc = SalesService.__new__(SalesService)
+    with pytest.raises(RuntimeError, match="ProcesarVentaUC"):
+        svc.procesar_venta([_Item()], DatosPago(efectivo_recibido=10.0))
+
+
+def test_legacy_unified_sales_service_blocked_by_default(monkeypatch):
+    monkeypatch.delenv("ALLOW_LEGACY_UNIFIED_SALES_SERVICE", raising=False)
+    svc = UnifiedSalesService(conn=None)
+    with pytest.raises(RuntimeError, match="UnifiedSalesService.procesar_venta"):
+        svc.procesar_venta([_Item()], DatosPago(efectivo_recibido=10.0))
+
+
+def test_legacy_minimal_sale_write_blocked_by_default(monkeypatch):
+    monkeypatch.delenv("ALLOW_LEGACY_MINIMAL_SALE_WRITE", raising=False)
+    svc = SalesService.__new__(SalesService)
+    with pytest.raises(RuntimeError, match="_procesar_venta_legacy_minimal"):
+        svc._procesar_venta_legacy_minimal(
+            items_payload=[{"product_id": 1, "qty": 1, "unit_price": 10}],
+            payment_method="Efectivo",
+            amount_paid=10.0,
+            client_id=None,
+            discount=0.0,
+            usuario="u",
+        )
+
+
+def test_no_ui_direct_sale_write():
+    assert "INSERT INTO ventas" not in VENTAS_UI_SRC
+    assert "VentaRepository(" not in VENTAS_UI_SRC
+    assert "create_sale(" not in VENTAS_UI_SRC
+    assert "result = _uc.ejecutar" in VENTAS_UI_SRC
+
+
+def test_no_legacy_ticket_path_active():
+    assert "ALLOW_LEGACY_MINIMAL_SALE_WRITE" in SALES_SRC
+    assert "_procesar_venta_legacy_minimal() está bloqueado por seguridad" in SALES_SRC
+    assert "ticket_data={\"folio\": folio, \"total\": total, \"items\": items_payload}" in SALES_SRC
+    assert "UnifiedSalesService.procesar_venta() está bloqueado por seguridad" in UNIFIED_SRC

--- a/pos_spj_v13.4/tests/test_mercado_pago_pending_flow.py
+++ b/pos_spj_v13.4/tests/test_mercado_pago_pending_flow.py
@@ -15,18 +15,18 @@ def test_ui_mercadopago_pending_branch_does_not_execute_sale():
     src = VENTAS_PY.read_text(encoding="utf-8")
     start = src.find("if is_mercado_pago(datos_pago.get('forma_pago')):")
     assert start != -1
-    block = src[start:start + 2500]
+    block = src[start:start + 3500]
     assert "create_pending_payment_sale(" in block
     assert "mp.crear_link(" in block
     assert "self.cancelar_venta(silent=True)" in block
     assert "return" in block
-    assert "execute_sale(" not in block
+    assert "result = _uc.ejecutar" not in block
 
 
 def test_ui_pending_branch_does_not_open_drawer_or_publish_completed_event():
     src = VENTAS_PY.read_text(encoding="utf-8")
     start = src.find("if is_mercado_pago(datos_pago.get('forma_pago')):")
     assert start != -1
-    block = src[start:start + 2500]
+    block = src[start:start + 3500]
     assert "_abrir_cajon(" not in block
     assert "VENTA_COMPLETADA" not in block

--- a/pos_spj_v13.4/tests/test_mercado_pago_webhook_confirmation.py
+++ b/pos_spj_v13.4/tests/test_mercado_pago_webhook_confirmation.py
@@ -42,11 +42,16 @@ def test_sales_service_confirm_pending_payment_sale_executes_sale_once():
         customer_service=MagicMock(),
     )
 
-    row = ("{\"branch_id\":1,\"user\":\"caj\",\"client_id\":1,\"items\":[{\"product_id\":1,\"qty\":1,\"unit_price\":100}],\"total\":100,\"notes\":\"x\"}", "pendiente_pago")
+    row = ("{\"branch_id\":1,\"user\":\"caj\",\"client_id\":1,\"items\":[{\"product_id\":1,\"qty\":1,\"unit_price\":100}],\"total\":100,\"notes\":\"x\",\"reservation_id\":77}", "pendiente_pago")
     svc.db.execute.return_value.fetchone.return_value = row
-    svc.execute_sale = MagicMock(return_value=("F-100", "<t>"))
+    rich = MagicMock(folio="F-100", ticket_html="<t>")
+    svc.execute_sale_result = MagicMock(return_value=rich)
 
     folio, ticket = svc.confirm_pending_payment_sale("VREF-1", payment_id="P-1")
     assert folio == "F-100"
     assert ticket == "<t>"
-    svc.execute_sale.assert_called_once()
+    svc.execute_sale_result.assert_called_once()
+    kwargs = svc.execute_sale_result.call_args.kwargs
+    assert kwargs["payment_method"] == "Mercado Pago"
+    assert kwargs["payment_breakdown"] == {"mercado_pago": 100.0}
+    assert kwargs["reservation_id"] == 77

--- a/pos_spj_v13.4/tests/test_phase5_payment_policy.py
+++ b/pos_spj_v13.4/tests/test_phase5_payment_policy.py
@@ -30,3 +30,15 @@ def test_build_payment_breakdown_credito_y_mixto():
 def test_helpers_credit_pending():
     assert PaymentPolicy.is_credit_sale('Crédito') is True
     assert PaymentPolicy.is_pending_payment('Mercado Pago') is True
+
+
+def test_payment_policy_credit_cash_zero_and_mixed_lines():
+    c = PaymentPolicy.build_payment_breakdown(total=200, method='Crédito', saldo_credito=200)
+    assert c['efectivo_recibido'] == 0.0
+    assert c['amount_paid_real'] == 0.0
+    assert c['lineas']['credito'] == 200
+
+    m = PaymentPolicy.build_payment_breakdown(total=100, method='Pago Mixto', cash=30, card=80)
+    assert m['lineas']['efectivo'] == 30
+    assert m['lineas']['tarjeta'] == 80
+    assert m['amount_paid_real'] == 110

--- a/pos_spj_v13.4/tests/test_sales_no_duplication_real.py
+++ b/pos_spj_v13.4/tests/test_sales_no_duplication_real.py
@@ -68,6 +68,14 @@ def test_e2e_contado_credito_canje_mp_pending_confirmed():
     bus = get_bus()
     events = []
     old_publish = bus.publish
+    old_handler_count = getattr(bus, "handler_count", None)
+    old_handler_labels = getattr(bus, "handler_labels", None)
+    bus.handler_count = lambda event: 3
+    bus.handler_labels = lambda event: [
+        "test_sale_inventory_deduct",
+        "test_sale_finance_income",
+        "test_sale_credit_cxc",
+    ]
 
     def capture(event, payload, **kwargs):
         events.append(event)
@@ -113,3 +121,7 @@ def test_e2e_contado_credito_canje_mp_pending_confirmed():
         assert st == "confirmada"
     finally:
         bus.publish = old_publish
+        if old_handler_count is not None:
+            bus.handler_count = old_handler_count
+        if old_handler_labels is not None:
+            bus.handler_labels = old_handler_labels

--- a/pos_spj_v13.4/tests/test_ticket_pipeline_integration.py
+++ b/pos_spj_v13.4/tests/test_ticket_pipeline_integration.py
@@ -85,3 +85,25 @@ def test_no_qprinter_en_rutas_termicas_principales():
             end = src.index("def _imprimir_ticket_hardware", start)
             src = src[start:end]
         assert "QPrinter" not in src
+
+
+def test_ticket_model_does_not_export_unavailable_zero_points():
+    from core.tickets.ticket_print_model import (
+        TicketPrintModel, TicketTotals, TicketPaymentInfo, TicketBranding, TicketLoyaltyInfo,
+    )
+
+    model = TicketPrintModel(
+        ticket_type="sale",
+        folio="F-0",
+        fecha="2026-01-01",
+        cajero="u",
+        cliente_nombre="Cliente",
+        items=[],
+        totals=TicketTotals(total_final=10),
+        payment=TicketPaymentInfo(forma_pago="Efectivo"),
+        branding=TicketBranding(),
+        loyalty=TicketLoyaltyInfo(puntos_ganados=0, puntos_totales=0, available=False),
+    )
+    data = model.to_dict()
+    assert data["puntos_totales"] is None
+    assert data["puntos_disponibles"] is False

--- a/pos_spj_v13.4/tests/test_ventas_checkout_async_flow.py
+++ b/pos_spj_v13.4/tests/test_ventas_checkout_async_flow.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+
+import pytest
+
 from presentation.sales.workers.sale_checkout_worker import SaleCheckoutWorker
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -10,25 +13,17 @@ class _UCOK:
         return {"ok": True, "folio": "V1", "venta_id": 1}
 
 
-class _UCFail:
-    def ejecutar(self, *_a, **_k):
-        raise RuntimeError("boom")
+def test_ventas_checkout_worker_blocked_for_transactional_sale():
+    with pytest.raises(RuntimeError, match="deshabilitado"):
+        SaleCheckoutWorker(_UCOK(), [], {}, 1, "cajero")
 
 
-def test_ventas_checkout_worker_success():
-    w = SaleCheckoutWorker(_UCOK(), [], {}, 1, "cajero")
-    got = {}
-    w.success.connect(lambda r: got.setdefault("result", r))
-    w.run()
-    assert got["result"]["ok"] is True
-
-
-def test_ventas_checkout_worker_failure_no_limpia_carrito():
-    w = SaleCheckoutWorker(_UCFail(), [], {}, 1, "cajero")
-    got = {}
-    w.failed.connect(lambda msg, _tb: got.setdefault("msg", msg))
-    w.run()
-    assert "boom" in got["msg"]
+def test_finalizar_venta_executes_uc_in_main_thread_without_sale_worker():
+    src = VENTAS.read_text(encoding="utf-8")
+    fn = src.split("def finalizar_venta", 1)[1].split("def _on_checkout_success", 1)[0]
+    assert "result = _uc.ejecutar(_items_uc, _dp, self.sucursal_id, usuario)" in fn
+    assert "SaleCheckoutWorker" not in fn
+    assert "moveToThread" not in fn
 
 
 def test_imprimir_ticket_no_printer_muestra_error_y_pdf():
@@ -55,6 +50,6 @@ def test_printer_callback_error_llega_a_ui():
 
 def test_finalizar_venta_no_llama_qprinter_directo():
     src = VENTAS.read_text(encoding="utf-8")
-    fn = src.split("def finalizar_venta", 1)[1].split("def generar_ticket", 1)[0]
+    fn = src.split("def finalizar_venta", 1)[1].split("def _on_checkout_success", 1)[0]
     assert "QPrinter" not in fn
     assert "QTextDocument" not in fn

--- a/pos_spj_v13.4/tests/test_ventas_cleanup_regression.py
+++ b/pos_spj_v13.4/tests/test_ventas_cleanup_regression.py
@@ -1,0 +1,293 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.use_cases.venta import DatosPago, ItemCarrito, ProcesarVentaUC
+from core.services.sales.sale_execution_result import (
+    SaleExecutionResult,
+    SaleExecutionItem,
+    SaleLoyaltyResult,
+    SalePaymentResult,
+)
+from core.services.sales_service import SalesService
+from presentation.sales.workers.sale_checkout_worker_factory import SaleCheckoutWorkerFactory
+
+
+def _result(**kw):
+    base = dict(
+        ok=True,
+        venta_id=123,
+        folio="F-123",
+        operation_id="op-123",
+        subtotal=100.0,
+        descuento_total=0.0,
+        total=100.0,
+        items=[SaleExecutionItem(1, "Backend", 1, 100, 100, 0, 100)],
+        payment=SalePaymentResult("Efectivo", 100, 100, 0, 0, 0, 0, 0, 0, {"efectivo": 100}),
+        loyalty=SaleLoyaltyResult(1, 0, 0.0, None, None, None, "", "op-123", False),
+        ticket_payload={},
+        ticket_html="",
+        warnings=[],
+        error="",
+    )
+    base.update(kw)
+    return SaleExecutionResult(**base)
+
+
+def _uc_with_sales(rich, loyalty=None):
+    sales = MagicMock()
+    sales.execute_sale_result.return_value = rich
+    inv = MagicMock()
+    inv.get_stock.return_value = 999
+    return ProcesarVentaUC(sales, inv, MagicMock(), loyalty, MagicMock()), sales
+
+
+def test_no_ticket_from_uc_original_items():
+    uc, _sales = _uc_with_sales(_result(ticket_payload={}, ticket_html=""))
+    res = uc.ejecutar(
+        [ItemCarrito(producto_id=1, cantidad=1, precio_unit=999.0, nombre="UI_ORIGINAL")],
+        DatosPago(forma_pago="Efectivo", monto_pagado=100.0),
+        1,
+        "cajero",
+    )
+    assert res.ok is True
+    assert res.ticket_html == ""
+    assert "ticket_html_missing_from_sales_service" in res.warnings
+    assert "UI_ORIGINAL" not in res.ticket_html
+
+
+def test_ticket_requires_backend_payload():
+    uc, _sales = _uc_with_sales(_result(ticket_payload={}, ticket_html="<html>legacy</html>"))
+    res = uc.ejecutar([ItemCarrito(1, 1, 100, "A")], DatosPago(monto_pagado=100), 1, "u")
+    assert res.ticket_payload == {}
+    assert "ticket_html_missing_from_sales_service" in res.warnings
+
+
+def test_ticket_payload_has_real_sale_id_and_total_matches_sale_result():
+    payload = {"venta_id": 123, "folio": "F-123", "totales": {"total_final": 100.0}}
+    uc, _sales = _uc_with_sales(_result(ticket_payload=payload, ticket_html="<html></html>"))
+    res = uc.ejecutar([ItemCarrito(1, 1, 100, "A")], DatosPago(monto_pagado=100), 1, "u")
+    assert res.ticket_payload["venta_id"] == res.venta_id == 123
+    assert res.ticket_payload["totales"]["total_final"] == res.total
+
+
+def test_loyalty_none_does_not_display_zero():
+    loyalty = MagicMock()
+    loyalty.enabled = True
+    loyalty.saldo.side_effect = RuntimeError("down")
+    uc, _sales = _uc_with_sales(_result(), loyalty=loyalty)
+    res = uc.ejecutar([ItemCarrito(1, 1, 100, "A")], DatosPago(monto_pagado=100, cliente_id=1), 1, "u")
+    assert res.puntos_totales is None
+    assert "loyalty_balance_unavailable" in res.warnings
+
+
+def test_loyalty_zero_only_if_service_confirms_zero():
+    loyalty = MagicMock()
+    loyalty.enabled = True
+    loyalty.saldo.return_value = 0
+    uc, _sales = _uc_with_sales(_result(), loyalty=loyalty)
+    res = uc.ejecutar([ItemCarrito(1, 1, 100, "A")], DatosPago(monto_pagado=100, cliente_id=1), 1, "u")
+    assert res.puntos_totales == 0
+    loyalty.saldo.assert_called_once_with(1)
+
+
+
+
+def test_ui_queries_saldo_when_result_points_missing():
+    loyalty = MagicMock()
+    loyalty.enabled = True
+    loyalty.saldo.return_value = 45
+    uc, _sales = _uc_with_sales(_result(), loyalty=loyalty)
+    res = uc.ejecutar([ItemCarrito(1, 1, 100, "A")], DatosPago(monto_pagado=100, cliente_id=1), 1, "u")
+    assert res.puntos_totales == 45
+    assert res.loyalty_result["available"] is True
+    loyalty.saldo.assert_called_once_with(1)
+
+
+def test_untrusted_zero_loyalty_result_does_not_display_zero():
+    loyalty = MagicMock()
+    loyalty.enabled = True
+    loyalty.saldo.return_value = 37
+    rich = _result(loyalty=SaleLoyaltyResult(1, 0, 0.0, 0, 0, None, "", "op-123", False))
+    uc, _sales = _uc_with_sales(rich, loyalty=loyalty)
+    res = uc.ejecutar([ItemCarrito(1, 1, 100, "A")], DatosPago(monto_pagado=100, cliente_id=1), 1, "u")
+    assert res.puntos_totales == 37
+    assert res.loyalty_result["puntos_totales"] == 37
+
+
+def test_ticket_does_not_print_fake_zero_points():
+    from core.ticket_escpos_renderer import TicketESCPOSRenderer
+
+    data = {
+        "folio": "F-1",
+        "items": [],
+        "totales": {"total_final": 10},
+        "pago": {"forma_pago": "Efectivo"},
+        "puntos_ganados": 5,
+        "puntos_totales": 0,
+        "loyalty": {"available": False, "puntos_ganados": 5, "puntos_totales": 0},
+        "layout_config": {"show_logo": False, "show_qr": False},
+    }
+    rendered = TicketESCPOSRenderer().render(data).decode("cp850", errors="ignore")
+    assert "Puntos ganados: +5" in rendered
+    assert "Saldo total: 0 puntos" not in rendered
+
+
+def test_customer_cache_updated_only_with_real_balance_static():
+    body = _source_between(
+        "modulos/ventas.py",
+        "    def _aplicar_resultado_venta",
+        "    def _on_checkout_failed",
+    )
+    update_pos = body.index('self.cliente_actual["puntos"] = puntos_totales')
+    reliable_pos = body.index("if saldo_confiable:")
+    unavailable_pos = body.index('self.lbl_puntos_venta.setText("⭐ Saldo de puntos no disponible")')
+    assert reliable_pos < update_pos < unavailable_pos
+
+
+
+
+def test_loyalty_service_saldo_error_not_fake_zero():
+    from core.services.loyalty_service import LoyaltyService
+
+    svc = LoyaltyService.__new__(LoyaltyService)
+    svc.db = object()
+    with pytest.raises(RuntimeError, match="loyalty_balance_unavailable"):
+        svc.saldo(1)
+
+
+def test_payment_breakdown_preserved_to_ticket_payload():
+    sales = SalesService.__new__(SalesService)
+    sales._normalize_payment_method = lambda value: "Mixto" if value in {"Mixto", "Pago Mixto"} else value
+    lines = sales._build_payment_breakdown("Mixto", 100.0, 0.0, {"efectivo": 40.0, "tarjeta": 60.0})
+    assert lines == {"efectivo": 40.0, "tarjeta": 60.0, "transferencia": 0.0, "credito": 0.0, "mercado_pago": 0.0}
+
+
+def test_pago_mixto_not_mapped_to_cash():
+    sales = SalesService.__new__(SalesService)
+    sales._normalize_payment_method = lambda value: "Mixto"
+    with pytest.raises(ValueError, match="requiere payment_breakdown"):
+        sales._build_payment_breakdown("Mixto", 100.0, 100.0, None)
+
+
+def test_unknown_payment_method_fails():
+    sales = SalesService.__new__(SalesService)
+    sales._normalize_payment_method = lambda value: value
+    with pytest.raises(ValueError, match="desconocido"):
+        sales._build_payment_breakdown("Crypto", 100.0, 100.0, None)
+
+
+def test_credit_sale_payment_payload_has_credit_total_and_cash_zero():
+    sales = SalesService.__new__(SalesService)
+    sales._normalize_payment_method = lambda value: "Crédito"
+    lines = sales._build_payment_breakdown("Crédito", 250.0, 0.0, None)
+    assert lines["credito"] == 250.0
+    assert lines["efectivo"] == 0.0
+
+
+def test_sale_checkout_factory_disabled_or_removed():
+    with pytest.raises(RuntimeError, match="deshabilitado"):
+        SaleCheckoutWorkerFactory(object()).build(object(), [], object(), 1, "u")
+
+
+def test_mp_pending_requires_items_for_reservation():
+    sales = SalesService.__new__(SalesService)
+    sales.db = object()
+    with pytest.raises(ValueError, match="requiere items"):
+        sales.create_pending_payment_sale(1, "u", [], total=1.0)
+
+
+def _source_between(path, start_marker, end_marker):
+    repo_root = Path(__file__).resolve().parents[1]
+    src = (repo_root / path).read_text(encoding="utf-8")
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    return src[start:end]
+
+
+def test_no_ticket_from_compra_actual_after_sale():
+    body = _source_between(
+        "modulos/ventas.py",
+        "    def _aplicar_resultado_venta",
+        "    def _on_checkout_failed",
+    )
+    assert "ticket_payload" in body
+    assert "_imprimir_ticket_consolidado(datos_ticket)" in body
+    assert "compra_actual" not in body
+    assert "self.totales" not in body
+
+
+def test_ui_does_not_cache_ticket_html_without_backend_payload_contract():
+    body = _source_between(
+        "modulos/ventas.py",
+        "    def _aplicar_resultado_venta",
+        "    def _on_checkout_failed",
+    )
+    branch_start = body.index("if (\n            not datos_ticket")
+    missing_payload_branch = body[branch_start:body.index("        else:", branch_start)]
+    assert 'self._ticket_html_cache = ""' in missing_payload_branch
+    assert "_imprimir_ticket_consolidado" not in missing_payload_branch
+    assert "Use reimpresión desde venta_id" in missing_payload_branch
+
+
+def test_sales_service_ticket_payload_contract_has_backend_sale_id_total_and_payment():
+    body = _source_between(
+        "core/services/sales_service.py",
+        "        ticket_payload = dict(datos_venta)",
+        "        if return_details:",
+    )
+    assert 'ticket_payload["venta_id"] = sale_id' in body
+    assert 'ticket_payload["sale_id"] = sale_id' in body
+    assert 'ticket_payload["operation_id"] = operation_id' in body
+    assert 'ticket_payload["folio"] = str(folio)' in body
+    assert 'ticket_payload["items"] = list(carrito_final)' in body
+    assert 'ticket_payload["total_final"] = round(float(total_a_pagar), 2)' in body
+    assert 'ticket_payload["totales"]' in body
+    assert 'ticket_payload["pago"]' in body
+    assert 'ticket_payload["loyalty"]' in body
+
+
+def test_tarjeta_not_modeled_as_cash_or_amount_paid_universal():
+    sales = SalesService.__new__(SalesService)
+    sales._normalize_payment_method = lambda value: "Tarjeta"
+    lines = sales._build_payment_breakdown("Tarjeta", 180.0, 999.0, None)
+    assert lines["tarjeta"] == 180.0
+    assert lines["efectivo"] == 0.0
+    assert sales._amount_paid_for_storage("Tarjeta", lines, 180.0) == 180.0
+
+
+def test_credit_not_amount_paid_real():
+    sales = SalesService.__new__(SalesService)
+    sales._normalize_payment_method = lambda value: "Credito"
+    lines = sales._build_payment_breakdown("Credito", 250.0, 999.0, None)
+    assert lines["credito"] == 250.0
+    assert lines["efectivo"] == 0.0
+    assert sales._amount_paid_for_storage("Credito", lines, 250.0) == 0.0
+
+
+def test_payment_validation_uses_breakdown_not_universal_amount_paid():
+    sales = SalesService.__new__(SalesService)
+    sales._normalize_payment_method = lambda value: value
+    sales.customer_service = None
+    lines = {"efectivo": 0.0, "tarjeta": 100.0, "transferencia": 0.0, "credito": 0.0, "mercado_pago": 0.0}
+    sales._validate_payment("Tarjeta", 100.0, lines)
+    with pytest.raises(ValueError, match="efectivo recibido"):
+        sales._validate_payment("Efectivo", 100.0, {**lines, "tarjeta": 0.0})
+
+
+def test_uc_preserves_payment_breakdown_to_sales_service():
+    payload = {"venta_id": 123, "folio": "F-123", "totales": {"total_final": 100.0}}
+    uc, sales = _uc_with_sales(_result(ticket_payload=payload, ticket_html="<html></html>"))
+    res = uc.ejecutar(
+        [ItemCarrito(1, 1, 100, "A")],
+        DatosPago(
+            forma_pago="Pago Mixto",
+            monto_pagado=0.0,
+            payment_breakdown={"efectivo": 40.0, "tarjeta": 60.0},
+        ),
+        1,
+        "u",
+    )
+    assert res.ok is True
+    assert sales.execute_sale_result.call_args.kwargs["payment_breakdown"] == {"efectivo": 40.0, "tarjeta": 60.0}


### PR DESCRIPTION
### Motivation

- Eliminar comportamientos frágiles/ambiguous en el flujo de venta: evitar reconstruir tickets desde UI, evitar ceros falsos de fidelidad y asegurar que las validaciones críticas no sean silenciosas.
- Soportar Mercado Pago pendiente con reserva de stock y rutas seguras de confirmación/cancelación para evitar pérdida de contexto en webhooks o fallos intermedios.
- Bloquear rutas legacy que escriben ventas fuera del flujo transaccional moderno y prevenir ventas ejecutadas desde hilos con conexiones SQLite compartidas.
- Reemplazar `pass` silenciosos por logs/raises y añadir comprobaciones críticas (handlers de inventario/finanzas/crédito) para evitar ventas sin guardrails.

### Description

- EventBus: ahora lanza `RuntimeError` si `strict=True` y no hay handlers críticos; añadido `handler_labels()` helper y mejor logging en `_dispatch`.
- Payloads / DTOs: `make_sale_payload` incluye `amount_paid` y `payment_breakdown`; dataclasses de resultados de venta (`SalePaymentResult`, `SaleLoyaltyResult`, etc.) ampliadas para representar ausencia de fidelidad de forma segura.
- Payment handling: `PaymentPolicy.build_payment_breakdown` refactorizado para devolver líneas detalladas (`lineas`/`breakdown`) y `amount_paid_real`; `SalesService` añade `_build_payment_breakdown`, `_amount_paid_for_storage`, `_calculate_change` y valida pagos usando el desglose en lugar de un único `amount_paid` ambíguo.
- Mercado Pago pendiente: `SalesService.create_pending_payment_sale` crea intención persistente que reserva stock mediante `StockReservationService.reservar`; añadido `attach_pending_payment_link`, `cancel_pending_payment_sale`, `confirm_pending_payment_sale` y `expire_pending_payment_sales` con manejo de reserva (confirmar/liberar) y limpieza en errores.
- StockReservationService: mejoras de migraciones idempotentes, fallback cuando `branch_inventory` no existe, `confirmar` valida estado (lanza en fallo) y `marcar_revision` para reservas que necesitan revisión.
- Transacción de venta: `SalesService._execute_sale_core` construye payload rico (ticket_payload), exige handlers críticos para `SALE_ITEMS_PROCESS` (bloqueo en producción), confirma reservas antes de imprimir y evita convertir venta exitosa en fallo por confirmaciones tardías; mejoras de logging y eliminación de `pass` silenciosos en validaciones de margen/costo y commits.
- UI / ModuloVentas: `finalizar_venta` ejecuta `ProcesarVentaUC.ejecutar()` en hilo principal (ya no clona servicios a QThread); Mercado Pago pendiente ahora reserva stock, adjunta link y libera reserva ante fallo de persistencia; `_aplicar_resultado_venta` ya no reconstruye ticket desde `compra_actual`, actualiza cache de puntos solo con saldo confiable y marca reservas en revisión si corresponde; muchos `pass` cambiados por logs/alerts.
- Workers / Factory: `SaleCheckoutWorker` y `SaleCheckoutWorkerFactory` bloqueados/deshabilitados para evitar ejecuciones transaccionales en hilos con conexiones SQLite compartidas; el worker todavía informa via señales para UI pero falla rápido con mensaje claro.
- Printer / Ticket: `PrinterService` y `PrintQueue` dejan de silenciar errores en commits/loads; `TicketESCPOSRenderer` y `TicketPrintModel` evitan imprimir o exponer saldos de fidelidad inexistentes (no mostrar 0 si no se confirmó saldo real).
- Loyalty service: `LoyaltyService.saldo` ahora registra y lanza `RuntimeError` cuando el saldo no está disponible (evita ceros falsos) y se adapta el flujo para pedir saldo sólo cuando sea necesario.
- Legacy / safety flags: rutas legacy para procesar/escribir ventas (`SalesService.procesar_venta`, `UnifiedSalesService.procesar_venta`, `_procesar_venta_legacy_minimal`, `VentaRepository.create_sale`) están bloqueadas por defecto y se habilitan solo mediante variables de entorno explícitas documentadas para pruebas legacy.

### Testing

- Ejecutadas y añadidas múltiples pruebas unitarias de integración y comportamiento sobre ventas, pago y reservas, incluyendo: `tests/test_fase1_procesar_venta_uc_rich_mapping.py`, `tests/test_fase4_payment_mapping.py`, `tests/test_fase5_stock_reservations.py`, `tests/test_fase7_critical_handlers.py`, `tests/test_fase7_mp_pending_context_recovery_e2e.py`, `tests/test_phase5_payment_policy.py`, `tests/test_mercado_pago_pending_flow.py`, `tests/test_mercado_pago_webhook_confirmation.py`, `tests/test_ticket_pipeline_integration.py` y la batería de tests nuevos en `tests/test_ventas_cleanup_regression.py`.
- Los tests enfocan: preservación de `payment_breakdown` hasta el ticket, comportamiento de MP pending + reservas (crear/confirmar/cancelar/expire), bloqueo de rutas legacy y bloqueo del worker/worker-factory para ventas, y que no se impriman ceros falsos de fidelidad; la suite automatizada de unidades y tests de integración relevantes pasó correctamente en el entorno de ejecución local.
- Se verificó también que no quedan `pass` silenciosos en validaciones críticas y que los nuevos logs/raises aparecen en los puntos esperados a través de los tests mencionados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186686fd3c832896d5e4596de23e63)