### PR TITLE
Add raffle ticket issuance/printing, ticket layout management and robustness improvements

### DIFF
--- a/pos_spj_v13.4/core/services/loyalty_service.py
+++ b/pos_spj_v13.4/core/services/loyalty_service.py
@@ -839,11 +839,18 @@ class LoyaltyService:
         folio_venta: str,
         monto_base: float,
         sucursal_id: int,
+        ticket_count: int | None = None,
     ) -> list[str]:
         raffle = self._app.repo.get_raffle_by_id(raffle_id)
         self.validate_ticket_generation(raffle, {"venta_id": venta_id})
         tickets = self._app.repo.generate_tickets_for_sale(
-            raffle_id, venta_id, cliente_id, folio_venta, monto_base, sucursal_id
+            raffle_id,
+            venta_id,
+            cliente_id,
+            folio_venta,
+            monto_base,
+            sucursal_id,
+            ticket_count=ticket_count,
         )
         if tickets and self._bus:
             for ticket in tickets:
@@ -859,6 +866,45 @@ class LoyaltyService:
                     async_=True,
                 )
         return tickets
+
+    def _normalize_raffle_payment_method(self, payment_method: Any) -> str:
+        try:
+            from core.services.payment_normalization import normalize_payment_method
+            return str(normalize_payment_method(str(payment_method or "")) or "").strip().lower()
+        except Exception:
+            return str(payment_method or "").strip().lower()
+
+    def _table_columns(self, table: str) -> set[str]:
+        try:
+            return {str(r[1] if isinstance(r, tuple) else r["name"]) for r in self.db.execute(f"PRAGMA table_info({table})").fetchall()}
+        except Exception:
+            return set()
+
+    def _eligible_ids(self, table: str, column: str, raffle_id: int) -> set[int]:
+        if column not in self._table_columns(table):
+            return set()
+        try:
+            rows = self.db.execute(f"SELECT {column} FROM {table} WHERE raffle_id=?", (int(raffle_id),)).fetchall()
+            return {int((r[0] if isinstance(r, tuple) else r[column]) or 0) for r in rows}
+        except Exception as exc:
+            logger.debug("No se pudieron leer elegibles de rifa tabla=%s columna=%s: %s", table, column, exc)
+            return set()
+
+    @staticmethod
+    def _sale_has_discount(sale_context: Dict[str, Any]) -> bool:
+        for key in ("discount", "descuento", "descuento_total", "loyalty_discount"):
+            try:
+                if float(sale_context.get(key) or 0) > 0:
+                    return True
+            except Exception:
+                pass
+        for it in sale_context.get("items") or []:
+            try:
+                if float(it.get("descuento") or it.get("discount") or it.get("descuento_pct") or 0) > 0:
+                    return True
+            except Exception:
+                continue
+        return False
 
     def evaluate_raffle_sale_eligibility(self, raffle_id: int, sale_context: Dict[str, Any]) -> Dict[str, Any]:
         raffle = self._app.repo.get_raffle_by_id(raffle_id)
@@ -876,10 +922,21 @@ class LoyaltyService:
             return {"eligible": False, "reason": "registered_required"}
         if float(sale_context.get("total") or 0) < float(rules.get("min_sale_amount") or 0):
             return {"eligible": False, "reason": "min_sale"}
-        if int(sale_context.get("sucursal_id") or 0) != int(raffle.get("sucursal_id") or 0):
+        if int(rules.get("include_discounted_sales") if rules.get("include_discounted_sales") is not None else 1) == 0 and self._sale_has_discount(sale_context):
+            return {"eligible": False, "reason": "discounted_sale_not_allowed"}
+
+        sale_branch_id = int(sale_context.get("sucursal_id") or 0)
+        eligible_branches = self._eligible_ids("raffle_eligible_branches", "sucursal_id", raffle_id)
+        raffle_branch_id = int(raffle.get("sucursal_id") or 0)
+        if eligible_branches:
+            if sale_branch_id not in eligible_branches:
+                return {"eligible": False, "reason": "branch_not_allowed"}
+        elif raffle_branch_id and sale_branch_id != raffle_branch_id:
             return {"eligible": False, "reason": "branch_not_allowed"}
+
         allowed_payments = _csv_tokens(rules.get("allowed_payment_methods"))
-        if allowed_payments and str(sale_context.get("payment_method") or "").strip().lower() not in allowed_payments:
+        payment = self._normalize_raffle_payment_method(sale_context.get("payment_method"))
+        if allowed_payments and payment not in {self._normalize_raffle_payment_method(p) for p in allowed_payments}:
             return {"eligible": False, "reason": "payment_not_allowed"}
         allowed_weekdays = _csv_tokens(rules.get("allowed_weekdays"))
         if allowed_weekdays and str(dt_obj.weekday()) not in allowed_weekdays and dt_obj.strftime("%A").lower() not in allowed_weekdays:
@@ -892,14 +949,12 @@ class LoyaltyService:
                 return {"eligible": False, "reason": "time_not_allowed"}
         items = sale_context.get("items") or []
         if items:
-            r = self.db.execute("SELECT product_id FROM raffle_eligible_products WHERE raffle_id=?", (int(raffle_id),)).fetchall()
-            allowed_products = {int((x[0] if isinstance(x, tuple) else x["product_id"]) or 0) for x in r}
-            r = self.db.execute("SELECT category_id FROM raffle_eligible_categories WHERE raffle_id=?", (int(raffle_id),)).fetchall()
-            allowed_categories = {int((x[0] if isinstance(x, tuple) else x["category_id"]) or 0) for x in r}
+            allowed_products = self._eligible_ids("raffle_eligible_products", "product_id", raffle_id)
+            allowed_categories = self._eligible_ids("raffle_eligible_categories", "category_id", raffle_id)
             if allowed_products or allowed_categories:
                 ok_item = False
                 for it in items:
-                    pid = int((it.get("product_id") or it.get("id") or 0) or 0)
+                    pid = int((it.get("product_id") or it.get("producto_id") or it.get("id") or 0) or 0)
                     cid = int((it.get("category_id") or it.get("categoria_id") or 0) or 0)
                     if (allowed_products and pid in allowed_products) or (allowed_categories and cid in allowed_categories):
                         ok_item = True
@@ -928,32 +983,126 @@ class LoyaltyService:
             raise ValueError("No activar rifa sin fecha válida, premio, presupuesto y reglas")
         self.validate_raffle_activation(raffle)
 
-    def process_raffles_for_sale(self, venta_id: int, cliente_id: int, folio: str, total: float, sucursal_id: int, payment_method=None, items=None, sale_datetime=None) -> list[dict]:
-        tickets_snapshot: list[dict] = []
+    def process_raffles_for_sale(self, venta_id: int, cliente_id: int, folio: str, total: float, sucursal_id: int, payment_method=None, items=None, sale_datetime=None, discount=0) -> list[dict]:
+        issued = self.issue_raffle_tickets_for_sale(
+            venta_id=int(venta_id),
+            folio_venta=str(folio or ""),
+            cliente_id=int(cliente_id or 0),
+            cliente_nombre="",
+            total=float(total or 0),
+            sucursal_id=int(sucursal_id or self.sucursal_id),
+            sale_datetime=sale_datetime,
+            payment_method=str(payment_method or ""),
+            items=items or [],
+            discount=discount,
+        )
+        return [
+            {
+                "raffle": str(t.get("raffle_name") or f"Rifa {t.get('raffle_id') or ''}"),
+                "numero_boleto": str(t.get("numero_boleto") or ""),
+                "raffle_ticket": t,
+            }
+            for t in issued
+        ]
+
+    def _raffle_print_payload(self, raffle: Dict[str, Any], ticket: Dict[str, Any], *, cliente_nombre: str = "", folio_venta: str = "", venta_id: int = 0, sucursal_id: int = 0) -> Dict[str, Any]:
+        prizes = []
+        try:
+            prizes = self._app.repo.list_raffle_prizes(int(raffle.get("id") or ticket.get("raffle_id") or 0))
+        except Exception:
+            prizes = []
+        premio = str(raffle.get("premio") or "")
+        if not premio and prizes:
+            premio = str(prizes[0].get("nombre") or prizes[0].get("descripcion") or "")
+        numero = str(ticket.get("numero_boleto") or "")
+        qr_content = f"RAFFLE:{ticket.get('raffle_id')}|SALE:{ticket.get('venta_id') or venta_id}|TICKET:{numero}"
+        return {
+            "ticket_type": "raffle_ticket",
+            "raffle_id": int(ticket.get("raffle_id") or raffle.get("id") or 0),
+            "raffle_name": str(raffle.get("nombre") or f"Rifa {ticket.get('raffle_id') or ''}"),
+            "premio": premio,
+            "numero_boleto": numero,
+            "cliente_id": int(ticket.get("cliente_id") or 0),
+            "cliente": str(cliente_nombre or ticket.get("cliente") or ""),
+            "folio_venta": str(ticket.get("folio_venta") or folio_venta or ""),
+            "venta_id": int(ticket.get("venta_id") or venta_id or 0),
+            "fecha_sorteo": str(raffle.get("fecha_sorteo") or raffle.get("fecha_fin") or ""),
+            "fecha_fin": str(raffle.get("fecha_fin") or ""),
+            "sucursal_id": int(sucursal_id or raffle.get("sucursal_id") or self.sucursal_id),
+            "qr_content": qr_content,
+            "barcode": numero,
+        }
+
+    def issue_raffle_tickets_for_sale(
+        self,
+        *,
+        venta_id,
+        folio_venta,
+        cliente_id,
+        cliente_nombre="",
+        total,
+        sucursal_id,
+        usuario="",
+        sale_datetime=None,
+        payment_method="",
+        items=None,
+        discount=0,
+    ) -> list[dict]:
         dt = str(sale_datetime or datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-        for raffle in (self._app.repo.get_active_raffles_for_sale(int(sucursal_id), dt) or []):
+        printable: list[dict] = []
+        try:
+            active = self._app.repo.get_active_raffles_for_sale(int(sucursal_id or self.sucursal_id), dt) or []
+        except Exception as exc:
+            logger.warning("No se pudieron consultar rifas activas venta=%s: %s", venta_id, exc)
+            return []
+        for raffle in active:
             rid = int(raffle.get("id") or 0)
-            eval_result = self.evaluate_raffle_sale_eligibility(rid, {"venta_id": venta_id, "cliente_id": cliente_id, "total": total, "sucursal_id": sucursal_id, "payment_method": payment_method, "items": items or [], "sale_datetime": dt})
-            if not eval_result.get("eligible"):
+            if rid <= 0:
                 continue
-            rules = eval_result.get("rules") or {}
-            max_customer = int(rules.get("max_tickets_per_customer") or 0)
-            current = self._app.repo.count_customer_tickets(rid, int(cliente_id or 0)) if cliente_id else 0
-            count = self.calculate_raffle_tickets_count(raffle, rules, {"total": total})
-            if max_customer > 0:
-                count = max(0, min(count, max_customer - current))
-            if count <= 0:
-                continue
-            existing_sale_tickets = [
-                t for t in self._app.repo.list_raffle_tickets(rid, limit=500)
-                if int(t.get("venta_id") or 0) == int(venta_id)
-            ]
-            if existing_sale_tickets:
-                continue
-            tickets = self.generate_tickets_for_sale(rid, int(venta_id), int(cliente_id or 0), str(folio or ""), float(total or 0), int(sucursal_id or self.sucursal_id))[:count]
-            for t in tickets:
-                tickets_snapshot.append({"raffle": str(raffle.get("nombre") or f"Rifa {rid}"), "numero_boleto": t})
-        return tickets_snapshot
+            try:
+                sale_context = {
+                    "venta_id": venta_id,
+                    "cliente_id": cliente_id,
+                    "total": total,
+                    "sucursal_id": sucursal_id,
+                    "payment_method": payment_method,
+                    "items": items or [],
+                    "sale_datetime": dt,
+                    "discount": discount,
+                }
+                eval_result = self.evaluate_raffle_sale_eligibility(rid, sale_context)
+                if not eval_result.get("eligible"):
+                    continue
+                rules = eval_result.get("rules") or {}
+                existing = self._app.repo.get_tickets_for_sale(rid, int(venta_id))
+                if existing:
+                    printable.extend([self._raffle_print_payload(raffle, t, cliente_nombre=cliente_nombre, folio_venta=folio_venta, venta_id=int(venta_id), sucursal_id=int(sucursal_id or self.sucursal_id)) for t in existing])
+                    continue
+                count = self.calculate_raffle_tickets_count(raffle, rules, sale_context)
+                max_customer = int(rules.get("max_tickets_per_customer") or 0)
+                current = self._app.repo.count_customer_tickets(rid, int(cliente_id or 0)) if cliente_id else 0
+                if max_customer > 0:
+                    count = max(0, min(count, max_customer - current))
+                if count <= 0:
+                    continue
+                created_numbers = self.generate_tickets_for_sale(
+                    rid,
+                    int(venta_id),
+                    int(cliente_id or 0),
+                    str(folio_venta or ""),
+                    float(total or 0),
+                    int(sucursal_id or self.sucursal_id),
+                    ticket_count=count,
+                )
+                created_number_set = set(created_numbers)
+                created = [
+                    t for t in self._app.repo.get_tickets_for_sale(rid, int(venta_id))
+                    if str(t.get("numero_boleto") or "") in created_number_set
+                ]
+                printable.extend([self._raffle_print_payload(raffle, t, cliente_nombre=cliente_nombre, folio_venta=folio_venta, venta_id=int(venta_id), sucursal_id=int(sucursal_id or self.sucursal_id)) for t in created])
+            except Exception as exc:
+                logger.warning("Emisión de boletos rifa=%s venta=%s falló: %s", rid, venta_id, exc)
+        return printable
 
     def cancel_tickets_for_sale(self, venta_id: int, reason: str) -> int:
         cancelled = int(self._app.repo.cancel_tickets_for_sale(venta_id, reason) or 0)

--- a/pos_spj_v13.4/core/services/printer_service.py
+++ b/pos_spj_v13.4/core/services/printer_service.py
@@ -24,6 +24,7 @@ logger = logging.getLogger("spj.printer")
 
 class PrintJobType(str, Enum):
     TICKET = "ticket"
+    RAFFLE_TICKET = "raffle_ticket"
     LABEL = "label"
     HTML = "html"
     RAW = "raw"
@@ -494,15 +495,15 @@ class PrinterService:
             logger.warning("No se pudo cargar branding de ticket: %s", exc)
             return None
 
-    def _get_layout(self):
+    def _get_layout(self, layout_type: str = "sale_ticket"):
         try:
             from core.tickets.ticket_layout_repository import TicketLayoutRepository
-            return TicketLayoutRepository(db_conn=self.db).load()
+            return TicketLayoutRepository(db_conn=self.db).load(layout_type=layout_type)
         except Exception as exc:
             logger.warning("No se pudo cargar Ticket Design activo; se usará layout default: %s", exc)
             try:
                 from core.tickets.ticket_layout_config import TicketLayoutConfig
-                return TicketLayoutConfig()
+                return TicketLayoutConfig.for_layout_type(layout_type)
             except Exception:
                 return None
 
@@ -520,27 +521,105 @@ class PrinterService:
                 continue
         return default
 
+    def _table_columns(self, table: str) -> set[str]:
+        if not self.db:
+            return set()
+        try:
+            return {str(r[1]) for r in self.db.execute(f"PRAGMA table_info({table})").fetchall()}
+        except Exception:
+            return set()
+
+    @staticmethod
+    def _normalize_ticket_unit(value: Any) -> str:
+        return str(value or "").strip()
+
+    @staticmethod
+    def _is_generic_ticket_unit(value: Any) -> bool:
+        normalized = PrinterService._normalize_ticket_unit(value).lower().rstrip(". ")
+        generic_units = {"", "pz", "pza", "pzas", "pieza", "piezas", "unidad", "unidades"}
+        return normalized in generic_units
+
+    def _ticket_item_product_id(self, item: Dict[str, Any]) -> int:
+        for key in ("product_id", "producto_id", "id_producto"):
+            raw = item.get(key)
+            if raw not in (None, ""):
+                try:
+                    return int(raw)
+                except Exception:
+                    return 0
+        # En payloads de UI antiguos ``id`` es el producto; en payloads de
+        # detalle de venta suele ser el id de línea y viene acompañado de
+        # venta_id/sale_id. No debe usarse como producto en ese caso.
+        if any(item.get(key) not in (None, "") for key in ("venta_id", "sale_id", "detalle_id", "line_id")):
+            return 0
+        raw = item.get("id")
+        if raw not in (None, ""):
+            try:
+                return int(raw)
+            except Exception:
+                return 0
+        return 0
+
+    def _ticket_product_select_columns(self, product_columns: set[str]) -> list[str]:
+        select_cols = ["id"]
+        for col in ("nombre", "descripcion", "producto", "unidad", "codigo_barras", "codigo"):
+            if col in product_columns and col not in select_cols:
+                select_cols.append(col)
+        return select_cols
+
+    def _fetch_ticket_product_row(self, item: Dict[str, Any], product_columns: set[str]):
+        if not (self.db and product_columns):
+            return None, 0
+        select_cols = self._ticket_product_select_columns(product_columns)
+        pid = self._ticket_item_product_id(item)
+        if pid:
+            try:
+                row = self.db.execute(
+                    f"SELECT {', '.join(select_cols)} FROM productos WHERE id=? LIMIT 1",
+                    (pid,),
+                ).fetchone()
+                if row:
+                    return row, pid
+            except Exception as exc:
+                logger.debug("No se pudo hidratar producto para ticket pid=%s: %s", pid, exc)
+        for item_key, product_col in (("codigo_barras", "codigo_barras"), ("barcode", "codigo_barras"), ("codigo", "codigo")):
+            code = str(item.get(item_key) or "").strip()
+            if not code or product_col not in product_columns:
+                continue
+            try:
+                row = self.db.execute(
+                    f"SELECT {', '.join(select_cols)} FROM productos WHERE {product_col}=? LIMIT 1",
+                    (code,),
+                ).fetchone()
+                if row:
+                    try:
+                        return row, int(self._row_value(row, "id", default=pid) or 0)
+                    except Exception:
+                        return row, pid
+            except Exception as exc:
+                logger.debug("No se pudo hidratar producto para ticket %s=%s: %s", product_col, code, exc)
+        return None, pid
+
     def _hydrate_ticket_items(self, items: list) -> list:
         hydrated = []
+        product_columns = self._table_columns("productos")
+        can_read_unidad = "unidad" in product_columns
         for item in list(items or []):
             it = dict(item or {})
-            pid = it.get("product_id") or it.get("producto_id") or it.get("id")
-            row = None
-            if self.db and pid:
-                try:
-                    row = self.db.execute("SELECT * FROM productos WHERE id=? LIMIT 1", (int(pid),)).fetchone()
-                except Exception as exc:
-                    logger.debug("No se pudo hidratar producto para ticket pid=%s: %s", pid, exc)
+            row, pid = self._fetch_ticket_product_row(it, product_columns)
             nombre = (
                 it.get("nombre") or it.get("name") or it.get("product_name") or
-                self._row_value(row, "nombre", "name", "descripcion", "producto", default="") or
+                self._row_value(row, "nombre", "descripcion", "producto", default="") or
                 (f"Producto {pid}" if pid else "Producto")
             )
-            unidad = (
-                it.get("unidad") or it.get("unit") or it.get("unidad_medida") or it.get("uom") or
-                self._row_value(row, "unidad", "unit", "unidad_medida", "unidad_venta", "uom", default="") or
-                "pz"
+            payload_unidad = self._normalize_ticket_unit(
+                it.get("unidad") or it.get("unit") or it.get("unidad_medida") or it.get("uom") or ""
             )
+            db_unidad = str(self._row_value(row, "unidad", default="") or "").strip() if can_read_unidad else ""
+            if db_unidad and self._is_generic_ticket_unit(payload_unidad):
+                unidad = db_unidad
+            else:
+                unidad = payload_unidad or db_unidad or "pz"
             cantidad = it.get("cantidad", it.get("qty", it.get("quantity", 0)))
             precio = it.get("precio_unitario", it.get("unit_price", 0))
             total = it.get("total", it.get("subtotal", None))
@@ -549,13 +628,20 @@ class PrinterService:
                     total = float(cantidad or 0) * float(precio or 0)
                 except Exception:
                     total = 0
+            try:
+                normalized_pid = int(pid or 0)
+            except Exception:
+                normalized_pid = 0
             it.update({
-                "product_id": int(pid or 0),
-                "producto_id": int(pid or 0),
+                "product_id": normalized_pid,
+                "producto_id": normalized_pid,
                 "nombre": str(nombre),
                 "name": str(nombre),
                 "unidad": str(unidad),
                 "unit": str(unidad),
+                "db_unidad": db_unidad,
+                "unidad_db": db_unidad,
+                "unidad_producto": db_unidad,
                 "cantidad": float(cantidad or 0),
                 "qty": float(cantidad or 0),
                 "precio_unitario": float(precio or 0),
@@ -599,9 +685,12 @@ class PrinterService:
             data.setdefault("empresa", self._get_cfg("nombre_empresa", "SPJ POS"))
             data.setdefault("direccion", self._get_cfg("direccion", ""))
             data.setdefault("telefono", self._get_cfg("telefono_empresa", ""))
-        layout = self._get_layout()
-        if layout is not None and not data.get("layout_config"):
+        layout = self._get_layout("sale_ticket")
+        if layout is not None:
             data["layout_config"] = layout.to_dict()
+            debug_logo = self._get_cfg("ticket_debug_logo", "")
+            if str(debug_logo).strip() == "1":
+                data["layout_config"]["ticket_debug_logo"] = True
         return data, branding, layout
 
     def print_ticket(self, ticket_data: Dict[str, Any], on_success: Callable = None, on_error: Callable = None) -> str:
@@ -649,6 +738,69 @@ class PrinterService:
             transport=self._resolve_transport(self._ticket_cfg),
             baud=self._safe_baud(self._ticket_cfg.get("baud_rate", 9600)),
             priority=2,
+            on_success=on_success,
+            on_error=on_error,
+        )
+        self.queue.submit(job)
+        return job.id
+
+    def print_raffle_ticket(self, raffle_ticket_data: Dict[str, Any], on_success: Callable = None, on_error: Callable = None) -> str:
+        if not self.enabled:
+            logger.debug("Impresión de boleto de sorteo deshabilitada (toggle printing)")
+            return ""
+        vr = self.validate_ticket_printer_config()
+        if not vr.ok:
+            msg = "; ".join(vr.errors or ["Configuración inválida de impresora"])
+            logger.warning("print_raffle_ticket bloqueado por config inválida: %s", msg)
+            if on_error:
+                try:
+                    on_error(Exception(msg))
+                except Exception:
+                    logger.exception("print_raffle_ticket on_error callback failed")
+            return ""
+        try:
+            from core.tickets.raffle_ticket_renderer import RaffleTicketESCPOSRenderer
+            prepared = dict(raffle_ticket_data or {})
+            prepared["ticket_type"] = "raffle_ticket"
+            branding = self._get_branding()
+            if branding:
+                prepared.setdefault("empresa", branding.brand_name)
+                prepared.setdefault("direccion", branding.address)
+                prepared.setdefault("telefono", branding.phone)
+            else:
+                prepared.setdefault("empresa", self._get_cfg("nombre_empresa", "SPJ POS"))
+                prepared.setdefault("direccion", self._get_cfg("direccion", ""))
+                prepared.setdefault("telefono", self._get_cfg("telefono_empresa", ""))
+            layout = self._get_layout("raffle_ticket")
+            prepared["layout_config"] = layout.to_dict() if layout else prepared.get("layout_config", {})
+            debug_logo = self._get_cfg("ticket_debug_logo", "")
+            if str(debug_logo).strip() == "1":
+                prepared["layout_config"]["ticket_debug_logo"] = True
+            paper_w = int(getattr(layout, "paper_width_mm", 0) or self._ticket_cfg.get("paper_width", 80))
+            renderer = RaffleTicketESCPOSRenderer(paper_width_mm=paper_w, encoding=str(self._ticket_cfg.get("encoding", "cp850")))
+            logo_b64 = ""
+            if branding and self._ticket_cfg.get("print_logo", True) and getattr(layout, "show_logo", True):
+                logo_b64 = branding.logo_b64 or ""
+            qr_content = prepared.get("qr_content") or prepared.get("numero_boleto") or prepared.get("barcode") or ""
+            prepared.setdefault("qr_content", str(qr_content or ""))
+            prepared.setdefault("barcode", str(prepared.get("numero_boleto") or qr_content or ""))
+            data = renderer.render(prepared, logo_b64=logo_b64, qr_content=str(qr_content or ""))
+        except Exception as exc:
+            logger.error("Error formateando boleto de sorteo: %s", exc)
+            if on_error:
+                try:
+                    on_error(exc)
+                except Exception:
+                    logger.exception("print_raffle_ticket on_error callback failed (renderer)")
+            return ""
+        job = PrintJob(
+            job_type=PrintJobType.RAFFLE_TICKET,
+            data=data,
+            raw_data=prepared,
+            destination=self._ticket_cfg.get("ubicacion", ""),
+            transport=self._resolve_transport(self._ticket_cfg),
+            baud=self._safe_baud(self._ticket_cfg.get("baud_rate", 9600)),
+            priority=3,
             on_success=on_success,
             on_error=on_error,
         )

--- a/pos_spj_v13.4/core/services/sales_fulfillment_service.py
+++ b/pos_spj_v13.4/core/services/sales_fulfillment_service.py
@@ -36,26 +36,28 @@ class SaleFulfillmentService:
         self.resolver = RecipeResolver(self.db)
         self.avail = AvailabilityService(self.db)
 
-    def _product_row(self, product_id: int):
-        """Read only product columns guaranteed by the current schema.
+    def _table_columns(self, table: str) -> set[str]:
+        try:
+            return {str(r[1]) for r in self.db.execute(f"PRAGMA table_info({table})").fetchall()}
+        except Exception:
+            return set()
 
-        Do not reference optional columns such as unidad_medida/unidad_venta in
-        SQL. SQLite raises `no such column` even inside COALESCE when a column is
-        absent, which would block checkout before the real stock validation.
+    def _product_row(self, product_id: int):
+        """Read only product columns that exist in the current schema.
+
+        Never reference optional columns inside COALESCE: SQLite raises
+        `no such column` before COALESCE can apply. Missing flags are added as
+        literal defaults in the SELECT list, which is safe and idempotent.
         """
+        cols = self._table_columns("productos")
+        select_parts = ["id"]
+        select_parts.append("nombre" if "nombre" in cols else "'' AS nombre")
+        select_parts.append("unidad" if "unidad" in cols else "'kg' AS unidad")
+        select_parts.append("tipo_producto" if "tipo_producto" in cols else "'simple' AS tipo_producto")
+        select_parts.append("COALESCE(es_compuesto,0) AS es_compuesto" if "es_compuesto" in cols else "0 AS es_compuesto")
+        select_parts.append("COALESCE(es_subproducto,0) AS es_subproducto" if "es_subproducto" in cols else "0 AS es_subproducto")
         return self.db.execute(
-            """
-            SELECT
-                id,
-                nombre,
-                unidad,
-                tipo_producto,
-                COALESCE(es_compuesto,0) AS es_compuesto,
-                COALESCE(es_subproducto,0) AS es_subproducto
-            FROM productos
-            WHERE id=?
-            LIMIT 1
-            """,
+            f"SELECT {', '.join(select_parts)} FROM productos WHERE id=? LIMIT 1",
             (int(product_id),),
         ).fetchone()
 
@@ -145,15 +147,57 @@ class SaleFulfillmentService:
         missing = max(0.0, qty - physical)
         raise ValueError(f"STOCK_INSUFICIENTE: producto={name} faltante={missing:.3f} {unit}")
 
+    def _active_recipe_id(self, product_id: int) -> int | None:
+        recipe_cols = self._table_columns("product_recipes")
+        if not recipe_cols or "id" not in recipe_cols:
+            return None
+        product_col = "product_id" if "product_id" in recipe_cols else "base_product_id" if "base_product_id" in recipe_cols else ""
+        if not product_col:
+            return None
+        where = f"{product_col}=?"
+        if "is_active" in recipe_cols:
+            where += " AND is_active=1"
+        row = self.db.execute(f"SELECT id FROM product_recipes WHERE {where} LIMIT 1", (int(product_id),)).fetchone()
+        if not row:
+            return None
+        try:
+            return int(row["id"] if hasattr(row, "keys") else row[0])
+        except Exception:
+            return None
+
+    def _recipe_components(self, recipe_id: int) -> list[tuple[int, float]]:
+        comp_cols = self._table_columns("product_recipe_components")
+        if not comp_cols:
+            return []
+        product_col = next((c for c in ("component_product_id", "producto_id", "componente_id", "product_id") if c in comp_cols), "")
+        qty_col = next((c for c in ("cantidad", "qty", "quantity") if c in comp_cols), "")
+        recipe_col = "recipe_id" if "recipe_id" in comp_cols else "receta_id" if "receta_id" in comp_cols else ""
+        if not product_col or not qty_col or not recipe_col:
+            return []
+        rows = self.db.execute(
+            f"SELECT {product_col} AS component_product_id, {qty_col} AS cantidad FROM product_recipe_components WHERE {recipe_col}=?",
+            (int(recipe_id),),
+        ).fetchall()
+        comps: list[tuple[int, float]] = []
+        for row in rows:
+            try:
+                pid = int(row["component_product_id"] if hasattr(row, "keys") else row[0])
+                qty = float(row["cantidad"] if hasattr(row, "keys") else row[1] or 0)
+            except Exception:
+                continue
+            if pid > 0 and qty > 0:
+                comps.append((pid, qty))
+        return comps
+
     def _virtual_from_recipe_deductions(self, product_id: int, qty: float, branch_id: int) -> Dict[int, float]:
-        rec = self.db.execute("SELECT id FROM product_recipes WHERE product_id=? AND is_active=1 LIMIT 1", (product_id,)).fetchone()
-        if not rec:
+        recipe_id = self._active_recipe_id(product_id)
+        if not recipe_id:
             return {}
-        comps = self.db.execute("SELECT component_product_id, COALESCE(cantidad,0) cantidad FROM product_recipe_components WHERE recipe_id=?", (rec[0],)).fetchall()
+        comps = self._recipe_components(recipe_id)
         merged: Dict[int, float] = {}
-        for c in comps:
-            need = float(c["cantidad"] if hasattr(c, "keys") else c[1]) * qty
-            exp = self.resolver.resolve_for_sale(int(c[0]), need, branch_id)
+        for component_pid, component_qty in comps:
+            need = float(component_qty or 0) * qty
+            exp = self.resolver.resolve_for_sale(int(component_pid), need, branch_id)
             if exp.cycle_detected:
                 raise ValueError(f"RECETA_CICLICA: producto={product_id}")
             for d in exp.deductions:
@@ -161,17 +205,17 @@ class SaleFulfillmentService:
         return merged
 
     def _virtual_from_recipe_availability(self, product_id: int, branch_id: int) -> float:
-        rec = self.db.execute("SELECT id FROM product_recipes WHERE product_id=? AND is_active=1 LIMIT 1", (product_id,)).fetchone()
-        if not rec:
+        recipe_id = self._active_recipe_id(product_id)
+        if not recipe_id:
             return 0.0
-        comps = self.db.execute("SELECT component_product_id, COALESCE(cantidad,0) cantidad FROM product_recipe_components WHERE recipe_id=?", (rec[0],)).fetchall()
+        comps = self._recipe_components(recipe_id)
         if not comps:
             return 0.0
         mins = []
-        for c in comps:
-            qty = float(c["cantidad"] if hasattr(c, "keys") else c[1])
+        for component_pid, component_qty in comps:
+            qty = float(component_qty or 0)
             if qty <= 0:
                 continue
-            avail = self.avail.virtual_stock(int(c[0]), branch_id)
+            avail = self.avail.virtual_stock(int(component_pid), branch_id)
             mins.append(avail / qty if qty > 0 else 0.0)
         return min(mins) if mins else 0.0

--- a/pos_spj_v13.4/core/services/sales_service.py
+++ b/pos_spj_v13.4/core/services/sales_service.py
@@ -34,7 +34,7 @@ class SalesService:
                  ticket_template_engine, whatsapp_service, config_service,
                  feature_flag_service, pricing_service=None,
                  growth_engine=None, notification_service=None,
-                 customer_service=None):
+                 customer_service=None, printer_service=None):
         # Inyección de dependencias
         self.db = db_conn
         self.pricing_service = pricing_service
@@ -61,6 +61,7 @@ class SalesService:
         self.config_service = config_service
         self.feature_flag_service = feature_flag_service
         self.customer_service = customer_service
+        self.printer_service = printer_service
         self._fulfillment = SaleFulfillmentService(db_conn)
         self._sale_loyalty_policy = None
 
@@ -467,6 +468,76 @@ class SalesService:
                 + f". Registrados: {registered}"
             )
 
+
+    def _raffle_auto_print_enabled(self) -> bool:
+        """Return whether confirmed-sale raffle tickets should be printed automatically."""
+        if not self.config_service:
+            return True
+        disabled_values = {"0", "false", "no", "off", "disabled", "desactivado"}
+        try:
+            raw = self.config_service.get("raffle_ticket_print_auto", None)
+            if raw in (None, ""):
+                raw = self.config_service.get("imprimir_automatico_boletos_sorteo", "1")
+        except Exception as exc:
+            logger.warning("No se pudo leer configuración de impresión automática de rifas: %s", exc)
+            return True
+        return str(raw).strip().lower() not in disabled_values
+
+    def _raffle_ticket_print_payload(self, snapshot):
+        """Normalize raffle snapshots or direct printable payloads into PrinterService input."""
+        if not isinstance(snapshot, dict):
+            return None
+        nested = snapshot.get("raffle_ticket")
+        if isinstance(nested, dict):
+            return nested
+        if str(snapshot.get("ticket_type") or "") == "raffle_ticket":
+            return snapshot
+        has_raffle_identity = (
+            snapshot.get("raffle_id") or snapshot.get("raffle_name") or snapshot.get("raffle")
+        )
+        if snapshot.get("numero_boleto") and has_raffle_identity:
+            payload = dict(snapshot)
+            payload.setdefault("ticket_type", "raffle_ticket")
+            payload.setdefault("raffle_name", payload.get("raffle") or "")
+            payload.setdefault("barcode", payload.get("numero_boleto"))
+            payload.setdefault(
+                "qr_content",
+                "RAFFLE:{raffle_id}|SALE:{venta_id}|TICKET:{numero}".format(
+                    raffle_id=payload.get("raffle_id", ""),
+                    venta_id=payload.get("venta_id", ""),
+                    numero=payload.get("numero_boleto", ""),
+                ),
+            )
+            return payload
+        return None
+
+    def _print_raffle_tickets_after_sale(self, raffle_tickets_snapshot, sale_id) -> list[str]:
+        """Print issued raffle tickets after the sale is confirmed without cancelling the sale."""
+        printed_job_ids: list[str] = []
+        if not raffle_tickets_snapshot or not self._raffle_auto_print_enabled():
+            return printed_job_ids
+        printer = getattr(self, "printer_service", None)
+        if not printer or not hasattr(printer, "print_raffle_ticket"):
+            return printed_job_ids
+        for snapshot in raffle_tickets_snapshot or []:
+            payload = self._raffle_ticket_print_payload(snapshot)
+            if not payload:
+                logger.debug("Snapshot de rifa sin payload imprimible venta=%s: %s", sale_id, snapshot)
+                continue
+            try:
+                job_id = printer.print_raffle_ticket(payload)
+                if job_id:
+                    printed_job_ids.append(str(job_id))
+            except Exception as exc:
+                logger.warning(
+                    "No se pudo imprimir boleto de rifa venta=%s boleto=%s: %s",
+                    sale_id,
+                    payload.get("numero_boleto") or payload.get("barcode") or "",
+                    exc,
+                )
+                continue
+        return printed_job_ids
+
     def _execute_sale_core(self, branch_id: int, user: str, items: list, payment_method: str,
                      amount_paid: float, client_id: int = None, client_phone: str = None,
                      client_level: str = 'bronce', discount: float = 0.0, notes: str = "",
@@ -753,17 +824,18 @@ class SalesService:
                     logger.warning("loyalty accrual venta=%s: %s", sale_id, _lyl_aw_err)
 
             raffle_tickets_snapshot = []
-            if client_id and self.loyalty_service:
+            if self.loyalty_service:
                 try:
                     raffle_tickets_snapshot = self.loyalty_service.process_raffles_for_sale(
                         venta_id=int(sale_id),
-                        cliente_id=int(client_id),
+                        cliente_id=int(client_id or 0),
                         folio=str(folio),
                         total=float(total_a_pagar),
                         sucursal_id=int(branch_id),
                         payment_method=str(payment_method or ""),
                         items=carrito_final,
                         sale_datetime=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                        discount=discount,
                     ) or []
                 except Exception as _raffle_err:
                     logger.warning("raffles process venta=%s: %s", sale_id, _raffle_err)
@@ -903,6 +975,8 @@ class SalesService:
             "mensaje": str((loyalty_result or {}).get("mensaje", "") or ""),
             "operation_id": operation_id,
         }
+        raffle_ticket_print_jobs = self._print_raffle_tickets_after_sale(raffle_tickets_snapshot, sale_id)
+        ticket_payload["raffle_ticket_print_jobs"] = raffle_ticket_print_jobs
         if return_details:
             return {
                 "ok": True,
@@ -917,6 +991,8 @@ class SalesService:
                 "loyalty": ticket_payload["loyalty"],
                 "ticket_payload": ticket_payload,
                 "ticket_html": ticket_final_html or "",
+                "raffle_tickets_snapshot": raffle_tickets_snapshot,
+                "raffle_ticket_print_jobs": raffle_ticket_print_jobs,
                 "warnings": [],
                 "error": "",
             }

--- a/pos_spj_v13.4/core/ticket_escpos_renderer.py
+++ b/pos_spj_v13.4/core/ticket_escpos_renderer.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import base64
 import io
+import json
 import logging
+import os
 import re
 import struct
 from typing import Any, Dict, List, Optional
@@ -82,10 +84,6 @@ class TicketESCPOSRenderer:
         return sorted(ordered, key=_order)
 
     def _block_enabled(self, layout: TicketLayoutConfig, block_name: str) -> bool:
-        blocks = getattr(layout, "blocks", {}) or {}
-        blk = blocks.get(block_name)
-        if blk is not None and hasattr(blk, "enabled"):
-            return bool(blk.enabled)
         flag_map = {
             "logo": "show_logo",
             "brand_header": "show_brand_name",
@@ -96,7 +94,13 @@ class TicketESCPOSRenderer:
             "barcode": "show_barcode",
         }
         attr = flag_map.get(block_name)
-        return bool(getattr(layout, attr, True)) if attr else True
+        if attr and not bool(getattr(layout, attr, True)):
+            return False
+        blocks = getattr(layout, "blocks", {}) or {}
+        blk = blocks.get(block_name)
+        if blk is not None and hasattr(blk, "enabled"):
+            return bool(blk.enabled)
+        return True
 
     def _render_block(self, block_name: str, ticket_data: Dict[str, Any], layout: TicketLayoutConfig,
                       width: int, logo_b64: str, qr_content: str) -> bytes:
@@ -147,7 +151,11 @@ class TicketESCPOSRenderer:
     def _logo_bytes(self, layout: TicketLayoutConfig, logo_b64: str) -> bytes:
         if not (getattr(layout, "show_logo", True) and logo_b64):
             return b""
-        logo_bytes = self._render_logo(logo_b64, getattr(layout, "logo_size", "md"))
+        logo_bytes = self._render_logo(
+            logo_b64,
+            getattr(layout, "logo_size", "md"),
+            debug_logo=getattr(layout, "ticket_debug_logo", False),
+        )
         if not logo_bytes:
             return b""
         return self._align_cmd(getattr(layout, "logo_alignment", "center")) + logo_bytes + self._linebreak() + INIT
@@ -304,8 +312,15 @@ class TicketESCPOSRenderer:
             return b""
         return ALIGN_CENTER + qr_bytes + self._linebreak() + INIT
 
+    def _barcode_value(self, ticket_data: Dict[str, Any]) -> str:
+        for key in ("barcode", "codigo_barras", "codigo", "folio"):
+            value = str(ticket_data.get(key) or "").strip()
+            if value:
+                return value
+        return ""
+
     def _barcode_bytes(self, ticket_data: Dict[str, Any], width: int) -> bytes:
-        value = str(ticket_data.get("barcode") or ticket_data.get("codigo_barras") or ticket_data.get("folio") or "").strip()
+        value = self._barcode_value(ticket_data)
         if not value:
             return b""
         img_bytes = self._render_code39_as_image(value)
@@ -385,52 +400,109 @@ class TicketESCPOSRenderer:
         lines.append(self._sanitize_text(ticket_data.get("mensaje_psicologico", "¡Gracias por su compra!")).center(width)[:width])
         return "\n".join(lines)
 
-    def _render_logo(self, logo_b64: str, logo_size: str = "md") -> Optional[bytes]:
+    def _logo_debug_enabled(self, debug_logo: Any = None) -> bool:
+        explicit = str(debug_logo).strip().lower() in {"1", "true", "si", "sí", "yes", "on"}
+        env_enabled = str(os.environ.get("ticket_debug_logo", os.environ.get("TICKET_DEBUG_LOGO", ""))).strip() == "1"
+        return explicit or env_enabled
+
+    def _logo_target_size(self, logo_size: str) -> tuple[int, int]:
+        size_key = str(logo_size or "md").lower()
+        try:
+            numeric_width = int(float(size_key))
+        except Exception:
+            numeric_width = None
+        if numeric_width:
+            return max(80, min(384 if self.paper_width <= 58 else 512, numeric_width)), 180 if self.paper_width <= 58 else 240
+        size_map_58 = {"sm": (192, 80), "md": (320, 140), "lg": (384, 180), "xl": (384, 220)}
+        size_map_80 = {"sm": (240, 100), "md": (384, 160), "lg": (512, 240), "xl": (512, 280)}
+        return (size_map_58 if self.paper_width <= 58 else size_map_80).get(
+            size_key,
+            (320, 140) if self.paper_width <= 58 else (384, 160),
+        )
+
+    def _decode_logo_b64(self, logo_b64: str) -> bytes:
+        raw_logo_b64 = str(logo_b64 or "").strip()
+        if "," in raw_logo_b64:
+            raw_logo_b64 = raw_logo_b64.split(",", 1)[1]
+        raw_logo_b64 = "".join(raw_logo_b64.split())
+        return base64.b64decode(raw_logo_b64, validate=False)
+
+    def _compose_logo_on_white(self, input_img):
+        from PIL import Image
+
+        original_mode = input_img.mode
+        has_alpha = original_mode in ("RGBA", "LA") or (original_mode == "P" and "transparency" in input_img.info)
+        if not has_alpha:
+            return input_img.convert("L"), None
+
+        rgba = input_img.convert("RGBA")
+        alpha = rgba.getchannel("A")
+        white = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+        composed = Image.alpha_composite(white, rgba).convert("L")
+        # Fully/mostly transparent pixels must be pure white before thresholding; otherwise
+        # transparent PNG backgrounds become dark thermal speckles on some printers.
+        transparent_mask = alpha.point(lambda a: 255 if a <= 32 else 0)
+        composed.paste(255, mask=transparent_mask)
+        return composed, alpha
+
+    def _resize_and_pad_logo(self, img, logo_size: str):
+        from PIL import Image
+
+        max_dots_w, max_dots_h = self._logo_target_size(logo_size)
+        ratio = min(max_dots_w / max(1, img.width), max_dots_h / max(1, img.height), 1.0)
+        if ratio < 1.0:
+            resampling = getattr(getattr(Image, "Resampling", Image), "LANCZOS", Image.BICUBIC)
+            img = img.resize((max(1, int(img.width * ratio)), max(1, int(img.height * ratio))), resampling)
+        if img.width % 8 != 0:
+            new_w = img.width + (8 - img.width % 8)
+            new_img = Image.new("L", (new_w, img.height), 255)
+            new_img.paste(img, (0, 0))
+            img = new_img
+        return img
+
+    def _dump_logo_diagnostics(self, input_img, processed, *, logo_size: str, original_mode: str, had_alpha: bool, threshold: int) -> None:
+        os.makedirs("logs", exist_ok=True)
+        try:
+            input_img.save("logs/ticket_logo_input.png")
+            processed.convert("L").save("logs/ticket_logo_processed.png")
+            with open("logs/ticket_logo_info.json", "w", encoding="utf-8") as fh:
+                json.dump(
+                    {
+                        "mode": original_mode,
+                        "size": list(input_img.size),
+                        "processed_size": list(processed.size),
+                        "logo_size": logo_size,
+                        "had_alpha": had_alpha,
+                        "threshold": threshold,
+                    },
+                    fh,
+                    ensure_ascii=False,
+                    indent=2,
+                )
+        except Exception as diag_exc:
+            logger.debug("No se pudo guardar diagnóstico de logo: %s", diag_exc)
+
+    def _render_logo(self, logo_b64: str, logo_size: str = "md", debug_logo: Any = None) -> Optional[bytes]:
         try:
             from PIL import Image
-            if "," in logo_b64:
-                logo_b64 = logo_b64.split(",", 1)[1]
-            img_bytes = base64.b64decode(logo_b64)
-            img = Image.open(io.BytesIO(img_bytes))
-            alpha = None
-            if img.mode in ("RGBA", "LA") or (img.mode == "P" and "transparency" in img.info):
-                rgba = img.convert("RGBA")
-                alpha = rgba.getchannel("A")
-                bg = Image.new("RGBA", rgba.size, "WHITE")
-                bg.alpha_composite(rgba)
-                img = bg.convert("RGB")
-            else:
-                img = img.convert("RGB")
-            img = img.convert("L")
-            if alpha is not None:
-                transparent_mask = alpha.point(lambda a: 255 if a < 245 else 0)
-                img.paste(255, mask=transparent_mask)
-            size_key = str(logo_size or "md").lower()
-            numeric_width = None
-            try:
-                numeric_width = int(float(size_key))
-            except Exception:
-                numeric_width = None
-            if numeric_width:
-                max_dots_w = max(80, min(384 if self.paper_width <= 58 else 512, numeric_width))
-                max_dots_h = 180 if self.paper_width <= 58 else 240
-            else:
-                size_map_58 = {"sm": (192, 80), "md": (320, 140), "lg": (384, 180), "xl": (384, 220)}
-                size_map_80 = {"sm": (240, 100), "md": (384, 160), "lg": (512, 240), "xl": (512, 280)}
-                max_dots_w, max_dots_h = (size_map_58 if self.paper_width <= 58 else size_map_80).get(
-                    size_key,
-                    (320, 140) if self.paper_width <= 58 else (384, 160),
+            img_bytes = self._decode_logo_b64(logo_b64)
+            input_img = Image.open(io.BytesIO(img_bytes))
+            input_img.load()
+            original_mode = input_img.mode
+            img, alpha = self._compose_logo_on_white(input_img)
+            img = self._resize_and_pad_logo(img, logo_size)
+            threshold = 150
+            processed = img.point(lambda x: 0 if x < threshold else 255, "1")
+            if self._logo_debug_enabled(debug_logo):
+                self._dump_logo_diagnostics(
+                    input_img,
+                    processed,
+                    logo_size=logo_size,
+                    original_mode=original_mode,
+                    had_alpha=alpha is not None,
+                    threshold=threshold,
                 )
-            ratio = min(max_dots_w / max(1, img.width), max_dots_h / max(1, img.height), 1.0)
-            if ratio < 1.0:
-                img = img.resize((max(1, int(img.width * ratio)), max(1, int(img.height * ratio))))
-            if img.width % 8 != 0:
-                new_w = img.width + (8 - img.width % 8)
-                new_img = Image.new("L", (new_w, img.height), 255)
-                new_img.paste(img, (0, 0))
-                img = new_img
-            img = img.point(lambda x: 0 if x < 150 else 255, "1")
-            return self._image_to_escpos_raster(img)
+            return self._image_to_escpos_raster(processed)
         except ImportError:
             logger.warning("Pillow no instalado — logo no se imprimirá. Instalar: pip install Pillow")
             return None

--- a/pos_spj_v13.4/core/tickets/raffle_ticket_renderer.py
+++ b/pos_spj_v13.4/core/tickets/raffle_ticket_renderer.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from core.ticket_escpos_renderer import (
+    ALIGN_CENTER,
+    ALIGN_LEFT,
+    BOLD_OFF,
+    BOLD_ON,
+    CUT_FULL,
+    CUT_PARTIAL,
+    DOUBLE_HW_ON,
+    FEED_N,
+    INIT,
+    NORMAL,
+    TicketESCPOSRenderer,
+)
+from core.tickets.ticket_layout_config import RAFFLE_BLOCK_ORDER, TicketLayoutConfig
+
+
+class RaffleTicketESCPOSRenderer(TicketESCPOSRenderer):
+    """ESC/POS renderer for loyalty raffle tickets.
+
+    It only formats the printable payload; all eligibility and issuance rules
+    belong to LoyaltyService/LoyaltyRepository.
+    """
+
+    def _raffle_layout_from_payload(self, ticket_data: Dict[str, Any]) -> TicketLayoutConfig:
+        raw_config = dict(ticket_data.get("layout_config") or {})
+        if not raw_config or "block_order" not in raw_config:
+            merged = TicketLayoutConfig.for_layout_type("raffle_ticket").to_dict()
+            merged.update(raw_config)
+            if "blocks" in raw_config:
+                merged["blocks"] = raw_config["blocks"]
+            raw_config = merged
+        return TicketLayoutConfig.from_dict(raw_config)
+
+    def render(self, ticket_data: Dict[str, Any], logo_b64: str = "", qr_content: str = "") -> bytes:
+        layout = self._raffle_layout_from_payload(ticket_data)
+        width = int(getattr(layout, "chars_per_line", self.chars_per_line) or self.chars_per_line)
+        qr_content = qr_content or str(ticket_data.get("qr_content") or ticket_data.get("numero_boleto") or "")
+        buf = bytearray(INIT)
+        for block_name in self._ordered_blocks(layout):
+            if block_name not in RAFFLE_BLOCK_ORDER:
+                continue
+            if not self._block_enabled(layout, block_name):
+                continue
+            buf += self._render_raffle_block(block_name, ticket_data, layout, width, logo_b64, qr_content)
+        feed_lines = max(0, min(10, int(getattr(layout, "feed_lines", 4) or 4)))
+        buf += FEED_N + bytes([feed_lines])
+        cut_type = str(getattr(layout, "cut_type", "partial") or "partial").lower()
+        buf += CUT_PARTIAL if cut_type == "partial" else CUT_FULL
+        return bytes(buf)
+
+    def _render_raffle_block(self, block_name: str, data: Dict[str, Any], layout: TicketLayoutConfig, width: int, logo_b64: str, qr_content: str) -> bytes:
+        if block_name == "logo":
+            return self._logo_bytes(layout, logo_b64)
+        if block_name == "brand_header":
+            return self._brand_header_bytes(data, layout)
+        if block_name == "raffle_title":
+            title = data.get("raffle_name") or data.get("nombre") or "SORTEO"
+            return self._separator(width) + ALIGN_CENTER + BOLD_ON + DOUBLE_HW_ON + self._text(title) + NORMAL + BOLD_OFF
+        if block_name == "ticket_number":
+            num = data.get("numero_boleto") or data.get("ticket_number") or ""
+            return ALIGN_CENTER + BOLD_ON + self._text("BOLETO") + DOUBLE_HW_ON + self._text(num) + NORMAL + BOLD_OFF
+        if block_name == "customer":
+            if not getattr(layout, "show_customer", True):
+                return b""
+            cliente = data.get("cliente") or data.get("cliente_nombre") or "Público General"
+            return ALIGN_LEFT + self._text(f"Cliente: {cliente}")
+        if block_name == "sale_info":
+            buf = bytearray(ALIGN_LEFT)
+            if data.get("folio_venta"):
+                buf += self._text(f"Venta: {data.get('folio_venta')}")
+            if data.get("venta_id"):
+                buf += self._text(f"ID venta: {data.get('venta_id')}")
+            return bytes(buf)
+        if block_name == "prize":
+            premio = data.get("premio") or data.get("prize") or ""
+            return (ALIGN_CENTER + self._text(f"Premio: {premio}")) if premio else b""
+        if block_name == "draw_date":
+            fecha = data.get("fecha_sorteo") or data.get("fecha_fin") or data.get("draw_date") or ""
+            return (ALIGN_CENTER + self._text(f"Sorteo: {fecha}")) if fecha else b""
+        if block_name == "qr":
+            return self._qr_bytes(layout, qr_content)
+        if block_name == "barcode":
+            return self._barcode_bytes({"barcode": data.get("barcode") or data.get("numero_boleto")}, width)
+        if block_name == "footer":
+            msg = data.get("footer_message") or getattr(layout, "footer_message", "") or "Gracias por participar"
+            return self._separator(width, char="-") + ALIGN_CENTER + self._text(msg)
+        if block_name == "legal":
+            msg = data.get("legal_message") or getattr(layout, "legal_message", "")
+            return (ALIGN_CENTER + self._text(msg)) if msg else b""
+        return b""
+
+    def render_text_preview(self, ticket_data: Dict[str, Any], layout_config: TicketLayoutConfig | None = None) -> str:
+        layout = layout_config or self._raffle_layout_from_payload(ticket_data)
+        width = int(getattr(layout, "chars_per_line", self.chars_per_line) or self.chars_per_line)
+        lines: List[str] = []
+        lines.append(str(ticket_data.get("empresa", "SPJ POS")).center(width)[:width])
+        lines.append("=" * width)
+        lines.append(str(ticket_data.get("raffle_name", "SORTEO")).center(width)[:width])
+        lines.append(f"BOLETO: {ticket_data.get('numero_boleto', '')}"[:width])
+        if ticket_data.get("cliente"):
+            lines.append(f"Cliente: {ticket_data.get('cliente')}"[:width])
+        if ticket_data.get("folio_venta"):
+            lines.append(f"Venta: {ticket_data.get('folio_venta')}"[:width])
+        if ticket_data.get("premio"):
+            lines.append(f"Premio: {ticket_data.get('premio')}"[:width])
+        if ticket_data.get("fecha_sorteo") or ticket_data.get("fecha_fin"):
+            lines.append(f"Sorteo: {ticket_data.get('fecha_sorteo') or ticket_data.get('fecha_fin')}"[:width])
+        return "\n".join(lines)

--- a/pos_spj_v13.4/core/tickets/ticket_layout_config.py
+++ b/pos_spj_v13.4/core/tickets/ticket_layout_config.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field, asdict, fields
 from typing import Any, Dict, List
 
 CHARS_BY_PAPER_WIDTH = {58: 32, 72: 42, 80: 48}
 DEFAULT_BLOCK_ORDER = [
     "logo", "brand_header", "sale_info", "customer", "items", "totals", "payment", "loyalty", "fomo", "qr", "barcode", "footer", "legal"
+]
+RAFFLE_BLOCK_ORDER = [
+    "logo", "brand_header", "raffle_title", "ticket_number", "customer", "sale_info", "prize", "draw_date", "qr", "barcode", "footer", "legal"
 ]
 
 
@@ -25,6 +28,7 @@ class TicketLayoutConfig:
     show_logo: bool = True
     logo_size: str = "md"
     logo_alignment: str = "center"
+    ticket_debug_logo: bool = False
     show_brand_name: bool = True
     show_slogan: bool = True
     show_address: bool = True
@@ -37,16 +41,26 @@ class TicketLayoutConfig:
     show_barcode: bool = False
     cut_type: str = "partial"
     feed_lines: int = 4
+    footer_message: str = ""
+    legal_message: str = ""
     block_order: List[str] = field(default_factory=lambda: list(DEFAULT_BLOCK_ORDER))
     blocks: Dict[str, TicketLayoutBlock] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        self.chars_per_line = CHARS_BY_PAPER_WIDTH.get(self.paper_width_mm, self.chars_per_line)
+        self.paper_width_mm = int(self.paper_width_mm or 80)
+        self.chars_per_line = CHARS_BY_PAPER_WIDTH.get(self.paper_width_mm, int(self.chars_per_line or 48))
+
         if not self.blocks:
             self.blocks = {
-                b: TicketLayoutBlock(enabled=(b not in {"barcode"}), order=i)
+                b: TicketLayoutBlock(enabled=self._default_block_enabled(b), order=i)
                 for i, b in enumerate(self.block_order)
             }
+        else:
+            # Ensure every configured block has an order and every ordered name has a block config.
+            # Missing per-block settings must inherit the global show_* flags so compact
+            # layouts from Ticket Design such as {"show_barcode": true} still render.
+            for i, name in enumerate(self.block_order):
+                self.blocks.setdefault(name, TicketLayoutBlock(enabled=self._default_block_enabled(name), order=i))
 
     def to_dict(self) -> Dict[str, Any]:
         data = asdict(self)
@@ -55,21 +69,67 @@ class TicketLayoutConfig:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TicketLayoutConfig":
-        obj = cls(**{k: v for k, v in (data or {}).items() if k != "blocks"})
-        raw_blocks = (data or {}).get("blocks") or {}
+        data = dict(data or {})
+        valid = {f.name for f in fields(cls)}
+        kwargs = {k: v for k, v in data.items() if k in valid and k != "blocks"}
+        obj = cls(**kwargs)
+        raw_blocks = data.get("blocks") or {}
         if raw_blocks:
-            obj.blocks = {k: TicketLayoutBlock(**v) if isinstance(v, dict) else TicketLayoutBlock() for k, v in raw_blocks.items()}
+            obj.blocks = {}
+            for k, v in raw_blocks.items():
+                if isinstance(v, TicketLayoutBlock):
+                    obj.blocks[k] = v
+                elif isinstance(v, dict):
+                    valid_block = {f.name for f in fields(TicketLayoutBlock)}
+                    obj.blocks[k] = TicketLayoutBlock(**{bk: bv for bk, bv in v.items() if bk in valid_block})
+                else:
+                    obj.blocks[k] = TicketLayoutBlock()
+            for i, name in enumerate(obj.block_order):
+                obj.blocks.setdefault(name, TicketLayoutBlock(enabled=obj._default_block_enabled(name), order=i))
         return obj
+
+    def _default_block_enabled(self, block_name: str) -> bool:
+        flag_map = {
+            "logo": self.show_logo,
+            "brand_header": self.show_brand_name,
+            "customer": self.show_customer,
+            "loyalty": self.show_loyalty,
+            "fomo": self.show_fomo,
+            "qr": self.show_qr,
+            "barcode": self.show_barcode,
+        }
+        return bool(flag_map.get(block_name, True))
+
+    @classmethod
+    def for_layout_type(cls, layout_type: str = "sale_ticket") -> "TicketLayoutConfig":
+        if str(layout_type or "sale_ticket") == "raffle_ticket":
+            cfg = cls(
+                block_order=list(RAFFLE_BLOCK_ORDER),
+                show_loyalty=False,
+                show_fomo=False,
+                show_qr=True,
+                show_barcode=True,
+                footer_message="Gracias por participar",
+                legal_message="Conserve este boleto para reclamar su premio.",
+            )
+            cfg.blocks = {b: TicketLayoutBlock(enabled=True, order=i) for i, b in enumerate(RAFFLE_BLOCK_ORDER)}
+            return cfg
+        return cls()
 
     @classmethod
     def from_legacy_config(cls, legacy: Dict[str, Any]) -> "TicketLayoutConfig":
         paper_w = int(legacy.get("ticket_paper_width", 80) or 80)
         logo_pos = str(legacy.get("ticket_logo_pos", "Centrado"))
         pos_map = {"Centrado": "center", "Izquierda": "left", "Derecha": "right"}
-        return cls(
+        cfg = cls(
             paper_width_mm=paper_w,
             show_qr=str(legacy.get("ticket_qr_enabled", "0")) == "1",
             show_barcode=str(legacy.get("ticket_bc_enabled", "0")) == "1",
             logo_alignment=pos_map.get(logo_pos, "center"),
             logo_size=str(legacy.get("ticket_logo_width", "150")),
         )
+        if "barcode" in cfg.blocks:
+            cfg.blocks["barcode"].enabled = cfg.show_barcode
+        if "qr" in cfg.blocks:
+            cfg.blocks["qr"].enabled = cfg.show_qr
+        return cfg

--- a/pos_spj_v13.4/core/tickets/ticket_layout_repository.py
+++ b/pos_spj_v13.4/core/tickets/ticket_layout_repository.py
@@ -1,24 +1,95 @@
 from __future__ import annotations
 
 import json
-from typing import Optional
+import logging
+from typing import Any, Optional
 
 from .ticket_layout_config import TicketLayoutConfig
 
+logger = logging.getLogger("spj.ticket_layout_repository")
+
 
 class TicketLayoutRepository:
+    """Single read/write gateway for thermal ticket layouts.
+
+    The canonical store is ticket_layouts(layout_type, config_json).  Legacy
+    configuraciones keys are read only as compatibility fallbacks for sale_ticket.
+    """
+
+    VALID_LAYOUT_TYPES = {"sale_ticket", "raffle_ticket"}
+
     def __init__(self, db_conn=None, config_service=None):
         self.db = db_conn
         self.config_service = config_service
+
+    def _normalize_layout_type(self, layout_type: str = "sale_ticket") -> str:
+        lt = str(layout_type or "sale_ticket").strip() or "sale_ticket"
+        return lt if lt in self.VALID_LAYOUT_TYPES else "sale_ticket"
+
+    def ensure_schema(self) -> None:
+        if self.db is None:
+            return
+        self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ticket_layouts(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                layout_type TEXT NOT NULL DEFAULT 'sale_ticket',
+                nombre TEXT NOT NULL DEFAULT 'Default',
+                config_json TEXT NOT NULL,
+                activo INTEGER DEFAULT 0,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT
+            )
+            """
+        )
+        cols = self._table_columns("ticket_layouts")
+        migrations = {
+            "layout_type": "ALTER TABLE ticket_layouts ADD COLUMN layout_type TEXT NOT NULL DEFAULT 'sale_ticket'",
+            "nombre": "ALTER TABLE ticket_layouts ADD COLUMN nombre TEXT NOT NULL DEFAULT 'Default'",
+            "config_json": "ALTER TABLE ticket_layouts ADD COLUMN config_json TEXT NOT NULL DEFAULT '{}'",
+            "activo": "ALTER TABLE ticket_layouts ADD COLUMN activo INTEGER DEFAULT 0",
+            "created_at": "ALTER TABLE ticket_layouts ADD COLUMN created_at TEXT DEFAULT CURRENT_TIMESTAMP",
+            "updated_at": "ALTER TABLE ticket_layouts ADD COLUMN updated_at TEXT",
+        }
+        for col, sql in migrations.items():
+            if col not in cols:
+                self.db.execute(sql)
+        self.db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ticket_layouts_type_active ON ticket_layouts(layout_type, activo, updated_at, id)"
+        )
+        try:
+            self.db.commit()
+        except Exception:
+            pass
+
+    def _table_columns(self, table: str) -> set[str]:
+        if self.db is None:
+            return set()
+        try:
+            return {str(r[1]) for r in self.db.execute(f"PRAGMA table_info({table})").fetchall()}
+        except Exception:
+            return set()
+
+    def _table_exists(self, table: str) -> bool:
+        if self.db is None:
+            return False
+        try:
+            row = self.db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone()
+            return bool(row)
+        except Exception:
+            return False
 
     def _get(self, key: str, default: str = "") -> str:
         if self.config_service is not None:
             v = self.config_service.get(key, default)
             return v if v not in (None, "") else default
-        if self.db is None:
+        if self.db is None or not self._table_exists("configuraciones"):
             return default
-        row = self.db.execute("SELECT valor FROM configuraciones WHERE clave=?", (key,)).fetchone()
-        return row[0] if row and row[0] else default
+        try:
+            row = self.db.execute("SELECT valor FROM configuraciones WHERE clave=?", (key,)).fetchone()
+            return row[0] if row and row[0] else default
+        except Exception:
+            return default
 
     def _set(self, key: str, value: str) -> None:
         if self.config_service is not None:
@@ -26,16 +97,78 @@ class TicketLayoutRepository:
             return
         if self.db is None:
             return
+        self.db.execute("CREATE TABLE IF NOT EXISTS configuraciones(clave TEXT PRIMARY KEY, valor TEXT)")
         self.db.execute("INSERT OR REPLACE INTO configuraciones(clave, valor) VALUES (?,?)", (key, value))
-        self.db.commit()
+        try:
+            self.db.commit()
+        except Exception:
+            pass
 
-    def load(self) -> TicketLayoutConfig:
+    def _row_to_dict(self, row) -> dict[str, Any]:
+        if not row:
+            return {}
+        if isinstance(row, dict):
+            return dict(row)
+        try:
+            return {k: row[k] for k in row.keys()}
+        except Exception:
+            return {
+                "id": row[0], "layout_type": row[1], "nombre": row[2], "config_json": row[3],
+                "activo": row[4], "created_at": row[5] if len(row) > 5 else None, "updated_at": row[6] if len(row) > 6 else None,
+            }
+
+    def get_active_layout_row(self, layout_type: str = "sale_ticket") -> Optional[dict[str, Any]]:
+        if self.db is None:
+            return None
+        self.ensure_schema()
+        lt = self._normalize_layout_type(layout_type)
+        row = self.db.execute(
+            """
+            SELECT id, layout_type, nombre, config_json, activo, created_at, updated_at
+              FROM ticket_layouts
+             WHERE layout_type=? AND activo=1
+             ORDER BY COALESCE(updated_at, created_at) DESC, id DESC
+             LIMIT 1
+            """,
+            (lt,),
+        ).fetchone()
+        return self._row_to_dict(row) if row else None
+
+    def _get_latest_layout_row(self, layout_type: str) -> Optional[dict[str, Any]]:
+        if self.db is None:
+            return None
+        self.ensure_schema()
+        row = self.db.execute(
+            """
+            SELECT id, layout_type, nombre, config_json, activo, created_at, updated_at
+              FROM ticket_layouts
+             WHERE layout_type=?
+             ORDER BY COALESCE(updated_at, created_at) DESC, id DESC
+             LIMIT 1
+            """,
+            (self._normalize_layout_type(layout_type),),
+        ).fetchone()
+        return self._row_to_dict(row) if row else None
+
+    def _cfg_from_row(self, row: dict[str, Any] | None) -> Optional[TicketLayoutConfig]:
+        if not row:
+            return None
+        try:
+            return TicketLayoutConfig.from_dict(json.loads(str(row.get("config_json") or "{}")))
+        except Exception as exc:
+            logger.warning("Layout inválido id=%s: %s", row.get("id"), exc)
+            return None
+
+    def _load_configuraciones_sale(self) -> Optional[TicketLayoutConfig]:
         raw = self._get("ticket_layout_config", "")
         if raw:
             try:
                 return TicketLayoutConfig.from_dict(json.loads(raw))
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("ticket_layout_config legacy inválido: %s", exc)
+        return None
+
+    def _load_legacy_sale(self) -> TicketLayoutConfig:
         legacy = {
             "ticket_paper_width": self._get("ticket_paper_width", "80"),
             "ticket_logo_width": self._get("ticket_logo_width", "150"),
@@ -45,5 +178,55 @@ class TicketLayoutRepository:
         }
         return TicketLayoutConfig.from_legacy_config(legacy)
 
-    def save(self, cfg: TicketLayoutConfig) -> None:
-        self._set("ticket_layout_config", json.dumps(cfg.to_dict(), ensure_ascii=False))
+    def load(self, layout_type: str = "sale_ticket") -> TicketLayoutConfig:
+        lt = self._normalize_layout_type(layout_type)
+        cfg = self._cfg_from_row(self.get_active_layout_row(lt)) or self._cfg_from_row(self._get_latest_layout_row(lt))
+        if cfg:
+            return cfg
+        if lt == "sale_ticket":
+            cfg = self._load_configuraciones_sale()
+            if cfg:
+                self._copy_on_read(cfg, lt, "Migrado desde configuraciones")
+                return cfg
+            return self._load_legacy_sale()
+        cfg = TicketLayoutConfig.for_layout_type(lt)
+        self._copy_on_read(cfg, lt, "Boleto de sorteo")
+        return cfg
+
+    def _copy_on_read(self, cfg: TicketLayoutConfig, layout_type: str, nombre: str) -> None:
+        if self.db is None:
+            return
+        try:
+            if self._get_latest_layout_row(layout_type):
+                return
+            self.save(cfg, layout_type=layout_type, nombre=nombre)
+        except Exception as exc:
+            logger.debug("copy-on-read layout omitido: %s", exc)
+
+    def save(self, cfg: TicketLayoutConfig | dict[str, Any], layout_type: str = "sale_ticket", nombre: str | None = None) -> None:
+        lt = self._normalize_layout_type(layout_type)
+        if not isinstance(cfg, TicketLayoutConfig):
+            cfg = TicketLayoutConfig.from_dict(dict(cfg or {}))
+        if lt == "raffle_ticket" and not cfg.block_order:
+            cfg = TicketLayoutConfig.for_layout_type("raffle_ticket")
+        raw = json.dumps(cfg.to_dict(), ensure_ascii=False)
+        if self.db is None:
+            if lt == "sale_ticket":
+                self._set("ticket_layout_config", raw)
+            return
+        self.ensure_schema()
+        self.db.execute("UPDATE ticket_layouts SET activo=0, updated_at=datetime('now') WHERE layout_type=?", (lt,))
+        self.db.execute(
+            """
+            INSERT INTO ticket_layouts(layout_type, nombre, config_json, activo, updated_at)
+            VALUES(?,?,?,?,datetime('now'))
+            """,
+            (lt, str(nombre or ("Ticket de venta" if lt == "sale_ticket" else "Boleto de sorteo")), raw, 1),
+        )
+        if lt == "sale_ticket":
+            self._set("ticket_layout_config", raw)
+        else:
+            try:
+                self.db.commit()
+            except Exception:
+                pass

--- a/pos_spj_v13.4/interfaz/main_window.py
+++ b/pos_spj_v13.4/interfaz/main_window.py
@@ -431,7 +431,6 @@ class DialogoLogin(QDialog):
             "}"
             "QPushButton:hover {"
             "  background: #1d4ed8;"
-            "  box-shadow: 0 0 18px rgba(37,99,235,0.55);"
             "}"
             "QPushButton:pressed { background: #1e40af; }"
             "QPushButton:disabled { background: #1e293b; color: #475569; }"

--- a/pos_spj_v13.4/modulos/design_tokens.py
+++ b/pos_spj_v13.4/modulos/design_tokens.py
@@ -309,7 +309,7 @@ class Transitions:
     EASING_LINEAR = "linear"
     
     # Propiedades comunes a animar
-    COMMON_PROPS = "background-color, border-color, color, box-shadow, transform"
+    COMMON_PROPS = "background-color, border-color, color, transform"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/pos_spj_v13.4/modulos/ticket_designer.py
+++ b/pos_spj_v13.4/modulos/ticket_designer.py
@@ -19,7 +19,7 @@ from PyQt5.QtWidgets import (
     QPlainTextEdit, QTextBrowser, QSplitter, QGroupBox,
     QListWidget, QMessageBox, QFileDialog, QTabWidget,
     QFormLayout, QLineEdit, QCheckBox, QComboBox, QSpinBox,
-    QDoubleSpinBox, QScrollArea, QFrame, QTextEdit,
+    QDoubleSpinBox, QScrollArea, QFrame, QTextEdit, QListWidgetItem,
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QFont, QPixmap
@@ -33,6 +33,29 @@ PAPER_SIZES = {
     "A4":              (210, 297),
     "Personalizado":   (0, 0),
 }
+
+BLOCK_LABELS = {
+    "logo": "Logo",
+    "brand_header": "Encabezado / marca",
+    "sale_info": "Datos de venta",
+    "customer": "Cliente",
+    "items": "Productos",
+    "totals": "Totales",
+    "payment": "Pago",
+    "loyalty": "Fidelidad",
+    "fomo": "FOMO / promociones",
+    "raffle_title": "Título del sorteo",
+    "ticket_number": "Número de boleto",
+    "prize": "Premio",
+    "draw_date": "Fecha del sorteo",
+    "qr": "Código QR",
+    "barcode": "Código de barras",
+    "footer": "Mensaje footer",
+    "legal": "Mensaje legal",
+}
+
+SALE_ONLY_BLOCKS = {"items", "totals", "payment", "loyalty", "fomo"}
+RAFFLE_ONLY_BLOCKS = {"raffle_title", "ticket_number", "prize", "draw_date"}
 
 
 class ModuloTicketDesigner(QWidget):
@@ -50,11 +73,13 @@ class ModuloTicketDesigner(QWidget):
         super().__init__(parent)
         self.container = container
         self._logo_b64 = ""
+        self.current_layout_type = "sale_ticket"
         self.init_ui()
         self.cargar_plantilla_actual()
         self._cargar_logo_guardado()
         self._cargar_config_qr_guardada()
         self._cargar_config_papel()
+        self._cargar_layout_activo()
 
     def set_usuario_actual(self, usuario: str, rol: str = "cajero") -> None:
         self.usuario_actual = usuario
@@ -87,12 +112,19 @@ class ModuloTicketDesigner(QWidget):
         btn_brand = create_secondary_button(self, btn_brand, "Editar marca en Configuración del Sistema")
         btn_brand.clicked.connect(self._abrir_configuracion_sistema)
         
+        self.cmb_layout_type = QComboBox()
+        self.cmb_layout_type.addItem("Ticket de venta", "sale_ticket")
+        self.cmb_layout_type.addItem("Boleto de sorteo", "raffle_ticket")
+        self.cmb_layout_type.currentIndexChanged.connect(self._on_layout_type_changed)
+        header.addWidget(QLabel("Diseñar:"))
+        header.addWidget(self.cmb_layout_type)
         header.addWidget(btn_print)
         header.addWidget(btn_brand)
         header.addWidget(btn_save_all)
         lay.addLayout(header)
 
-        tabs = QTabWidget()
+        self.tabs = QTabWidget()
+        tabs = self.tabs
         tabs.setObjectName("tabWidget")
         lay.addWidget(tabs)
 
@@ -111,14 +143,14 @@ class ModuloTicketDesigner(QWidget):
         self._build_tab_media(tab_media)
 
         # Tab 3: Fidelidad
-        tab_loyalty = QWidget()
-        tabs.addTab(tab_loyalty, "🎯 Fidelidad")
-        self._build_tab_loyalty(tab_loyalty)
+        self.tab_loyalty = QWidget()
+        tabs.addTab(self.tab_loyalty, "🎯 Fidelidad")
+        self._build_tab_loyalty(self.tab_loyalty)
 
         # Tab 4: FOMO / Promociones
-        tab_fomo = QWidget()
-        tabs.addTab(tab_fomo, "🔥 FOMO / Promociones")
-        self._build_tab_fomo(tab_fomo)
+        self.tab_fomo = QWidget()
+        tabs.addTab(self.tab_fomo, "🔥 FOMO / Promociones")
+        self._build_tab_fomo(self.tab_fomo)
 
         # Tab 5: Impresión ESC/POS
         tab_paper = QWidget()
@@ -140,6 +172,23 @@ class ModuloTicketDesigner(QWidget):
         self.lista_variables.addItems(self.variables_disponibles)
         self.lista_variables.itemDoubleClicked.connect(self.insertar_variable)
         lv.addWidget(self.lista_variables)
+
+        self.lst_blocks = QListWidget()
+        self.lst_blocks.setObjectName("inputField")
+        self.lst_blocks.setToolTip("Activa/desactiva bloques y usa Subir/Bajar para definir el orden ESC/POS")
+        self.lst_blocks.itemChanged.connect(self.actualizar_vista_previa)
+        lv.addWidget(QLabel("Bloques ESC/POS:"))
+        lv.addWidget(self.lst_blocks)
+        btn_block_order = QHBoxLayout()
+        btn_up = QPushButton("↑")
+        btn_down = QPushButton("↓")
+        btn_up = create_secondary_button(self, btn_up, "Subir bloque")
+        btn_down = create_secondary_button(self, btn_down, "Bajar bloque")
+        btn_up.clicked.connect(lambda: self._mover_bloque(-1))
+        btn_down.clicked.connect(lambda: self._mover_bloque(1))
+        btn_block_order.addWidget(btn_up)
+        btn_block_order.addWidget(btn_down)
+        lv.addLayout(btn_block_order)
         splitter.addWidget(grp_vars)
 
         grp_ed = QGroupBox("📝 Plantilla HTML (solo Preview/PDF avanzado)")
@@ -186,6 +235,10 @@ class ModuloTicketDesigner(QWidget):
         lbl_brand = QLabel("Usa logo de Configuración del Sistema como fuente principal.")
         lbl_brand.setObjectName("caption")
         fl.addRow("", lbl_brand)
+        self.chk_logo = QCheckBox("Mostrar logo")
+        self.chk_logo.setChecked(True)
+        self.chk_logo.stateChanged.connect(self.actualizar_vista_previa)
+        fl.addRow("", self.chk_logo)
         self.lbl_logo_preview = QLabel("Sin logo cargado")
         self.lbl_logo_preview.setFixedHeight(90)
         self.lbl_logo_preview.setFixedWidth(200)
@@ -212,6 +265,16 @@ class ModuloTicketDesigner(QWidget):
         self.cmb_logo_pos.setObjectName("inputField")
         self.cmb_logo_pos.currentIndexChanged.connect(self.actualizar_vista_previa)
         fl.addRow("Posición:", self.cmb_logo_pos)
+        self.txt_footer_message = QLineEdit()
+        self.txt_footer_message.setPlaceholderText("Mensaje final / footer")
+        self.txt_footer_message.setObjectName("inputField")
+        self.txt_footer_message.textChanged.connect(self.actualizar_vista_previa)
+        fl.addRow("Footer:", self.txt_footer_message)
+        self.txt_legal_message = QLineEdit()
+        self.txt_legal_message.setPlaceholderText("Texto legal o condiciones")
+        self.txt_legal_message.setObjectName("inputField")
+        self.txt_legal_message.textChanged.connect(self.actualizar_vista_previa)
+        fl.addRow("Legal:", self.txt_legal_message)
         lm.addWidget(grp_logo)
 
         # QR
@@ -237,7 +300,8 @@ class ModuloTicketDesigner(QWidget):
         grp_bc = QGroupBox("Código de barras")
         grp_bc.setObjectName("styledGroup")
         fb = QFormLayout(grp_bc)
-        self.chk_barcode = QCheckBox("Incluir barcode (folio)")
+        self.chk_barcode = QCheckBox("Incluir barcode (folio / número de boleto)")
+        self.chk_barcode.stateChanged.connect(self.actualizar_vista_previa)
         fb.addRow("", self.chk_barcode)
         self.cmb_barcode_type = QComboBox()
         self.cmb_barcode_type.addItems(["Code128","EAN13","QR (alternativo)"])
@@ -433,6 +497,170 @@ class ModuloTicketDesigner(QWidget):
             except: pass
         except Exception as e: logger.debug("load paper cfg: %s", e)
 
+
+    def _layout_repo(self):
+        from core.tickets.ticket_layout_repository import TicketLayoutRepository
+        return TicketLayoutRepository(db_conn=self.container.db)
+
+    def _on_layout_type_changed(self):
+        self.current_layout_type = self.cmb_layout_type.currentData() or "sale_ticket"
+        self._aplicar_bloques_por_tipo()
+        self.cargar_plantilla_actual()
+        self._cargar_layout_activo()
+        self.actualizar_vista_previa()
+
+    def _allowed_blocks_for_current_type(self):
+        from core.tickets.ticket_layout_config import DEFAULT_BLOCK_ORDER, RAFFLE_BLOCK_ORDER
+        layout_type = self.current_layout_type or "sale_ticket"
+        return list(RAFFLE_BLOCK_ORDER if layout_type == "raffle_ticket" else DEFAULT_BLOCK_ORDER)
+
+    def _set_sale_only_tabs_enabled(self, enabled: bool):
+        tabs = getattr(self, "tabs", None)
+        if not tabs:
+            return
+        for tab in (getattr(self, "tab_loyalty", None), getattr(self, "tab_fomo", None)):
+            if tab is not None:
+                idx = tabs.indexOf(tab)
+                if idx >= 0:
+                    tabs.setTabEnabled(idx, bool(enabled))
+
+    def _on_layout_type_changed(self):
+        self.current_layout_type = self.cmb_layout_type.currentData() or "sale_ticket"
+        self._aplicar_bloques_por_tipo()
+        self.cargar_plantilla_actual()
+        self._cargar_layout_activo()
+        self.actualizar_vista_previa()
+
+    def _aplicar_bloques_por_tipo(self):
+        is_raffle = self.current_layout_type == "raffle_ticket"
+        self.variables_disponibles = [
+            "{{raffle_name}}", "{{numero_boleto}}", "{{cliente_nombre}}", "{{folio_venta}}",
+            "{{premio}}", "{{fecha_sorteo}}", "{{qr_code}}", "{{barcode}}", "{{logo}}",
+            "{{nombre_empresa}}", "{{direccion}}", "{{telefono}}", "{{footer_message}}", "{{legal_message}}",
+        ] if is_raffle else [
+            "{{folio}}", "{{fecha}}", "{{cajero}}", "{{cliente_nombre}}",
+            "{{items_html}}", "{{total}}", "{{subtotal}}", "{{descuento}}",
+            "{{forma_pago}}", "{{cambio}}", "{{puntos_ganados}}",
+            "{{puntos_totales}}", "{{mensaje_psicologico}}",
+            "{{qr_code}}", "{{barcode}}", "{{logo}}",
+            "{{nombre_empresa}}", "{{direccion}}", "{{telefono}}", "{{footer_message}}", "{{legal_message}}",
+        ]
+        if hasattr(self, "lista_variables"):
+            self.lista_variables.clear(); self.lista_variables.addItems(self.variables_disponibles)
+        self._set_sale_only_tabs_enabled(not is_raffle)
+        self._populate_block_list(self._allowed_blocks_for_current_type(), {})
+        if hasattr(self, "cmb_qr_dato"):
+            self.cmb_qr_dato.clear()
+            self.cmb_qr_dato.addItems(
+                ["Número de boleto", "Folio de venta", "URL del negocio", "WhatsApp del negocio"]
+                if is_raffle else
+                ["URL del negocio", "Folio de la venta", "Número de cliente", "WhatsApp del negocio"]
+            )
+        if hasattr(self, "txt_editor") and not self.txt_editor.toPlainText().strip():
+            self.txt_editor.setPlainText(self.obtener_html_defecto())
+
+    def _populate_block_list(self, order, enabled_by_block=None):
+        if not hasattr(self, "lst_blocks"):
+            return
+        enabled_by_block = enabled_by_block or {}
+        previous = self.lst_blocks.blockSignals(True)
+        try:
+            self.lst_blocks.clear()
+            for block_name in order:
+                item = QListWidgetItem(BLOCK_LABELS.get(block_name, block_name))
+                item.setData(Qt.UserRole, block_name)
+                item.setFlags(item.flags() | Qt.ItemIsUserCheckable | Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+                item.setCheckState(Qt.Checked if enabled_by_block.get(block_name, True) else Qt.Unchecked)
+                self.lst_blocks.addItem(item)
+        finally:
+            self.lst_blocks.blockSignals(previous)
+
+    def _block_list_state(self):
+        order = []
+        enabled = {}
+        if not hasattr(self, "lst_blocks") or self.lst_blocks.count() == 0:
+            for name in self._allowed_blocks_for_current_type():
+                order.append(name); enabled[name] = True
+            return order, enabled
+        for row in range(self.lst_blocks.count()):
+            item = self.lst_blocks.item(row)
+            name = item.data(Qt.UserRole)
+            if not name:
+                continue
+            order.append(str(name))
+            enabled[str(name)] = item.checkState() == Qt.Checked
+        return order, enabled
+
+    def _mover_bloque(self, delta: int):
+        if not hasattr(self, "lst_blocks"):
+            return
+        row = self.lst_blocks.currentRow()
+        new_row = row + int(delta)
+        if row < 0 or new_row < 0 or new_row >= self.lst_blocks.count():
+            return
+        item = self.lst_blocks.takeItem(row)
+        self.lst_blocks.insertItem(new_row, item)
+        self.lst_blocks.setCurrentRow(new_row)
+        self.actualizar_vista_previa()
+
+    def _cargar_layout_activo(self):
+        try:
+            cfg = self._layout_repo().load(layout_type=self.current_layout_type)
+            self.spin_paper_w.setValue(int(cfg.paper_width_mm or 80))
+            self.spin_logo_w.setValue(int(float(cfg.logo_size)) if str(cfg.logo_size).replace('.', '', 1).isdigit() else self.spin_logo_w.value())
+            pos = {"center": "Centrado", "left": "Izquierda", "right": "Derecha"}.get(str(cfg.logo_alignment), "Centrado")
+            idx = self.cmb_logo_pos.findText(pos)
+            if idx >= 0: self.cmb_logo_pos.setCurrentIndex(idx)
+            self.chk_logo.setChecked(bool(cfg.show_logo and cfg.blocks.get("logo", None).enabled if cfg.blocks.get("logo") else cfg.show_logo))
+            self.chk_qr.setChecked(bool(cfg.show_qr and cfg.blocks.get("qr", None).enabled if cfg.blocks.get("qr") else cfg.show_qr))
+            self.chk_barcode.setChecked(bool(cfg.show_barcode and cfg.blocks.get("barcode", None).enabled if cfg.blocks.get("barcode") else cfg.show_barcode))
+            self.txt_footer_message.setText(str(getattr(cfg, "footer_message", "") or ""))
+            self.txt_legal_message.setText(str(getattr(cfg, "legal_message", "") or ""))
+            allowed = self._allowed_blocks_for_current_type()
+            ordered = [name for name in list(cfg.block_order or allowed) if name in allowed]
+            ordered += [name for name in allowed if name not in ordered]
+            enabled = {name: bool(cfg.blocks.get(name).enabled) for name in cfg.blocks if name in allowed}
+            self._populate_block_list(ordered, enabled)
+        except Exception as e:
+            logger.debug("load active layout: %s", e)
+
+    def _layout_config_from_controls(self):
+        from core.tickets.ticket_layout_config import TicketLayoutConfig, TicketLayoutBlock, DEFAULT_BLOCK_ORDER, RAFFLE_BLOCK_ORDER
+        layout_type = self.current_layout_type or "sale_ticket"
+        # Keep this expression explicit: raffle_ticket uses only RAFFLE_BLOCK_ORDER; sale_ticket uses DEFAULT_BLOCK_ORDER.
+        default_order = list(RAFFLE_BLOCK_ORDER if layout_type == "raffle_ticket" else DEFAULT_BLOCK_ORDER)
+        order, enabled = self._block_list_state()
+        order = [name for name in order if name in default_order]
+        order += [name for name in default_order if name not in order]
+        cfg = TicketLayoutConfig.for_layout_type(layout_type) if layout_type == "raffle_ticket" else TicketLayoutConfig()
+        cfg.paper_width_mm = int(self.spin_paper_w.value())
+        cfg.logo_size = str(self.spin_logo_w.value())
+        cfg.logo_alignment = {"Centrado": "center", "Izquierda": "left", "Derecha": "right"}.get(self.cmb_logo_pos.currentText(), "center")
+        cfg.show_logo = bool(self.chk_logo.isChecked()) and bool(enabled.get("logo", True))
+        cfg.show_qr = bool(self.chk_qr.isChecked()) and bool(enabled.get("qr", True))
+        cfg.show_barcode = bool(self.chk_barcode.isChecked()) and bool(enabled.get("barcode", True))
+        cfg.show_customer = bool(enabled.get("customer", True))
+        cfg.footer_message = self.txt_footer_message.text().strip()
+        cfg.legal_message = self.txt_legal_message.text().strip()
+        cfg.block_order = order
+        cfg.blocks = {name: TicketLayoutBlock(enabled=bool(enabled.get(name, True)), order=i) for i, name in enumerate(order)}
+        for name, flag in (("logo", cfg.show_logo), ("qr", cfg.show_qr), ("barcode", cfg.show_barcode), ("customer", cfg.show_customer)):
+            if name in cfg.blocks:
+                cfg.blocks[name].enabled = bool(flag)
+        if layout_type == "sale_ticket":
+            cfg.show_loyalty = bool(enabled.get("loyalty", True)); cfg.show_fomo = bool(enabled.get("fomo", True))
+        else:
+            cfg.show_loyalty = False; cfg.show_fomo = False
+        return cfg
+
+    def _guardar_layout_activo(self):
+        try:
+            layout_type = self.current_layout_type or "sale_ticket"
+            cfg = self._layout_config_from_controls()
+            self._layout_repo().save(cfg, layout_type=layout_type)
+        except Exception as e:
+            logger.warning("save active layout: %s", e)
+
     # ══════════════════════════════════════════════════════════════════════
     #  Guardar
     # ══════════════════════════════════════════════════════════════════════
@@ -440,24 +668,26 @@ class ModuloTicketDesigner(QWidget):
     def _guardar_todo(self):
         try:
             db = self.container.db
-            self.container.config_service.set('ticket_template_html', self.txt_editor.toPlainText())
+            self.container.config_service.set(self._template_config_key(), self.txt_editor.toPlainText())
             u = lambda k, v: db.execute(
                 "INSERT INTO configuraciones(clave,valor) VALUES(?,?) ON CONFLICT(clave) DO UPDATE SET valor=excluded.valor", (k, v))
             u('ticket_logo_b64', self._logo_b64)
-            u('ticket_logo_width', str(self.spin_logo_w.value()))
-            u('ticket_logo_pos', self.cmb_logo_pos.currentText())
-            u('ticket_qr_enabled', '1' if self.chk_qr.isChecked() else '0')
-            u('ticket_qr_dato', self.cmb_qr_dato.currentText())
-            u('ticket_qr_url', self.txt_qr_url.text().strip())
-            u('ticket_qr_size', str(self.spin_qr_size.value()))
-            u('ticket_bc_enabled', '1' if self.chk_barcode.isChecked() else '0')
-            u('ticket_bc_type', self.cmb_barcode_type.currentText())
-            u('ticket_paper_width', str(self.spin_paper_w.value()))
-            u('ticket_paper_height', str(self.spin_paper_h.value()))
-            u('ticket_font_family', self.cmb_font_family.currentText())
-            u('ticket_font_size', str(self.spin_font_base.value()))
-            u('ticket_margin_top', str(self.spin_margin_top.value()))
-            u('ticket_margin_side', str(self.spin_margin_side.value()))
+            if self.current_layout_type == "sale_ticket":
+                u('ticket_logo_width', str(self.spin_logo_w.value()))
+                u('ticket_logo_pos', self.cmb_logo_pos.currentText())
+                u('ticket_qr_enabled', '1' if self.chk_qr.isChecked() else '0')
+                u('ticket_qr_dato', self.cmb_qr_dato.currentText())
+                u('ticket_qr_url', self.txt_qr_url.text().strip())
+                u('ticket_qr_size', str(self.spin_qr_size.value()))
+                u('ticket_bc_enabled', '1' if self.chk_barcode.isChecked() else '0')
+                u('ticket_bc_type', self.cmb_barcode_type.currentText())
+                u('ticket_paper_width', str(self.spin_paper_w.value()))
+                u('ticket_paper_height', str(self.spin_paper_h.value()))
+                u('ticket_font_family', self.cmb_font_family.currentText())
+                u('ticket_font_size', str(self.spin_font_base.value()))
+                u('ticket_margin_top', str(self.spin_margin_top.value()))
+                u('ticket_margin_side', str(self.spin_margin_side.value()))
+            self._guardar_layout_activo()
             try: db.commit()
             except: pass
             QMessageBox.information(self, "✅ Guardado", "Plantilla, medios y papel guardados.")
@@ -472,15 +702,19 @@ class ModuloTicketDesigner(QWidget):
         self.txt_editor.insertPlainText(item.text())
         self.txt_editor.setFocus()
 
+    def _template_config_key(self):
+        return "raffle_ticket_template_html" if self.current_layout_type == "raffle_ticket" else "ticket_template_html"
+
     def cargar_plantilla_actual(self):
-        try: plantilla = self.container.config_service.get('ticket_template_html', self.obtener_html_defecto())
+        key = self._template_config_key()
+        try: plantilla = self.container.config_service.get(key, self.obtener_html_defecto())
         except: plantilla = self.obtener_html_defecto()
-        self.txt_editor.setPlainText(plantilla)
+        self.txt_editor.setPlainText(plantilla or self.obtener_html_defecto())
         self.actualizar_vista_previa()
 
     def guardar_plantilla(self):
         try:
-            self.container.config_service.set('ticket_template_html', self.txt_editor.toPlainText())
+            self.container.config_service.set(self._template_config_key(), self.txt_editor.toPlainText())
             QMessageBox.information(self, "✅", "Plantilla guardada.")
         except Exception as e: QMessageBox.critical(self, "Error", str(e))
 
@@ -491,7 +725,7 @@ class ModuloTicketDesigner(QWidget):
         logo_pos = self.cmb_logo_pos.currentText() if hasattr(self, 'cmb_logo_pos') else "Centrado"
         align = {"Centrado":"center","Izquierda":"left","Derecha":"right"}.get(logo_pos,"center")
         logo_w = self.spin_logo_w.value() if hasattr(self, 'spin_logo_w') else 150
-        if self._logo_b64:
+        if self._logo_b64 and (not hasattr(self, 'chk_logo') or self.chk_logo.isChecked()):
             logo_html = f'<div style="text-align:{align};"><img src="{self._logo_b64}" width="{logo_w}px"></div>'
         else:
             logo_html = '<div style="text-align:center;color:#aaa;font-size:10px;border:1px dashed #ccc;padding:10px;">[Logo — cargar en pestaña Medios]</div>'
@@ -501,7 +735,7 @@ class ModuloTicketDesigner(QWidget):
         if hasattr(self, 'chk_qr') and self.chk_qr.isChecked():
             qr_url = self.txt_qr_url.text().strip() if hasattr(self,'txt_qr_url') else ''
             qr_size = self.spin_qr_size.value() if hasattr(self,'spin_qr_size') else 100
-            qr_content = qr_url or 'V-99998'
+            qr_content = qr_url or ('1-99998-1' if self.current_layout_type == 'raffle_ticket' else 'V-99998')
             qr_dato = self.cmb_qr_dato.currentText() if hasattr(self,'cmb_qr_dato') else ''
             try:
                 import io as _io, qrcode as _qrc
@@ -518,7 +752,8 @@ class ModuloTicketDesigner(QWidget):
         barcode_html = ''
         if hasattr(self, 'chk_barcode') and self.chk_barcode.isChecked():
             bc = self.cmb_barcode_type.currentText() if hasattr(self,'cmb_barcode_type') else 'Code128'
-            barcode_html = f'<div style="text-align:center;background:#f5f5f5;padding:4px;font-family:monospace;font-size:9px;">||||||||||||| V-99998 |||||||||||||<br><small>{bc}</small></div>'
+            bc_value = '1-99998-1' if self.current_layout_type == 'raffle_ticket' else 'V-99998'
+            barcode_html = f'<div style="text-align:center;background:#f5f5f5;padding:4px;font-family:monospace;font-size:9px;">||||||||||||| {bc_value} |||||||||||||<br><small>{bc}</small></div>'
 
         font_fam = self.cmb_font_family.currentText() if hasattr(self,'cmb_font_family') else 'Courier New'
         font_sz = self.spin_font_base.value() if hasattr(self,'spin_font_base') else 12
@@ -530,6 +765,10 @@ class ModuloTicketDesigner(QWidget):
             'descuento':'$0.00','forma_pago':'Efectivo','cambio':'$49.50',
             'puntos_ganados':'25','puntos_totales':'125',
             'mensaje_psicologico':'⭐ ¡Gracias por tu compra!',
+            'raffle_name':'Sorteo Navidad SPJ','numero_boleto':'1-99998-1',
+            'folio_venta':'V-99998','premio':'Cena familiar','fecha_sorteo':'2026-12-24',
+            'footer_message': self.txt_footer_message.text().strip() if hasattr(self, 'txt_footer_message') else '',
+            'legal_message': self.txt_legal_message.text().strip() if hasattr(self, 'txt_legal_message') else '',
             'logo':logo_html,'qr_code':qr_html,'barcode':barcode_html,
             'nombre_empresa':'SPJ POS','direccion':'Calle 1 #123',
             'telefono':'+52 614 123 4567',
@@ -537,6 +776,8 @@ class ModuloTicketDesigner(QWidget):
                          '<tr><td>Pierna</td><td>2.0kg</td><td>$120.00</td></tr>',
         }
         try:
+            if self.current_layout_type == "raffle_ticket":
+                raise RuntimeError("preview directo de boleto de sorteo")
             html = self.container.ticket_template_engine.generar_ticket(
                 plantilla, {'folio':dummy['folio'],'cajero':dummy['cajero'],
                     'fecha':dummy['fecha'],'cliente':'Juan Pérez',
@@ -554,23 +795,42 @@ class ModuloTicketDesigner(QWidget):
 
     def _actualizar_preview_escpos(self, dummy: dict):
         try:
-            from core.ticket_escpos_renderer import TicketESCPOSRenderer
-            payload = {
-                "empresa": dummy.get("nombre_empresa", "SPJ POS"),
-                "direccion": dummy.get("direccion", ""),
-                "telefono": dummy.get("telefono", ""),
-                "folio": dummy.get("folio", "V-99998"),
-                "fecha": dummy.get("fecha", ""),
-                "cajero": dummy.get("cajero", ""),
-                "cliente": dummy.get("cliente_nombre", ""),
-                "items": [
-                    {"nombre": "Pechuga", "cantidad": 1.5, "total": 150},
-                    {"nombre": "Pierna", "cantidad": 2.0, "total": 120},
-                ],
-                "totales": {"total_final": 250.50},
-                "layout_config": {"paper_width_mm": self.spin_paper_w.value()},
-            }
-            txt = TicketESCPOSRenderer(paper_width_mm=self.spin_paper_w.value()).render_text_preview(payload)
+            layout_cfg = self._layout_config_from_controls() if hasattr(self, "lst_blocks") else None
+            if self.current_layout_type == "raffle_ticket":
+                from core.tickets.raffle_ticket_renderer import RaffleTicketESCPOSRenderer
+                payload = {
+                    "empresa": dummy.get("nombre_empresa", "SPJ POS"),
+                    "direccion": dummy.get("direccion", ""),
+                    "telefono": dummy.get("telefono", ""),
+                    "raffle_name": dummy.get("raffle_name", "Sorteo"),
+                    "numero_boleto": dummy.get("numero_boleto", "1-99998-1"),
+                    "cliente": dummy.get("cliente_nombre", ""),
+                    "folio_venta": dummy.get("folio_venta", "V-99998"),
+                    "premio": dummy.get("premio", ""),
+                    "fecha_sorteo": dummy.get("fecha_sorteo", ""),
+                    "footer_message": dummy.get("footer_message", ""),
+                    "legal_message": dummy.get("legal_message", ""),
+                    "layout_config": layout_cfg.to_dict() if layout_cfg else {"paper_width_mm": self.spin_paper_w.value()},
+                }
+                txt = RaffleTicketESCPOSRenderer(paper_width_mm=self.spin_paper_w.value()).render_text_preview(payload, layout_cfg)
+            else:
+                from core.ticket_escpos_renderer import TicketESCPOSRenderer
+                payload = {
+                    "empresa": dummy.get("nombre_empresa", "SPJ POS"),
+                    "direccion": dummy.get("direccion", ""),
+                    "telefono": dummy.get("telefono", ""),
+                    "folio": dummy.get("folio", "V-99998"),
+                    "fecha": dummy.get("fecha", ""),
+                    "cajero": dummy.get("cajero", ""),
+                    "cliente": dummy.get("cliente_nombre", ""),
+                    "items": [
+                        {"nombre": "Pechuga", "cantidad": 1.5, "total": 150},
+                        {"nombre": "Pierna", "cantidad": 2.0, "total": 120},
+                    ],
+                    "totales": {"total_final": 250.50},
+                    "layout_config": layout_cfg.to_dict() if layout_cfg else {"paper_width_mm": self.spin_paper_w.value()},
+                }
+                txt = TicketESCPOSRenderer(paper_width_mm=self.spin_paper_w.value()).render_text_preview(payload)
             self.txt_preview_escpos.setPlainText(txt)
         except Exception as e:
             self.txt_preview_escpos.setPlainText(f"[preview escpos no disponible] {e}")
@@ -587,6 +847,21 @@ class ModuloTicketDesigner(QWidget):
             self.txt_editor.setPlainText(self.obtener_html_defecto())
 
     def obtener_html_defecto(self):
+        if self.current_layout_type == "raffle_ticket":
+            return """<div style="text-align:center;max-width:300px;margin:auto;">
+{{logo}}
+<h2 style="margin:4px 0;">{{nombre_empresa}}</h2>
+<p style="font-size:10px;margin:2px 0;">{{direccion}}<br>Tel: {{telefono}}</p>
+<hr style="border:none;border-top:1px dashed #000;">
+<h2>{{raffle_name}}</h2>
+<p style="font-size:18px;"><b>{{numero_boleto}}</b></p>
+<p>Cliente: {{cliente_nombre}}<br>Venta: {{folio_venta}}</p>
+<p>Premio: {{premio}}<br>Sorteo: {{fecha_sorteo}}</p>
+{{qr_code}}
+{{barcode}}
+<p style="font-size:10px;">{{footer_message}}</p>
+<p style="font-size:9px;">{{legal_message}}</p>
+</div>"""
         return """<div style="text-align:center;max-width:300px;margin:auto;">
 {{logo}}
 <h2 style="margin:4px 0;">{{nombre_empresa}}</h2>
@@ -625,19 +900,35 @@ Puntos: +{{puntos_ganados}} | Total: {{puntos_totales}}</p>
                 QMessageBox.warning(self, "Aviso", "No hay impresora térmica ESC/POS configurada.")
                 return
 
-            sample_ticket = {
-                "folio": "TST-ESC-POS",
-                "fecha": "2026-01-01 12:00:00",
-                "cajero": "Diseñador",
-                "cliente": "Cliente muestra",
-                "items": [
-                    {"nombre": "Producto Demo", "cantidad": 1, "precio_unitario": 100, "total": 100},
-                ],
-                "totales": {"subtotal": 100, "descuento": 0, "total_final": 100},
-                "forma_pago": "Prueba",
-                "plantilla": "ticket_designer_sample",
-            }
-            printer_svc.print_ticket(sample_ticket)
+            if self.current_layout_type == "raffle_ticket":
+                sample_ticket = {
+                    "ticket_type": "raffle_ticket",
+                    "raffle_name": "Sorteo Navidad SPJ",
+                    "numero_boleto": "1-99998-1",
+                    "cliente": "Cliente muestra",
+                    "folio_venta": "TST-ESC-POS",
+                    "premio": "Cena familiar",
+                    "fecha_sorteo": "2026-12-24",
+                    "qr_content": "RAFFLE:1|SALE:TST-ESC-POS|TICKET:1-99998-1",
+                    "barcode": "1-99998-1",
+                    "layout_config": self._layout_config_from_controls().to_dict(),
+                }
+                printer_svc.print_raffle_ticket(sample_ticket)
+            else:
+                sample_ticket = {
+                    "folio": "TST-ESC-POS",
+                    "fecha": "2026-01-01 12:00:00",
+                    "cajero": "Diseñador",
+                    "cliente": "Cliente muestra",
+                    "items": [
+                        {"nombre": "Producto Demo", "cantidad": 1, "precio_unitario": 100, "total": 100},
+                    ],
+                    "totales": {"subtotal": 100, "descuento": 0, "total_final": 100},
+                    "forma_pago": "Prueba",
+                    "plantilla": "ticket_designer_sample",
+                    "layout_config": self._layout_config_from_controls().to_dict(),
+                }
+                printer_svc.print_ticket(sample_ticket)
             QMessageBox.information(self, "✅ Impreso", "Muestra enviada a impresora térmica ESC/POS.")
         except Exception as e:
             QMessageBox.critical(self, "Error", str(e))

--- a/pos_spj_v13.4/repositories/loyalty_repository.py
+++ b/pos_spj_v13.4/repositories/loyalty_repository.py
@@ -613,16 +613,20 @@ class LoyaltyRepository:
         folio_venta: str,
         monto_base: float,
         sucursal_id: int,
+        ticket_count: int | None = None,
     ) -> List[str]:
         raffle = self.get_raffle_by_id(raffle_id)
         if not raffle:
             raise ValueError("rifa inexistente")
-        ticket_amount = float(raffle.get("monto_por_boleto") or 0)
-        if ticket_amount <= 0:
-            raise ValueError("monto_por_boleto inválido")
-        tickets_count = max(1, int(float(monto_base or 0) / ticket_amount))
-        max_per_customer = int(raffle.get("max_boletos_por_cliente") or tickets_count)
-        tickets_count = min(tickets_count, max(1, max_per_customer))
+        if ticket_count is None:
+            ticket_amount = float(raffle.get("monto_por_boleto") or 0)
+            if ticket_amount <= 0:
+                raise ValueError("monto_por_boleto inválido")
+            tickets_count = max(1, int(float(monto_base or 0) / ticket_amount))
+            max_per_customer = int(raffle.get("max_boletos_por_cliente") or tickets_count)
+            tickets_count = min(tickets_count, max(1, max_per_customer))
+        else:
+            tickets_count = max(0, int(ticket_count or 0))
 
         created: List[str] = []
         for i in range(tickets_count):
@@ -650,6 +654,21 @@ class LoyaltyRepository:
                 continue
         return created
 
+    def get_tickets_for_sale(self, raffle_id: int, venta_id: int) -> List[Dict[str, Any]]:
+        self.ensure_raffle_tables()
+        rows = self.db.execute(
+            """
+            SELECT *
+              FROM raffle_tickets
+             WHERE raffle_id=?
+               AND venta_id=?
+               AND (estado IS NULL OR estado<>'cancelado')
+             ORDER BY id ASC
+            """,
+            (int(raffle_id), int(venta_id)),
+        ).fetchall()
+        return [self._row_to_dict(r) for r in rows]
+
     def cancel_tickets_for_sale(self, venta_id: int, reason: str) -> int:
         cur = self.db.execute(
             """
@@ -657,7 +676,7 @@ class LoyaltyRepository:
                SET estado='cancelado',
                    cancel_reason=?,
                    cancelled_at=datetime('now')
-             WHERE venta_id=? AND estado<>'cancelado'
+             WHERE venta_id=? AND (estado IS NULL OR estado<>'cancelado')
             """,
             (str(reason or "cancelación de venta"), int(venta_id)),
         )
@@ -671,12 +690,20 @@ class LoyaltyRepository:
               FROM raffles
              WHERE estado='activa'
                AND COALESCE(financial_status,'')='reservada'
-               AND sucursal_id=?
+               AND (
+                    sucursal_id=?
+                    OR EXISTS (
+                        SELECT 1
+                          FROM raffle_eligible_branches reb
+                         WHERE reb.raffle_id = raffles.id
+                           AND reb.sucursal_id = ?
+                    )
+               )
                AND (fecha_inicio IS NULL OR fecha_inicio<=?)
                AND (fecha_fin IS NULL OR fecha_fin>=?)
              ORDER BY created_at DESC
             """,
-            (int(sucursal_id), str(sale_datetime), str(sale_datetime)),
+            (int(sucursal_id), int(sucursal_id), str(sale_datetime), str(sale_datetime)),
         ).fetchall()
         return [self._row_to_dict(r) for r in rows]
 

--- a/pos_spj_v13.4/tests/test_loyalty_raffle_issue_tickets.py
+++ b/pos_spj_v13.4/tests/test_loyalty_raffle_issue_tickets.py
@@ -1,0 +1,117 @@
+import sqlite3
+
+from core.services.loyalty_service import LoyaltyService
+
+
+def _service():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    svc = LoyaltyService(db, sucursal_id=1)
+    svc._app.repo.ensure_raffle_tables()
+    return svc, db
+
+
+def _active_raffle(db, *, min_sale=0, required_customer=0, max_sale=0, max_customer=0, allowed_payment="", include_discounted=1, ticket_strategy="per_amount", tickets_per_sale=1, amount_per_ticket=100):
+    db.execute(
+        """
+        INSERT INTO raffles(nombre,premio,monto_por_boleto,max_boletos_por_cliente,estado,financial_status,fecha_inicio,fecha_fin,sucursal_id)
+        VALUES('Navidad','Canasta',100,99,'activa','reservada','2026-01-01 00:00:00','2026-12-31 23:59:59',1)
+        """
+    )
+    rid = db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    db.execute(
+        """
+        INSERT INTO raffle_rules(raffle_id,requires_registered_customer,min_sale_amount,ticket_strategy,amount_per_ticket,tickets_per_sale,max_tickets_per_sale,max_tickets_per_customer,include_discounted_sales,allowed_payment_methods)
+        VALUES(?,?,?,?,?,?,?,?,?,?)
+        """,
+        (rid, required_customer, min_sale, ticket_strategy, amount_per_ticket, tickets_per_sale, max_sale, max_customer, include_discounted, allowed_payment),
+    )
+    db.execute("INSERT INTO raffle_prizes(raffle_id,nombre) VALUES(?, 'Canasta')", (rid,))
+    return rid
+
+
+def _issue(svc, **kw):
+    params = dict(venta_id=10, folio_venta="V-10", cliente_id=1, cliente_nombre="Ana", total=250, sucursal_id=1, sale_datetime="2026-06-01 12:00:00", payment_method="efectivo", items=[])
+    params.update(kw)
+    return svc.issue_raffle_tickets_for_sale(**params)
+
+
+def test_loyalty_issues_raffle_tickets_for_active_raffle():
+    svc, db = _service(); _active_raffle(db)
+    tickets = _issue(svc)
+    assert len(tickets) == 2
+    assert tickets[0]["ticket_type"] == "raffle_ticket"
+    assert db.execute("SELECT COUNT(*) FROM raffle_tickets").fetchone()[0] == 2
+
+
+def test_loyalty_does_not_issue_if_no_active_raffle():
+    svc, _ = _service()
+    assert _issue(svc) == []
+
+
+def test_loyalty_does_not_issue_if_min_sale_not_met():
+    svc, db = _service(); _active_raffle(db, min_sale=300)
+    assert _issue(svc, total=250) == []
+
+
+def test_loyalty_does_not_issue_without_customer_when_required():
+    svc, db = _service(); _active_raffle(db, required_customer=1)
+    assert _issue(svc, cliente_id=0) == []
+
+
+def test_loyalty_raffle_ticket_generation_is_idempotent():
+    svc, db = _service(); _active_raffle(db)
+    first = _issue(svc)
+    second = _issue(svc)
+    assert [t["numero_boleto"] for t in first] == [t["numero_boleto"] for t in second]
+    assert db.execute("SELECT COUNT(*) FROM raffle_tickets").fetchone()[0] == 2
+
+
+def test_loyalty_respects_max_tickets_per_sale():
+    svc, db = _service(); _active_raffle(db, max_sale=1)
+    assert len(_issue(svc)) == 1
+    assert db.execute("SELECT COUNT(*) FROM raffle_tickets").fetchone()[0] == 1
+
+
+def test_loyalty_respects_max_tickets_per_customer():
+    svc, db = _service(); _active_raffle(db, max_customer=1)
+    assert len(_issue(svc)) == 1
+    assert _issue(svc, venta_id=11, folio_venta="V-11") == []
+
+
+def test_loyalty_respects_payment_method_rules():
+    svc, db = _service(); _active_raffle(db, allowed_payment="tarjeta")
+    assert _issue(svc, payment_method="efectivo") == []
+    assert len(_issue(svc, payment_method="tarjeta")) == 2
+
+
+def test_loyalty_respects_fixed_tickets_per_sale_without_extra_rows():
+    svc, db = _service(); _active_raffle(db, ticket_strategy="fixed", tickets_per_sale=3, amount_per_ticket=100)
+
+    tickets = _issue(svc, total=1000)
+
+    assert len(tickets) == 3
+    assert db.execute("SELECT COUNT(*) FROM raffle_tickets").fetchone()[0] == 3
+
+
+def test_loyalty_respects_include_discounted_sales_rule():
+    svc, db = _service(); _active_raffle(db, include_discounted=0)
+
+    assert _issue(svc, discount=10) == []
+    assert _issue(svc, venta_id=11, folio_venta="V-11", items=[{"product_id": 1, "descuento": 5}]) == []
+
+
+def test_loyalty_respects_eligible_branch_table():
+    svc, db = _service(); rid = _active_raffle(db)
+    db.execute("INSERT INTO raffle_eligible_branches(raffle_id, sucursal_id) VALUES(?, 2)", (rid,))
+
+    assert _issue(svc, sucursal_id=1) == []
+    assert len(_issue(svc, sucursal_id=2, venta_id=12, folio_venta="V-12")) == 2
+
+
+def test_loyalty_respects_eligible_products_table():
+    svc, db = _service(); rid = _active_raffle(db)
+    db.execute("INSERT INTO raffle_eligible_products(raffle_id, product_id) VALUES(?, 7)", (rid,))
+
+    assert _issue(svc, items=[{"product_id": 3}]) == []
+    assert len(_issue(svc, venta_id=13, folio_venta="V-13", items=[{"product_id": 7}])) == 2

--- a/pos_spj_v13.4/tests/test_qss_no_box_shadow.py
+++ b/pos_spj_v13.4/tests/test_qss_no_box_shadow.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QT_QSS_DIRS = ("interfaz", "modulos", "ui", "presentation", "core")
+
+
+def _qt_style_sources():
+    for rel in QT_QSS_DIRS:
+        base = ROOT / rel
+        if not base.exists():
+            continue
+        yield from base.rglob("*.py")
+        yield from base.rglob("*.qss")
+
+
+def test_qt_qss_sources_do_not_use_unsupported_box_shadow():
+    offenders = []
+    for path in _qt_style_sources():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "box-shadow" in text:
+            offenders.append(str(path.relative_to(ROOT)))
+
+    assert offenders == [], "Qt/QSS no soporta box-shadow; usa QGraphicsDropShadowEffect: " + ", ".join(offenders)

--- a/pos_spj_v13.4/tests/test_sales_service_single_event_flow.py
+++ b/pos_spj_v13.4/tests/test_sales_service_single_event_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 from core.services.sales_service import SalesService
 
 
-def _build_service():
+def _build_service(printer_service=None, auto_print="1"):
     db = MagicMock()
     db.cursor.return_value = MagicMock()
 
@@ -20,6 +20,14 @@ def _build_service():
 
     finance = MagicMock()
 
+    def _config_get(key, default=None):
+        values = {
+            "ticket_template_html": "<html>{{folio}}</html>",
+            "raffle_ticket_print_auto": auto_print,
+            "imprimir_automatico_boletos_sorteo": auto_print,
+        }
+        return values.get(key, default)
+
     svc = SalesService(
         db_conn=db,
         sales_repo=sales_repo,
@@ -31,15 +39,23 @@ def _build_service():
         sync_service=None,
         ticket_template_engine=MagicMock(),
         whatsapp_service=MagicMock(),
-        config_service=MagicMock(get=MagicMock(return_value="<html>{{folio}}</html>")),
+        config_service=MagicMock(get=MagicMock(side_effect=_config_get)),
         feature_flag_service=MagicMock(),
         growth_engine=MagicMock(),
         notification_service=MagicMock(),
         customer_service=customer,
+        printer_service=printer_service,
     )
     svc._validate_stock_pre_sale = MagicMock()
     svc._resolve_sale_items = MagicMock(return_value=[])
     svc._comisiones_svc = MagicMock()
+    svc._loyalty_policy = MagicMock(return_value=None)
+
+    from core.events.domain_events import SALE_ITEMS_PROCESS
+    from core.events import event_bus
+    bus = event_bus.get_bus()
+    bus.subscribe(SALE_ITEMS_PROCESS, lambda payload: None, priority=100, label="sale_inventory_test")
+    bus.subscribe(SALE_ITEMS_PROCESS, lambda payload: None, priority=90, label="sale_finance_test")
     return svc, loyalty, finance
 
 
@@ -138,3 +154,119 @@ def test_sale_without_active_raffle_does_not_break_ticket_generation():
     args, _kwargs = svc.ticket_template_engine.generar_ticket.call_args
     datos_venta = args[1]
     assert datos_venta.get("raffle_tickets_snapshot") == []
+
+
+def test_sale_prints_raffle_ticket_when_raffle_active():
+    printer = MagicMock()
+    printer.print_raffle_ticket.return_value = "job-raffle-1"
+    svc, loyalty, _finance = _build_service(printer_service=printer)
+    ticket_payload = {
+        "ticket_type": "raffle_ticket",
+        "raffle_id": 1,
+        "raffle_name": "Navidad SPJ",
+        "numero_boleto": "1-10-1",
+        "folio_venta": "F-10",
+        "venta_id": 10,
+        "barcode": "1-10-1",
+    }
+    loyalty.process_raffles_for_sale.return_value = [
+        {"raffle": "Navidad SPJ", "numero_boleto": "1-10-1", "raffle_ticket": ticket_payload}
+    ]
+
+    folio, ticket = svc.execute_sale(
+        branch_id=1,
+        user="cajero",
+        items=[{"product_id": 1, "qty": 1, "unit_price": 100.0}],
+        payment_method="Efectivo",
+        amount_paid=100.0,
+        client_id=1,
+    )
+
+    assert folio == "F-10"
+    assert ticket is not None
+    printer.print_raffle_ticket.assert_called_once_with(ticket_payload)
+
+
+def test_sale_does_not_print_raffle_ticket_when_not_eligible():
+    printer = MagicMock()
+    svc, loyalty, _finance = _build_service(printer_service=printer)
+    loyalty.process_raffles_for_sale.return_value = []
+
+    svc.execute_sale(
+        branch_id=1,
+        user="cajero",
+        items=[{"product_id": 1, "qty": 1, "unit_price": 100.0}],
+        payment_method="Efectivo",
+        amount_paid=100.0,
+        client_id=1,
+    )
+
+    printer.print_raffle_ticket.assert_not_called()
+
+
+def test_sale_does_not_cancel_if_raffle_ticket_print_fails():
+    printer = MagicMock()
+    printer.print_raffle_ticket.side_effect = [RuntimeError("printer offline"), "job-raffle-2"]
+    svc, loyalty, _finance = _build_service(printer_service=printer)
+    first = {"ticket_type": "raffle_ticket", "numero_boleto": "1-10-1", "raffle_id": 1}
+    second = {"ticket_type": "raffle_ticket", "numero_boleto": "1-10-2", "raffle_id": 1}
+    loyalty.process_raffles_for_sale.return_value = [
+        {"raffle": "Navidad SPJ", "numero_boleto": "1-10-1", "raffle_ticket": first},
+        {"raffle": "Navidad SPJ", "numero_boleto": "1-10-2", "raffle_ticket": second},
+    ]
+
+    folio, ticket = svc.execute_sale(
+        branch_id=1,
+        user="cajero",
+        items=[{"product_id": 1, "qty": 1, "unit_price": 100.0}],
+        payment_method="Efectivo",
+        amount_paid=100.0,
+        client_id=1,
+    )
+
+    assert folio == "F-10"
+    assert ticket is not None
+    assert printer.print_raffle_ticket.call_count == 2
+
+
+def test_sale_does_not_duplicate_raffle_ticket_prints_when_retry_returns_existing_snapshot_once():
+    printer = MagicMock()
+    printer.print_raffle_ticket.return_value = "job-raffle-1"
+    svc, loyalty, _finance = _build_service(printer_service=printer)
+    payload = {"ticket_type": "raffle_ticket", "numero_boleto": "1-10-1", "raffle_id": 1}
+    loyalty.process_raffles_for_sale.side_effect = [
+        [{"raffle": "Navidad SPJ", "numero_boleto": "1-10-1", "raffle_ticket": payload}],
+        [],
+    ]
+
+    for _ in range(2):
+        svc.execute_sale(
+            branch_id=1,
+            user="cajero",
+            items=[{"product_id": 1, "qty": 1, "unit_price": 100.0}],
+            payment_method="Efectivo",
+            amount_paid=100.0,
+            client_id=1,
+        )
+
+    printer.print_raffle_ticket.assert_called_once_with(payload)
+
+
+def test_sale_respects_raffle_ticket_auto_print_config():
+    printer = MagicMock()
+    svc, loyalty, _finance = _build_service(printer_service=printer, auto_print="0")
+    payload = {"ticket_type": "raffle_ticket", "numero_boleto": "1-10-1", "raffle_id": 1}
+    loyalty.process_raffles_for_sale.return_value = [
+        {"raffle": "Navidad SPJ", "numero_boleto": "1-10-1", "raffle_ticket": payload}
+    ]
+
+    svc.execute_sale(
+        branch_id=1,
+        user="cajero",
+        items=[{"product_id": 1, "qty": 1, "unit_price": 100.0}],
+        payment_method="Efectivo",
+        amount_paid=100.0,
+        client_id=1,
+    )
+
+    printer.print_raffle_ticket.assert_not_called()

--- a/pos_spj_v13.4/tests/test_sales_stock_validation_regression.py
+++ b/pos_spj_v13.4/tests/test_sales_stock_validation_regression.py
@@ -1,0 +1,253 @@
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.events.domain_events import SALE_ITEMS_PROCESS
+from core.events.event_bus import get_bus
+from core.events.handlers.inventory_handler import SaleInventoryHandler
+from core.services.sales_fulfillment_service import SaleFulfillmentService
+from core.services.sales_service import SalesService
+
+
+class _SqlSalesRepo:
+    def __init__(self, db):
+        self.db = db
+
+    def create_sale(self, **kwargs):
+        cur = self.db.execute(
+            """
+            INSERT INTO ventas(folio, sucursal_id, usuario, cliente_id, subtotal, descuento, total, forma_pago)
+            VALUES(?,?,?,?,?,?,?,?)
+            """,
+            (
+                "F-STOCK-1",
+                kwargs.get("branch_id"),
+                kwargs.get("user"),
+                kwargs.get("client_id"),
+                kwargs.get("subtotal"),
+                kwargs.get("discount"),
+                kwargs.get("total"),
+                kwargs.get("payment_method"),
+            ),
+        )
+        return int(cur.lastrowid), "F-STOCK-1"
+
+    def save_sale_item(self, sale_id, product_id, qty, unit_price, subtotal):
+        self.db.execute(
+            "INSERT INTO detalles_venta(venta_id, producto_id, cantidad, precio_unitario, subtotal) VALUES(?,?,?,?,?)",
+            (sale_id, product_id, qty, unit_price, subtotal),
+        )
+
+
+def _db_with_basic_sales_schema(stock=10.0):
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE productos(id INTEGER PRIMARY KEY, nombre TEXT, existencia REAL, unidad TEXT)")
+    db.execute("INSERT INTO productos(id,nombre,existencia,unidad) VALUES(1,'Pollo',?, 'kg')", (stock,))
+    db.execute(
+        """
+        CREATE TABLE ventas(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            folio TEXT,
+            sucursal_id INTEGER,
+            usuario TEXT,
+            cliente_id INTEGER,
+            subtotal REAL,
+            descuento REAL,
+            total REAL,
+            forma_pago TEXT
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE detalles_venta(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            venta_id INTEGER,
+            producto_id INTEGER,
+            cantidad REAL,
+            precio_unitario REAL,
+            subtotal REAL
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE movimientos_caja(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            venta_id INTEGER,
+            monto REAL,
+            descripcion TEXT
+        )
+        """
+    )
+    return db
+
+
+def _build_sales_service(db):
+    config = MagicMock()
+    config.get.side_effect = lambda key, default=None: "<html>{{folio}}</html>" if key == "ticket_template_html" else default
+    ticket_engine = MagicMock()
+    ticket_engine.generar_ticket.return_value = "<html>F-STOCK-1</html>"
+    loyalty = MagicMock()
+    loyalty.compute_redemption_discount.return_value = 0.0
+    loyalty.process_raffles_for_sale.return_value = []
+    customer = MagicMock()
+    customer.get_customer.return_value = {"id": 1}
+    customer.validate_credit.return_value = (True, "")
+    svc = SalesService(
+        db_conn=db,
+        sales_repo=_SqlSalesRepo(db),
+        recipe_repo=MagicMock(),
+        inventory_service=MagicMock(),
+        finance_service=MagicMock(),
+        loyalty_service=loyalty,
+        promotion_engine=None,
+        sync_service=None,
+        ticket_template_engine=ticket_engine,
+        whatsapp_service=MagicMock(),
+        config_service=config,
+        feature_flag_service=MagicMock(),
+        growth_engine=MagicMock(),
+        notification_service=MagicMock(),
+        customer_service=customer,
+    )
+    svc._lote_svc = None
+    svc._loyalty_policy = MagicMock(return_value=None)
+    svc._resolve_sale_items = MagicMock(
+        return_value=[{"product_id": 1, "qty": 1.0, "cantidad": 1.0, "unit_price": 10.0, "es_compuesto": 0}]
+    )
+    return svc
+
+
+class _BusSnapshot:
+    def __init__(self):
+        self.bus = get_bus()
+        self.handlers = {k: list(v) for k, v in getattr(self.bus, "_handlers", {}).items()}
+
+    def restore(self):
+        self.bus.clear_handlers()
+        for event, handlers in self.handlers.items():
+            for priority, label, handler in handlers:
+                self.bus.subscribe(event, handler, priority=priority, label=label)
+
+
+def test_prevalidate_stock_fails_before_event_when_insufficient():
+    db = _db_with_basic_sales_schema(stock=0.25)
+    svc = _build_sales_service(db)
+    snapshot = _BusSnapshot()
+    published = []
+    try:
+        get_bus().clear_handlers(SALE_ITEMS_PROCESS)
+        get_bus().subscribe(SALE_ITEMS_PROCESS, lambda payload: published.append(payload), priority=100, label="sale_inventory_test")
+        get_bus().subscribe(SALE_ITEMS_PROCESS, lambda payload: None, priority=90, label="sale_finance_test")
+
+        with pytest.raises(RuntimeError, match="STOCK_INSUFICIENTE"):
+            svc.execute_sale(
+                branch_id=1,
+                user="cajero",
+                items=[{"product_id": 1, "qty": 1, "unit_price": 10}],
+                payment_method="Efectivo",
+                amount_paid=10,
+                client_id=1,
+            )
+
+        assert published == []
+        assert db.execute("SELECT COUNT(*) FROM ventas").fetchone()[0] == 0
+    finally:
+        snapshot.restore()
+
+
+def test_prevalidate_stock_uses_existing_schema_only():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    # Minimal old schema: no tipo_producto/es_compuesto/es_subproducto columns.
+    db.execute("CREATE TABLE productos(id INTEGER PRIMARY KEY, nombre TEXT, existencia REAL, unidad TEXT)")
+    db.execute("INSERT INTO productos(id,nombre,existencia,unidad) VALUES(1,'Pollo',5,'kg')")
+
+    lines = SaleFulfillmentService(db).resolve_item(1, 2, 1)
+
+    assert len(lines) == 1
+    assert lines[0].product_id == 1
+    assert lines[0].qty == 2
+
+
+def test_prevalidate_stock_handles_recipe_schema_without_cantidad_column():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE productos(id INTEGER PRIMARY KEY, nombre TEXT, existencia REAL, unidad TEXT, tipo_producto TEXT)"
+    )
+    db.execute("INSERT INTO productos(id,nombre,existencia,unidad,tipo_producto) VALUES(1,'Milanesa',0,'kg','procesable')")
+    db.execute("INSERT INTO productos(id,nombre,existencia,unidad,tipo_producto) VALUES(2,'Pechuga',10,'kg','simple')")
+    db.execute("CREATE TABLE product_recipes(id INTEGER PRIMARY KEY, base_product_id INTEGER, is_active INTEGER)")
+    db.execute("CREATE TABLE product_recipe_components(recipe_id INTEGER, component_product_id INTEGER, quantity REAL)")
+    db.execute("INSERT INTO product_recipes(id,base_product_id,is_active) VALUES(7,1,1)")
+    db.execute("INSERT INTO product_recipe_components(recipe_id,component_product_id,quantity) VALUES(7,2,2.0)")
+
+    lines = SaleFulfillmentService(db).resolve_item(1, 2, 1)
+
+    assert len(lines) == 1
+    assert lines[0].product_id == 2
+    assert lines[0].qty == 4.0
+    assert lines[0].mode == "VIRTUAL_FROM_COMPONENTS"
+
+
+def test_inventory_handler_still_blocks_if_stock_changes_after_prevalidation():
+    db = _db_with_basic_sales_schema(stock=2.0)
+    SaleFulfillmentService(db).resolve_item(1, 1, 1)
+
+    class RaceAwareInventory:
+        def __init__(self):
+            self.stock = 0.0
+
+        def deduct_stock(self, product_id, branch_id, qty, **kwargs):
+            if self.stock < float(qty):
+                raise RuntimeError("Stock insuficiente después de prevalidación")
+            self.stock -= float(qty)
+
+    inv = RaceAwareInventory()
+    handler = SaleInventoryHandler(inv, db=db)
+
+    with pytest.raises(RuntimeError, match="Stock insuficiente después de prevalidación"):
+        handler.handle({"branch_id": 1, "sale_id": 10, "folio": "F10", "items": [{"product_id": 1, "qty": 1}]})
+
+    assert inv.stock == 0.0
+
+
+def test_sale_rollback_keeps_cash_and_inventory_intact():
+    db = _db_with_basic_sales_schema(stock=5.0)
+    svc = _build_sales_service(db)
+    snapshot = _BusSnapshot()
+    try:
+        get_bus().clear_handlers(SALE_ITEMS_PROCESS)
+
+        def _inventory_race(payload):
+            raise RuntimeError("Inventario cambió antes del commit")
+
+        def _finance_should_not_run(payload):
+            db.execute(
+                "INSERT INTO movimientos_caja(venta_id,monto,descripcion) VALUES(?,?,?)",
+                (payload.get("sale_id"), payload.get("total"), "NO_DEBE_EJECUTARSE"),
+            )
+
+        get_bus().subscribe(SALE_ITEMS_PROCESS, _inventory_race, priority=100, label="sale_inventory_race_guard")
+        get_bus().subscribe(SALE_ITEMS_PROCESS, _finance_should_not_run, priority=90, label="sale_finance_test")
+
+        with pytest.raises(RuntimeError, match="inventario y caja están intactos"):
+            svc.execute_sale(
+                branch_id=1,
+                user="cajero",
+                items=[{"product_id": 1, "qty": 1, "unit_price": 10}],
+                payment_method="Efectivo",
+                amount_paid=10,
+                client_id=1,
+            )
+
+        assert db.execute("SELECT COUNT(*) FROM ventas").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM detalles_venta").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM movimientos_caja").fetchone()[0] == 0
+        assert db.execute("SELECT existencia FROM productos WHERE id=1").fetchone()[0] == 5.0
+    finally:
+        snapshot.restore()

--- a/pos_spj_v13.4/tests/test_ticket_designer_raffle_layout_contract.py
+++ b/pos_spj_v13.4/tests/test_ticket_designer_raffle_layout_contract.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _src():
+    return (ROOT / "modulos" / "ticket_designer.py").read_text(encoding="utf-8")
+
+
+def test_ticket_design_can_save_sale_ticket_layout():
+    src = _src()
+    assert '"sale_ticket"' in src
+    assert 'save(cfg, layout_type=layout_type)' in src
+
+
+def test_ticket_design_can_save_raffle_ticket_layout():
+    src = _src()
+    assert '"raffle_ticket"' in src
+    assert 'Boleto de sorteo' in src
+    assert 'raffle_ticket_template_html' in src
+
+
+def test_ticket_design_does_not_mix_sale_and_raffle_blocks():
+    src = _src()
+    assert 'RAFFLE_BLOCK_ORDER if layout_type == "raffle_ticket" else DEFAULT_BLOCK_ORDER' in src
+    assert 'cfg.show_loyalty = False; cfg.show_fomo = False' in src
+    assert 'SALE_ONLY_BLOCKS = {"items", "totals", "payment", "loyalty", "fomo"}' in src
+    assert 'RAFFLE_ONLY_BLOCKS = {"raffle_title", "ticket_number", "prize", "draw_date"}' in src
+
+
+def test_ticket_design_loads_active_layout_by_type():
+    src = _src()
+    assert 'load(layout_type=self.current_layout_type)' in src
+    assert 'self._on_layout_type_changed' in src
+
+
+def test_ticket_design_exposes_raffle_blocks_and_footer_legal_controls():
+    src = _src()
+    for token in [
+        '"raffle_title"',
+        '"ticket_number"',
+        '"prize"',
+        '"draw_date"',
+        'self.txt_footer_message',
+        'self.txt_legal_message',
+        'Bloques ESC/POS:',
+    ]:
+        assert token in src
+
+
+def test_ticket_design_sample_print_uses_raffle_printer_for_raffle_layout():
+    src = _src()
+    start = src.index('def _imprimir_muestra')
+    fn = src[start:]
+    assert 'self.current_layout_type == "raffle_ticket"' in fn
+    assert 'printer_svc.print_raffle_ticket(sample_ticket)' in fn
+    assert 'printer_svc.print_ticket(sample_ticket)' in fn

--- a/pos_spj_v13.4/tests/test_ticket_designer_ui_contract.py
+++ b/pos_spj_v13.4/tests/test_ticket_designer_ui_contract.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 
 
+ROOT = Path(__file__).resolve().parents[1]
+
+
 def _read(rel):
-    return Path(rel).read_text(encoding='utf-8')
+    return (ROOT / rel).read_text(encoding='utf-8')
 
 
 def test_print_sample_calls_printer_service_not_qprinter():
@@ -10,6 +13,7 @@ def test_print_sample_calls_printer_service_not_qprinter():
     start = src.index('def _imprimir_muestra')
     fn = src[start:]
     assert 'printer_svc.print_ticket(' in fn
+    assert 'printer_svc.print_raffle_ticket(' in fn
     assert 'QPrinter' not in fn
 
 
@@ -30,3 +34,10 @@ def test_ui_warns_html_is_preview_only_and_has_escpos_preview():
 def test_branding_message_uses_system_config_source():
     src = _read('modulos/ticket_designer.py')
     assert 'Usa logo de Configuración del Sistema como fuente principal.' in src
+
+
+def test_raffle_layout_disables_sale_only_tabs_and_uses_raffle_preview_renderer():
+    src = _read('modulos/ticket_designer.py')
+    assert '_set_sale_only_tabs_enabled(not is_raffle)' in src
+    assert 'RaffleTicketESCPOSRenderer' in src
+    assert 'Número de boleto' in src

--- a/pos_spj_v13.4/tests/test_ticket_escpos_renderer.py
+++ b/pos_spj_v13.4/tests/test_ticket_escpos_renderer.py
@@ -57,3 +57,13 @@ def test_long_names_wrapped_in_preview():
     r = TicketESCPOSRenderer()
     p = r.render_text_preview(_sample())
     assert "extremadamente" in p
+
+
+def test_renderer_prints_barcode_from_compact_layout_config():
+    r = TicketESCPOSRenderer()
+    data = {
+        "folio": "V-COMPACT-1",
+        "layout_config": {"show_logo": False, "show_qr": False, "show_barcode": True},
+    }
+    out = r.render(data)
+    assert b"\x1dv0" in out

--- a/pos_spj_v13.4/tests/test_ticket_layout_config.py
+++ b/pos_spj_v13.4/tests/test_ticket_layout_config.py
@@ -45,3 +45,33 @@ def test_legacy_migration_keys():
     assert cfg.logo_alignment == "right"
     assert cfg.show_qr is True
     assert cfg.show_barcode is False
+
+
+def test_partial_layout_show_barcode_enables_barcode_block():
+    cfg = TicketLayoutConfig.from_dict({"show_barcode": True})
+    assert cfg.show_barcode is True
+    assert cfg.blocks["barcode"].enabled is True
+
+
+def test_partial_layout_show_qr_false_disables_qr_block():
+    cfg = TicketLayoutConfig.from_dict({"show_qr": False})
+    assert cfg.show_qr is False
+    assert cfg.blocks["qr"].enabled is False
+
+
+def test_from_dict_missing_barcode_block_inherits_show_barcode_flag():
+    cfg = TicketLayoutConfig.from_dict({
+        "show_barcode": True,
+        "blocks": {"items": {"enabled": True, "order": 4}},
+    })
+
+    assert cfg.blocks["barcode"].enabled is True
+
+
+def test_from_dict_missing_barcode_block_inherits_show_barcode_false():
+    cfg = TicketLayoutConfig.from_dict({
+        "show_barcode": False,
+        "blocks": {"items": {"enabled": True, "order": 4}},
+    })
+
+    assert cfg.blocks["barcode"].enabled is False

--- a/pos_spj_v13.4/tests/test_ticket_layout_repository_regression.py
+++ b/pos_spj_v13.4/tests/test_ticket_layout_repository_regression.py
@@ -1,0 +1,66 @@
+import json
+import sqlite3
+
+from core.tickets.ticket_layout_config import TicketLayoutConfig, TicketLayoutBlock, RAFFLE_BLOCK_ORDER
+from core.tickets.ticket_layout_repository import TicketLayoutRepository
+
+
+def _db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE configuraciones(clave TEXT PRIMARY KEY, valor TEXT)")
+    return conn
+
+
+def test_ticket_layout_repository_loads_active_ticket_layouts_sale_ticket():
+    db = _db()
+    repo = TicketLayoutRepository(db_conn=db)
+    repo.ensure_schema()
+    inactive = TicketLayoutConfig(show_qr=False)
+    active = TicketLayoutConfig(show_qr=True, show_barcode=True)
+    db.execute("INSERT INTO ticket_layouts(layout_type,nombre,config_json,activo) VALUES(?,?,?,0)", ("sale_ticket", "old", json.dumps(inactive.to_dict())))
+    db.execute("INSERT INTO ticket_layouts(layout_type,nombre,config_json,activo) VALUES(?,?,?,1)", ("sale_ticket", "active", json.dumps(active.to_dict())))
+    loaded = repo.load(layout_type="sale_ticket")
+    assert loaded.show_qr is True
+    assert loaded.show_barcode is True
+
+
+def test_ticket_layout_repository_falls_back_to_configuraciones():
+    db = _db()
+    cfg = TicketLayoutConfig(paper_width_mm=58, show_qr=True)
+    db.execute("INSERT INTO configuraciones(clave,valor) VALUES('ticket_layout_config',?)", (json.dumps(cfg.to_dict()),))
+    loaded = TicketLayoutRepository(db_conn=db).load(layout_type="sale_ticket")
+    assert loaded.paper_width_mm == 58
+    assert loaded.show_qr is True
+
+
+def test_ticket_layout_repository_falls_back_to_legacy():
+    db = _db()
+    db.executemany("INSERT INTO configuraciones(clave,valor) VALUES(?,?)", [
+        ("ticket_paper_width", "58"), ("ticket_logo_pos", "Derecha"), ("ticket_qr_enabled", "1"), ("ticket_bc_enabled", "1")
+    ])
+    loaded = TicketLayoutRepository(db_conn=db).load(layout_type="sale_ticket")
+    assert loaded.paper_width_mm == 58
+    assert loaded.logo_alignment == "right"
+    assert loaded.show_barcode is True
+
+
+def test_ticket_layout_repository_supports_raffle_ticket():
+    db = _db()
+    loaded = TicketLayoutRepository(db_conn=db).load(layout_type="raffle_ticket")
+    assert loaded.block_order == RAFFLE_BLOCK_ORDER
+    assert loaded.show_barcode is True
+    assert "ticket_number" in loaded.blocks
+
+
+def test_ticket_layout_repository_save_activates_one_layout_per_type():
+    db = _db()
+    repo = TicketLayoutRepository(db_conn=db)
+    repo.save(TicketLayoutConfig(show_qr=False), layout_type="sale_ticket")
+    repo.save(TicketLayoutConfig(show_qr=True), layout_type="sale_ticket")
+    repo.save(TicketLayoutConfig.for_layout_type("raffle_ticket"), layout_type="raffle_ticket")
+    sale_active = db.execute("SELECT COUNT(*) FROM ticket_layouts WHERE layout_type='sale_ticket' AND activo=1").fetchone()[0]
+    raffle_active = db.execute("SELECT COUNT(*) FROM ticket_layouts WHERE layout_type='raffle_ticket' AND activo=1").fetchone()[0]
+    assert sale_active == 1
+    assert raffle_active == 1
+    assert repo.load("sale_ticket").show_qr is True

--- a/pos_spj_v13.4/tests/test_ticket_rendering_regression.py
+++ b/pos_spj_v13.4/tests/test_ticket_rendering_regression.py
@@ -1,0 +1,379 @@
+import base64
+import io
+import os
+import sqlite3
+
+from PIL import Image
+
+from core.ticket_escpos_renderer import ALIGN_CENTER, ALIGN_RIGHT, GS, INIT, TicketESCPOSRenderer
+from core.tickets.ticket_layout_config import TicketLayoutBlock, TicketLayoutConfig
+from core.tickets.raffle_ticket_renderer import RaffleTicketESCPOSRenderer
+from core.services.printer_service import PrinterService
+
+
+def test_renderer_respects_block_order():
+    cfg = TicketLayoutConfig(block_order=["totals", "items", "footer"], show_qr=False, show_barcode=False)
+    cfg.blocks = {name: TicketLayoutBlock(enabled=True, order=i) for i, name in enumerate(cfg.block_order)}
+    data = {"items": [{"nombre": "A", "cantidad": 1, "total": 2}], "totales": {"total_final": 2}, "layout_config": cfg.to_dict()}
+    text = TicketESCPOSRenderer().render(data).decode("cp850", errors="ignore")
+    assert text.index("TOTAL") < text.index("PRODUCTO")
+
+
+def test_renderer_skips_disabled_blocks():
+    cfg = TicketLayoutConfig(show_qr=False, show_barcode=False)
+    cfg.blocks["items"].enabled = False
+    data = {"items": [{"nombre": "NO_DEBE_SALIR", "cantidad": 1, "total": 2}], "totales": {"total_final": 2}, "layout_config": cfg.to_dict()}
+    text = TicketESCPOSRenderer().render(data).decode("cp850", errors="ignore")
+    assert "NO_DEBE_SALIR" not in text
+    assert "TOTAL" in text
+
+
+def test_renderer_prints_barcode_when_enabled():
+    cfg = TicketLayoutConfig(show_barcode=True)
+    cfg.blocks["barcode"].enabled = True
+    data = {"folio": "V-123", "layout_config": cfg.to_dict()}
+    assert GS + b"v0" in TicketESCPOSRenderer().render(data)
+
+
+def test_renderer_does_not_print_barcode_when_disabled():
+    cfg = TicketLayoutConfig(show_barcode=False)
+    cfg.blocks["barcode"].enabled = True
+    data = {"folio": "V-123", "layout_config": cfg.to_dict()}
+    assert GS + b"v0" not in TicketESCPOSRenderer().render(data)
+
+
+def test_barcode_block_uses_folio_when_no_barcode():
+    cfg = TicketLayoutConfig(show_barcode=True)
+    cfg.blocks["barcode"].enabled = True
+    assert TicketESCPOSRenderer()._barcode_bytes({"folio": "V-123"}, 32)
+
+
+def test_barcode_block_uses_codigo_barras_when_present():
+    assert TicketESCPOSRenderer()._barcode_bytes({"codigo_barras": "ABC123"}, 32)
+
+
+def test_barcode_not_rendered_when_show_barcode_false():
+    cfg = TicketLayoutConfig(show_barcode=False)
+    cfg.blocks["barcode"].enabled = True
+    assert GS + b"v0" not in TicketESCPOSRenderer().render({"folio": "A", "layout_config": cfg.to_dict()})
+
+
+def test_barcode_not_rendered_when_block_disabled():
+    cfg = TicketLayoutConfig(show_barcode=True)
+    cfg.blocks["barcode"].enabled = False
+    assert GS + b"v0" not in TicketESCPOSRenderer().render({"folio": "A", "layout_config": cfg.to_dict()})
+
+
+def test_renderer_prints_barcode_when_block_missing_but_show_barcode_enabled():
+    data = {
+        "folio": "V-MISSING-BLOCK",
+        "layout_config": {
+            "show_logo": False,
+            "show_qr": False,
+            "show_barcode": True,
+            "blocks": {"items": {"enabled": True, "order": 4}},
+        },
+    }
+
+    assert GS + b"v0" in TicketESCPOSRenderer().render(data)
+
+
+def test_barcode_value_prefers_barcode_then_codigo_barras_then_folio():
+    renderer = TicketESCPOSRenderer()
+
+    assert renderer._barcode_value({"barcode": "BAR", "codigo_barras": "COD", "folio": "FOL"}) == "BAR"
+    assert renderer._barcode_value({"codigo_barras": "COD", "folio": "FOL"}) == "COD"
+    assert renderer._barcode_value({"folio": "FOL"}) == "FOL"
+
+
+def test_barcode_raster_resets_printer_after_image():
+    cfg = TicketLayoutConfig(show_barcode=True)
+    cfg.blocks["barcode"].enabled = True
+    out = TicketESCPOSRenderer().render({"folio": "V-RESET", "layout_config": cfg.to_dict()})
+
+    assert GS + b"v0" in out
+    assert INIT in out[out.index(GS + b"v0"):]
+
+def test_renderer_respects_logo_size_and_alignment():
+    img = Image.new("RGBA", (10, 10), (0, 0, 0, 255))
+    buf = io.BytesIO(); img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    cfg = TicketLayoutConfig(logo_size="sm", logo_alignment="right", block_order=["logo"])
+    cfg.blocks = {"logo": TicketLayoutBlock(enabled=True, order=0)}
+    out = TicketESCPOSRenderer(paper_width_mm=58).render({"layout_config": cfg.to_dict()}, logo_b64=b64)
+    assert ALIGN_RIGHT in out
+    assert GS + b"v0" in out
+
+
+def test_transparent_logo_background_becomes_white():
+    img = Image.new("RGBA", (8, 8), (0, 0, 0, 0))
+    img.putpixel((3, 3), (0, 0, 0, 255))
+    buf = io.BytesIO(); img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    out = TicketESCPOSRenderer()._render_logo(b64, "md")
+    assert out is not None
+    # Raster header is 8 bytes; one black pixel should not turn whole transparent background black.
+    payload = out[8:]
+    assert payload.count(b"\xff") > payload.count(b"\x00")
+
+
+def test_logo_data_uri_transparent_background_becomes_white():
+    img = Image.new("RGBA", (8, 1), (0, 0, 0, 0))
+    img.putpixel((0, 0), (0, 0, 0, 255))
+    buf = io.BytesIO(); img.save(buf, format="PNG")
+    data_uri = "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+    out = TicketESCPOSRenderer()._render_logo(data_uri, "md")
+
+    assert out is not None
+    assert out[8:] == bytes([0b01111111])
+
+
+def test_logo_partial_alpha_antialias_does_not_create_black_background():
+    img = Image.new("RGBA", (8, 1), (0, 0, 0, 0))
+    img.putpixel((0, 0), (0, 0, 0, 255))
+    img.putpixel((1, 0), (0, 0, 0, 64))
+    buf = io.BytesIO(); img.save(buf, format="PNG")
+
+    out = TicketESCPOSRenderer()._render_logo(base64.b64encode(buf.getvalue()).decode(), "md")
+
+    assert out is not None
+    assert out[8:] == bytes([0b01111111])
+
+
+def test_logo_alpha_diagnostic_enabled_by_layout_config(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    img = Image.new("RGBA", (8, 8), (0, 0, 0, 0))
+    buf = io.BytesIO(); img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    cfg = TicketLayoutConfig(block_order=["logo"], ticket_debug_logo=True)
+    cfg.blocks = {"logo": TicketLayoutBlock(enabled=True, order=0)}
+
+    TicketESCPOSRenderer().render({"layout_config": cfg.to_dict()}, logo_b64=b64)
+
+    assert (tmp_path / "logs" / "ticket_logo_input.png").exists()
+    assert (tmp_path / "logs" / "ticket_logo_processed.png").exists()
+    info = (tmp_path / "logs" / "ticket_logo_info.json").read_text(encoding="utf-8")
+    assert '"had_alpha": true' in info
+
+def test_logo_render_does_not_raise_on_invalid_base64():
+    assert TicketESCPOSRenderer()._render_logo("not base64", "md") is None
+
+
+def test_logo_size_md_for_58mm():
+    img = Image.new("RGBA", (1000, 500), (0, 0, 0, 255))
+    buf = io.BytesIO(); img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    out = TicketESCPOSRenderer(paper_width_mm=58)._render_logo(b64, "md")
+    width_bytes = int.from_bytes(out[4:6], "little")
+    height = int.from_bytes(out[6:8], "little")
+    assert width_bytes * 8 <= 320
+    assert height <= 140
+
+
+def test_logo_alpha_diagnostic_disabled_by_default(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    img = Image.new("RGBA", (8, 8), (0, 0, 0, 0))
+    buf = io.BytesIO(); img.save(buf, format="PNG")
+    TicketESCPOSRenderer()._render_logo(base64.b64encode(buf.getvalue()).decode(), "md")
+    assert not (tmp_path / "logs" / "ticket_logo_processed.png").exists()
+
+
+def _product_db(with_unit=True):
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    unit_col = ", unidad TEXT" if with_unit else ""
+    db.execute(f"CREATE TABLE productos(id INTEGER PRIMARY KEY, nombre TEXT{unit_col})")
+    if with_unit:
+        db.execute("INSERT INTO productos(id,nombre,unidad) VALUES(1,'Azucar','kg')")
+    else:
+        db.execute("INSERT INTO productos(id,nombre) VALUES(1,'Azucar')")
+    return db
+
+
+def test_ticket_item_uses_product_unit_when_payload_is_pza():
+    svc = PrinterService(db_conn=_product_db()); svc.queue.stop()
+    assert svc._hydrate_ticket_items([{"product_id": 1, "unidad": "pza"}])[0]["unidad"] == "kg"
+
+
+def test_ticket_item_uses_product_unit_when_payload_is_pz():
+    svc = PrinterService(db_conn=_product_db()); svc.queue.stop()
+    assert svc._hydrate_ticket_items([{"product_id": 1, "unidad": "pz"}])[0]["unidad"] == "kg"
+
+
+def test_ticket_item_preserves_specific_payload_unit_if_no_db_unit():
+    svc = PrinterService(db_conn=_product_db(with_unit=False)); svc.queue.stop()
+    assert svc._hydrate_ticket_items([{"product_id": 1, "unidad": "caja"}])[0]["unidad"] == "caja"
+
+
+def test_ticket_item_does_not_crash_without_product_id():
+    svc = PrinterService(db_conn=_product_db()); svc.queue.stop()
+    assert svc._hydrate_ticket_items([{"nombre": "Libre", "unidad": "pza"}])[0]["nombre"] == "Libre"
+
+
+def test_ticket_item_hydrates_product_name_and_unit_from_db():
+    svc = PrinterService(db_conn=_product_db()); svc.queue.stop()
+    item = svc._hydrate_ticket_items([{"product_id": 1, "unidad": "pza"}])[0]
+    assert item["nombre"] == "Azucar"
+    assert item["unidad"] == "kg"
+    assert item["db_unidad"] == "kg"
+
+
+def test_ticket_item_does_not_treat_sale_detail_id_as_product_id():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE productos(id INTEGER PRIMARY KEY, nombre TEXT, unidad TEXT)")
+    db.execute("INSERT INTO productos(id,nombre,unidad) VALUES(99,'No debe usarse','kg')")
+    svc = PrinterService(db_conn=db); svc.queue.stop()
+
+    item = svc._hydrate_ticket_items([{
+        "id": 99,
+        "venta_id": 10,
+        "nombre": "Linea libre",
+        "unidad": "pza",
+    }])[0]
+
+    assert item["product_id"] == 0
+    assert item["nombre"] == "Linea libre"
+    assert item["unidad"] == "pza"
+    assert item["db_unidad"] == ""
+
+
+def test_ticket_item_hydrates_product_unit_by_barcode_when_product_id_missing():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE productos(id INTEGER PRIMARY KEY, nombre TEXT, unidad TEXT, codigo_barras TEXT)")
+    db.execute("INSERT INTO productos(id,nombre,unidad,codigo_barras) VALUES(7,'Pollo a granel','kg','750001')")
+    svc = PrinterService(db_conn=db); svc.queue.stop()
+
+    item = svc._hydrate_ticket_items([{
+        "barcode": "750001",
+        "unidad": "PZA.",
+    }])[0]
+
+    assert item["product_id"] == 7
+    assert item["producto_id"] == 7
+    assert item["nombre"] == "Pollo a granel"
+    assert item["unidad"] == "kg"
+    assert item["unidad_producto"] == "kg"
+
+
+def test_raffle_ticket_renderer_respects_block_order():
+    cfg = TicketLayoutConfig.for_layout_type("raffle_ticket")
+    cfg.block_order = ["ticket_number", "raffle_title"]
+    cfg.blocks = {name: TicketLayoutBlock(enabled=True, order=i) for i, name in enumerate(cfg.block_order)}
+    text = RaffleTicketESCPOSRenderer().render({"raffle_name": "Gran Sorteo", "numero_boleto": "1-2-1", "layout_config": cfg.to_dict()}).decode("cp850", errors="ignore")
+    assert text.index("1-2-1") < text.index("Gran Sorteo")
+
+
+def test_raffle_ticket_renderer_prints_ticket_number():
+    text = RaffleTicketESCPOSRenderer().render({"numero_boleto": "1-2-1", "layout_config": TicketLayoutConfig.for_layout_type("raffle_ticket").to_dict()}).decode("cp850", errors="ignore")
+    assert "1-2-1" in text
+
+
+def test_raffle_ticket_renderer_prints_barcode_when_enabled():
+    cfg = TicketLayoutConfig.for_layout_type("raffle_ticket")
+    assert GS + b"v0" in RaffleTicketESCPOSRenderer().render({"numero_boleto": "1-2-1", "layout_config": cfg.to_dict()})
+
+
+def test_raffle_ticket_renderer_prints_qr_when_enabled():
+    cfg = TicketLayoutConfig.for_layout_type("raffle_ticket")
+    assert GS + b"v0" in RaffleTicketESCPOSRenderer().render({"numero_boleto": "1-2-1", "qr_content": "QR", "layout_config": cfg.to_dict()})
+
+
+def test_raffle_ticket_renderer_defaults_to_raffle_layout_without_layout_config():
+    text = RaffleTicketESCPOSRenderer().render({"numero_boleto": "1-2-1", "raffle_name": "Sorteo"}).decode("cp850", errors="ignore")
+
+    assert "BOLETO" in text
+    assert "1-2-1" in text
+    assert "Sorteo" in text
+
+
+def test_raffle_ticket_renderer_compact_config_keeps_raffle_blocks():
+    text = RaffleTicketESCPOSRenderer().render({
+        "numero_boleto": "1-2-1",
+        "layout_config": {"show_qr": False, "show_barcode": False},
+    }).decode("cp850", errors="ignore")
+
+    assert "BOLETO" in text
+    assert "1-2-1" in text
+
+
+def test_raffle_ticket_renderer_does_not_print_disabled_blocks():
+    cfg = TicketLayoutConfig.for_layout_type("raffle_ticket")
+    cfg.blocks["ticket_number"].enabled = False
+    text = RaffleTicketESCPOSRenderer().render({"numero_boleto": "1-2-1", "layout_config": cfg.to_dict()}).decode("cp850", errors="ignore")
+    assert "1-2-1" not in text
+
+
+def test_printer_service_injects_ticket_debug_logo_config():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE configuraciones(clave TEXT PRIMARY KEY, valor TEXT)")
+    db.execute("INSERT INTO configuraciones(clave, valor) VALUES('ticket_debug_logo', '1')")
+    svc = PrinterService(db_conn=db); svc.queue.stop()
+
+    prepared, _, _ = svc._prepare_ticket_data({"items": []})
+
+    assert prepared["layout_config"]["ticket_debug_logo"] is True
+
+
+def test_printer_service_injects_active_sale_ticket_layout():
+    db = sqlite3.connect(":memory:"); db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE configuraciones(clave TEXT PRIMARY KEY, valor TEXT)")
+    cfg = TicketLayoutConfig(show_barcode=True)
+    cfg.blocks["barcode"].enabled = True
+    from core.tickets.ticket_layout_repository import TicketLayoutRepository
+    TicketLayoutRepository(db_conn=db).save(cfg, layout_type="sale_ticket")
+    svc = PrinterService(db_conn=db); svc.queue.stop()
+    prepared, _, _ = svc._prepare_ticket_data({"folio": "V-1", "items": []})
+    assert prepared["layout_config"]["show_barcode"] is True
+
+
+def test_print_raffle_ticket_uses_raw_renderer_even_in_text_diagnostic_mode(monkeypatch, tmp_path):
+    db = sqlite3.connect(":memory:"); db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE configuraciones(clave TEXT PRIMARY KEY, valor TEXT)")
+    svc = PrinterService(db_conn=db)
+    svc._ticket_cfg = {
+        "ubicacion": str(tmp_path / "raffle.prn"),
+        "transport": "file",
+        "encoding": "cp850",
+        "print_logo": False,
+        "print_qr": True,
+        "escpos_mode": "text_diagnostic",
+    }
+    monkeypatch.setattr(svc, "validate_ticket_printer_config", lambda: type("VR", (), {"ok": True, "errors": []})())
+
+    job_id = svc.print_raffle_ticket({"numero_boleto": "1-2-1"})
+
+    try:
+        assert job_id
+        _, _, job = svc.queue._queue.get_nowait()
+        assert job.job_type.value == "raffle_ticket"
+        assert job.data.startswith(INIT)
+        assert GS + b"v0" in job.data
+        assert job.raw_data["qr_content"] == "1-2-1"
+        assert job.raw_data["barcode"] == "1-2-1"
+    finally:
+        svc.queue.stop()
+
+
+def test_print_raffle_ticket_loads_raffle_layout(monkeypatch, tmp_path):
+    db = sqlite3.connect(":memory:"); db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE configuraciones(clave TEXT PRIMARY KEY, valor TEXT)")
+    cfg = TicketLayoutConfig.for_layout_type("raffle_ticket")
+    cfg.show_barcode = False
+    cfg.blocks["barcode"].enabled = False
+    from core.tickets.ticket_layout_repository import TicketLayoutRepository
+    TicketLayoutRepository(db_conn=db).save(cfg, layout_type="raffle_ticket")
+    svc = PrinterService(db_conn=db)
+    svc._ticket_cfg = {"ubicacion": str(tmp_path / "out.prn"), "transport": "file", "encoding": "cp850", "print_logo": True, "print_qr": True}
+    monkeypatch.setattr(svc, "validate_ticket_printer_config", lambda: type("VR", (), {"ok": True, "errors": []})())
+    job_id = svc.print_raffle_ticket({"numero_boleto": "1-2-1"})
+    try:
+        assert job_id
+        _, _, job = svc.queue._queue.get_nowait()
+        assert job.job_type.value == "raffle_ticket"
+        assert job.raw_data["layout_config"]["show_barcode"] is False
+    finally:
+        svc.queue.stop()


### PR DESCRIPTION
### Motivation
- Introduce first-class support for raffle (sorteo) tickets: issuance rules, printable payloads and on-sale printing.  
- Harden ticket rendering and layout handling to support multiple layout types (sale vs raffle) and legacy DB schemas.  
- Improve ticket hydration (product names/units) and logo rendering for reliable ESC/POS output on varied environments.  
- Expose designer UI controls to create and persist raffle-specific layouts and avoid QSS misuse (box-shadow).  

### Description
- Loyalty and raffle: `LoyaltyService` now evaluates more eligibility rules (discount exclusion, branch/product tables, normalized payment methods), issues idempotent raffle tickets via `issue_raffle_tickets_for_sale`, and builds printable payloads; `LoyaltyRepository` supports `ticket_count` in generation, `get_tickets_for_sale`, and active-raffle lookups that consider eligible branches.  
- Printing and layouts: `PrinterService` gained `print_raffle_ticket`, layout-aware loading via `TicketLayoutRepository`, improved item hydration (product id heuristics, unit selection), and injects debug logo flag into layout config.  
- Renderers: `TicketESCPOSRenderer` logo rendering rewritten (robust base64 handling, alpha compositing, resizing, optional diagnostics), barcode helper added, and block enable/ordering logic hardened; new `RaffleTicketESCPOSRenderer` implements raffle-specific ESC/POS blocks.  
- Ticket layout model & repo: `TicketLayoutConfig` supports raffle defaults, block map normalization and debug flag; `TicketLayoutRepository` persisted store for `ticket_layouts(layout_type, config_json)`, migration/compat fallbacks and copy-on-read behavior.  
- UI changes: `modulos/ticket_designer.py` extended to switch between `sale_ticket` and `raffle_ticket` modes, manage block order/visibility, preview raffle tickets, save per-layout templates and print sample raffle tickets using `print_raffle_ticket`.  
- Sales integration and resilience: `SalesService` accepts an injected `printer_service`, collects raffle snapshots from loyalty, and optionally auto-prints issued raffle tickets after sale commit (configurable via `raffle_ticket_print_auto`).  
- Fulfillment/backwards-compat: `SaleFulfillmentService` and helpers detect available DB columns to avoid SQL errors on older schemas and properly resolve recipe components (variable column names).  
- Misc: small UI/QSS removal of unsupported `box-shadow` in styles.  

### Testing
- Added comprehensive unit tests covering raffle issuance, printer/layout contract, ESC/POS rendering, ticket designer UI contract, sales flow (including printing behavior), stock validation regression, and QSS scan (`tests/test_loyalty_raffle_issue_tickets.py`, `tests/test_ticket_escpos_renderer.py`, `tests/test_ticket_layout_config.py`, `tests/test_ticket_layout_repository_regression.py`, `tests/test_ticket_rendering_regression.py`, `tests/test_ticket_designer_*`, `tests/test_sales_service_single_event_flow.py`, `tests/test_sales_stock_validation_regression.py`, `tests/test_qss_no_box_shadow.py`).  
- Ran the test suite including the new tests locally in the CI/dev environment and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bc40ebf448328a33a359855e1f2a0)