### PR TITLE
Refactor delivery bounded-context: canonical events, outbox, domain & legacy bridge

### DIFF
--- a/docs/EVENT_CATALOG.md
+++ b/docs/EVENT_CATALOG.md
@@ -1,0 +1,67 @@
+# Event Catalog — Delivery Canonical Events
+
+Este catálogo enumera los eventos canónicos del bounded context Delivery. Los nombres legacy se mantienen solo por `LegacyDeliveryEventBridge` durante la migración.
+
+## Convenciones
+
+- Nombres canónicos: mayúsculas en inglés, prefijo `DELIVERY_` para eventos logísticos y `INVENTORY_` para solicitudes hacia inventario.
+- Payloads: JSON serializable; nunca incluir `db`, conexiones SQLite, objetos PyQt ni clientes WhatsApp.
+- Idempotencia: usar `operation_id` estable en eventos críticos.
+- Persistencia confiable: eventos críticos se registran en `delivery_outbox_events`.
+- EventBus en memoria: permitido para refrescos/UI/compatibilidad, no como única garantía de inventario o notificación crítica.
+
+## Eventos Delivery
+
+| Evento | Crítico | Emisor principal | Payload requerido | Idempotencia sugerida | Consumidores |
+| --- | --- | --- | --- | --- | --- |
+| `DELIVERY_ORDER_CREATED` | No | `CreateDeliveryOrderUseCase` | `order_id`, `folio`, `direccion`, `total`, `sucursal_id`, `usuario` | `delivery:{order_id}:created` | UI, bridge legacy, notificaciones internas. |
+| `DELIVERY_ORDER_RESERVED` | Sí operacional | `CreateDeliveryOrderUseCase` | `order_id`, `operation_id`, `items`, `branch_id` | `delivery:{order_id}` | `DeliveryInventoryProjectionService`. |
+| `DELIVERY_ORDER_PREPARING` | No | `ChangeDeliveryStatusUseCase` | `order_id`, `folio`, `usuario`, `sucursal_id` | `delivery:{order_id}:preparacion` | UI/badges/notificaciones internas. |
+| `DELIVERY_DRIVER_ASSIGNED` | No | Futuro caso de uso asignación | `order_id`, `driver_id`, `driver_nombre`, `tiempo_estimado` | `delivery:{order_id}:driver:{driver_id}` | UI, PWA, tracking. |
+| `DELIVERY_OUT_FOR_DELIVERY` | No/WA | `ChangeDeliveryStatusUseCase` | `order_id`, `driver_id`, `folio`, `cliente_tel` | `delivery:{order_id}:en_ruta` | WhatsApp, bridge legacy, UI. |
+| `DELIVERY_ORDER_DELIVERED` | Sí | `ChangeDeliveryStatusUseCase` | `order_id`, `folio`, `driver_id`, `total`, `sucursal_id`, `responsable` | `delivery:{order_id}:entregado` | Inventario, finanzas/caja, bridge legacy. |
+| `DELIVERY_ORDER_CANCELLED` | Sí | `ChangeDeliveryStatusUseCase` / cancel use case | `order_id`, `folio`, `usuario`, `motivo` | `delivery:{order_id}:cancelado` | Inventario release, ventas projection, UI. |
+| `DELIVERY_ADJUSTMENT_APPROVAL_REQUIRED` | Sí | `AdjustDeliveryWeightUseCase` | `order_id`, `item_id`, `folio`, `cliente_tel`, `requested_qty`, `prepared_qty`, `new_subtotal` | `delivery:{order_id}:item:{item_id}:adjustment_required` | WhatsApp notifier, UI badges. |
+| `DELIVERY_ITEM_WEIGHT_ADJUSTED` | No | `AdjustDeliveryWeightUseCase` | `order_id`, `item_id`, `requested_qty`, `prepared_qty`, `new_total` | `delivery:{order_id}:item:{item_id}:weight_adjusted` | Totales/UI/auditoría. |
+| `DELIVERY_TOTAL_UPDATED` | No/operacional | `DeliveryTotalService` / adjustment use case | `order_id`, `old_total`, `new_total`, `folio`, `cliente_tel` | `delivery:{order_id}:total:{new_total}` | Sale projection, pagos, UI. |
+| `DELIVERY_SCHEDULED_ORDER_ACTIVATED` | No | `ActivateScheduledOrderUseCase` | `order_id`, `workflow_type`, `usuario`, `sucursal_id` | `delivery:{order_id}:scheduled_activated` | UI, ventas projection, WhatsApp. |
+
+## Eventos hacia inventario
+
+| Evento | Crítico | Payload requerido | Idempotencia sugerida | Consumidores |
+| --- | --- | --- | --- | --- |
+| `INVENTORY_COMMIT_REQUIRED` | Sí | `order_id`, `operation_id`, `items`, `sucursal_id` | `delivery:{order_id}` y por item `delivery:{order_id}:item:{item_id}:commit` | `DeliveryInventoryProjectionService`. |
+| `INVENTORY_RELEASE_REQUIRED` | Sí | `order_id`, `operation_id`, `reason` | `delivery:{order_id}` | `DeliveryInventoryProjectionService`, bridge legacy. |
+
+## Eventos de notificación
+
+| Evento | Crítico | Payload requerido | Idempotencia sugerida | Consumidores |
+| --- | --- | --- | --- | --- |
+| `CUSTOMER_NOTIFICATION_REQUESTED` | Sí | `order_id`, `canal`, `template`, `params`, `cliente_tel` | `delivery:{order_id}:notify:{template}` | `WhatsAppDeliveryNotifier` / notification handler. |
+
+## Bridge legacy temporal
+
+| Canónico | Legacy emitido | Política |
+| --- | --- | --- |
+| `DELIVERY_ORDER_CREATED` | `pedido_delivery_creado`, `pedido_whatsapp_recibido` | Mantener hasta migrar UI/handlers WhatsApp a canónico. |
+| `DELIVERY_OUT_FOR_DELIVERY` | `pedido_en_ruta` | Mantener hasta migrar consumidores de ruta. |
+| `DELIVERY_ORDER_DELIVERED` | `pedido_entregado` | Mantener hasta migrar consumidores de entrega/liquidación. |
+| `INVENTORY_RELEASE_REQUIRED` | `stock_liberar_solicitado` | Mantener hasta migrar liberación legacy. |
+| `CUSTOMER_NOTIFICATION_REQUESTED` | No traduce a `notificacion_whatsapp_enviada` | `notificacion_whatsapp_enviada` solo confirma envío directo legacy. |
+
+## Estados relacionados
+
+| Estado delivery | Evento típico de entrada | Evento crítico asociado |
+| --- | --- | --- |
+| `pendiente` | `DELIVERY_ORDER_CREATED` | `DELIVERY_ORDER_RESERVED` si hay items inventariables. |
+| `preparacion` | `DELIVERY_ORDER_PREPARING` | Ninguno obligatorio. |
+| `en_ruta` | `DELIVERY_OUT_FOR_DELIVERY` | `CUSTOMER_NOTIFICATION_REQUESTED` opcional/según canal. |
+| `entregado` | `DELIVERY_ORDER_DELIVERED` | `INVENTORY_COMMIT_REQUIRED`. |
+| `cancelado` | `DELIVERY_ORDER_CANCELLED` | `INVENTORY_RELEASE_REQUIRED`. |
+| `programado` activado | `DELIVERY_SCHEDULED_ORDER_ACTIVATED` | Reserva/forecast según flujo. |
+
+## Referencias
+
+- Arquitectura delivery: `docs/architecture/DELIVERY_ARCHITECTURE.md`.
+- Auditoría y fases: `docs/audits/DELIVERY_REFACTOR_AUDIT.md`.
+- WhatsApp + Delivery legacy: `docs/EVENT_CATALOG_WHATSAPP_DELIVERY.md`.

--- a/docs/EVENT_CATALOG_WHATSAPP_DELIVERY.md
+++ b/docs/EVENT_CATALOG_WHATSAPP_DELIVERY.md
@@ -41,3 +41,14 @@
 - Consumers: ERP UI inbox and badge counters.
 - Persistence: `notification_inbox` (+ optional `event_log`).
 - Idempotency key: `branch_notification:{dedupe_key}`.
+
+## Delivery canonical vs legacy bridge (Fase 11)
+- Canonical source events: `DELIVERY_ORDER_CREATED`, `DELIVERY_ORDER_PREPARING`, `DELIVERY_OUT_FOR_DELIVERY`, `DELIVERY_ORDER_DELIVERED`, `DELIVERY_ORDER_CANCELLED`, `DELIVERY_ORDER_RESERVED`, `INVENTORY_COMMIT_REQUIRED`, `INVENTORY_RELEASE_REQUIRED`, `CUSTOMER_NOTIFICATION_REQUESTED`.
+- Temporary bridge: `LegacyDeliveryEventBridge` translates canonical events to legacy names only for old consumers.
+- Legacy translations currently supported:
+  - `DELIVERY_ORDER_CREATED` → `pedido_delivery_creado`, `pedido_whatsapp_recibido`.
+  - `DELIVERY_OUT_FOR_DELIVERY` → `pedido_en_ruta`.
+  - `DELIVERY_ORDER_DELIVERED` → `pedido_entregado`.
+  - `INVENTORY_RELEASE_REQUIRED` → `stock_liberar_solicitado`.
+- `notificacion_whatsapp_enviada` is not generated from `CUSTOMER_NOTIFICATION_REQUESTED`; it remains a legacy confirmation emitted only after direct notifier success in compatibility mode.
+- Removal policy: migrate listeners to canonical events first, then remove bridge translations in a later cleanup phase.

--- a/docs/architecture/DELIVERY_ARCHITECTURE.md
+++ b/docs/architecture/DELIVERY_ARCHITECTURE.md
@@ -1,0 +1,226 @@
+# Delivery Architecture — Fase 14
+
+Este documento describe el estado objetivo incremental del bounded context `core/delivery` después de las fases 0–13. La arquitectura es pragmática: mantiene compatibilidad con `core/services/delivery_service.py` y la UI actual, pero mueve decisiones de negocio a dominio/application y efectos secundarios a outbox/proyecciones/adapters.
+
+## Objetivos de arquitectura
+
+- `delivery_orders.estado` es la fuente de verdad del estado logístico.
+- `ventas.estado` y `ventas.total` son proyecciones comerciales controladas por `SaleDeliveryProjectionService`.
+- `delivery_items` son items operativos/preparación; `detalles_venta` conservan el detalle comercial/fiscal.
+- La UI no decide reglas de transición: solicita acciones válidas a `DeliveryService.get_valid_actions()`, que delega en `DeliveryStateMachine`.
+- Inventario, WhatsApp y efectos críticos se disparan por eventos canónicos y outbox transaccional cuando aplica.
+- Los eventos legacy siguen vivos solo mediante `LegacyDeliveryEventBridge` durante la migración.
+
+## Mapa de módulos
+
+```text
+core/delivery/
+  domain/              # puro: estados, entidades, policies, state machine, eventos
+  application/         # casos de uso: crear, cambiar estado, ajustar peso, outbox, sync WA
+  infrastructure/      # SQLite migrator, outbox repository, adapters WA/inventario
+  projections/         # ventas e inventario como efectos secundarios controlados
+
+core/services/
+  delivery_service.py  # fachada legacy compatible hacia use cases
+  order_total_service.py # shim hacia DeliveryTotalService
+
+repositories/
+  delivery_repository.py # persistencia delivery; schema delegado a migrator
+```
+
+## Flujo: crear pedido
+
+```mermaid
+flowchart TD
+    UI[UI / WhatsApp / PWA] --> DS[DeliveryService facade]
+    DS --> UC[CreateDeliveryOrderUseCase]
+    UC --> VAL[Validar dirección, duplicados y workflow]
+    VAL --> GEO[GeocodingAdapter opcional]
+    GEO --> REPO[DeliveryRepository]
+    REPO --> DB[(delivery_orders + delivery_items + history)]
+    UC --> OUTBOX[(delivery_outbox_events)]
+    OUTBOX --> EVT[DELIVERY_ORDER_CREATED / DELIVERY_ORDER_RESERVED / CUSTOMER_NOTIFICATION_REQUESTED]
+    EVT --> INV[DeliveryInventoryProjectionService]
+    EVT --> WA[WhatsAppDeliveryNotifier]
+    EVT --> LEGACY[LegacyDeliveryEventBridge]
+```
+
+Reglas clave:
+
+1. La dirección es obligatoria para pedidos de entrega a domicilio.
+2. Geocoding es opcional y no debe bloquear la creación si falla de forma no crítica.
+3. La deduplicación se hace por `whatsapp_order_id` o `venta_id` cuando el origen es WhatsApp/venta existente.
+4. Los eventos críticos se encolan sin `db` en payload.
+
+## Flujo: cambiar estado
+
+```mermaid
+flowchart TD
+    UI[UI / PWA / handler] --> DS[DeliveryService.update_status]
+    DS --> UC[ChangeDeliveryStatusUseCase]
+    UC --> SM[DeliveryStateMachine.assert_can_transition]
+    SM --> REPO[DeliveryRepository.update_status]
+    REPO --> HIST[delivery_order_history]
+    UC --> SALE[SaleDeliveryProjectionService]
+    UC --> OUTBOX[(delivery_outbox_events)]
+    OUTBOX --> INV_COMMIT[INVENTORY_COMMIT_REQUIRED]
+    OUTBOX --> INV_RELEASE[INVENTORY_RELEASE_REQUIRED]
+    OUTBOX --> NOTIFY[CUSTOMER_NOTIFICATION_REQUESTED]
+    UC --> BUS[EventBus canónico]
+    BUS --> BRIDGE[LegacyDeliveryEventBridge]
+```
+
+Reglas clave:
+
+- `programado` no avanza a `preparacion`, `en_ruta` o `entregado` sin activarse.
+- `counter` no puede ir a `en_ruta`; puede pasar de `preparacion` a `entregado` con responsable.
+- Delivery a domicilio debe pasar por `en_ruta` antes de `entregado`.
+- `entregado` requiere responsable.
+- `en_ruta` y `entregado` se bloquean si hay ajuste pendiente de cliente.
+- `entregado` no regresa a estados previos sin proceso explícito de reverso.
+
+## Flujo: ajuste de peso
+
+```mermaid
+flowchart TD
+    UI[Preparación / PesoRealDialog] --> DS[DeliveryService.adjust_item_weight]
+    DS --> UC[AdjustDeliveryWeightUseCase]
+    UC --> POLICY[WeightAdjustmentPolicy]
+    POLICY -->|Dentro tolerancia| APPLY[Aplicar final_qty/prepared_qty]
+    POLICY -->|Fuera tolerancia| PENDING[Guardar pending_prepared_qty + pending_subtotal]
+    APPLY --> TOTAL[DeliveryTotalService recalcula desde delivery_items]
+    PENDING --> BLOCK[Marca adjustment_pending]
+    TOTAL --> OUTBOX_TOTAL[DELIVERY_TOTAL_UPDATED]
+    PENDING --> OUTBOX_ADJ[DELIVERY_ADJUSTMENT_APPROVAL_REQUIRED]
+    OUTBOX_ADJ --> WA[WhatsAppDeliveryNotifier]
+```
+
+Reglas clave:
+
+- Dentro de tolerancia: se actualiza item, se recalcula `delivery_orders.total`, se emite `DELIVERY_TOTAL_UPDATED`.
+- Fuera de tolerancia: no se aplica el total real hasta aceptación del cliente; se guarda cantidad/subtotal pendiente.
+- Aceptación: aplica cantidad pendiente, recalcula total y proyecta a ventas.
+- Rechazo: conserva cantidad/subtotal original y desbloquea según política.
+
+## Tabla de estados
+
+| Estado canónico | Significado | Legacy normalizado | Acciones principales |
+| --- | --- | --- | --- |
+| `pendiente` | Pedido creado, aún no preparado. | `pendiente_wa` | Preparar, cancelar, ver detalle. |
+| `preparacion` | Pedido en surtido/preparación. | `asignado`, `listo`, `en_preparacion` | Ajustar peso, asignar, enviar a ruta, entregar si `counter`, cancelar. |
+| `en_ruta` | Pedido salió con repartidor. | `en_camino` | Entregar, notificar. |
+| `entregado` | Pedido finalizado logísticamente. | `entregada` | Imprimir/ver; reverso explícito pendiente. |
+| `cancelado` | Pedido cancelado. | `cancelada` | Reactivar a pendiente si política lo permite. |
+| `programado` | Pedido reservado para ventana futura. | `scheduled` | Activar, reprogramar, cancelar. |
+
+## Tabla de eventos canónicos
+
+| Evento | Crítico/outbox | Payload mínimo | Consumidores esperados |
+| --- | --- | --- | --- |
+| `DELIVERY_ORDER_CREATED` | No siempre | `order_id`, `folio`, `direccion`, `total`, `sucursal_id`, `usuario` | UI, bridge legacy, analytics. |
+| `DELIVERY_ORDER_RESERVED` | Sí operacional | `order_id`, `operation_id`, `items`, `branch_id` | Inventario/reservas. |
+| `DELIVERY_ORDER_PREPARING` | No | `order_id`, `folio`, `usuario`, `sucursal_id` | UI/notificaciones internas. |
+| `DELIVERY_DRIVER_ASSIGNED` | No | `order_id`, `driver_id`, `driver_nombre`, `tiempo_estimado` | UI/PWA/repartidores. |
+| `DELIVERY_OUT_FOR_DELIVERY` | No/WA | `order_id`, `driver_id`, `folio`, `cliente_tel` | WhatsApp, bridge legacy, UI. |
+| `DELIVERY_ORDER_DELIVERED` | Sí | `order_id`, `folio`, `driver_id`, `total`, `sucursal_id`, `responsable` | Inventario commit, finanzas/caja, bridge legacy. |
+| `DELIVERY_ORDER_CANCELLED` | Sí | `order_id`, `folio`, `usuario`, `motivo` | Inventario release, UI, ventas projection. |
+| `DELIVERY_ADJUSTMENT_APPROVAL_REQUIRED` | Sí | `order_id`, `item_id`, `folio`, `cliente_tel`, `requested_qty`, `prepared_qty`, `new_subtotal` | WhatsApp/customer approval. |
+| `DELIVERY_ITEM_WEIGHT_ADJUSTED` | No | `order_id`, `item_id`, `requested_qty`, `prepared_qty`, `new_total` | Totales/UI. |
+| `DELIVERY_TOTAL_UPDATED` | No/operacional | `order_id`, `old_total`, `new_total`, `folio`, `cliente_tel` | Ventas projection, pagos. |
+| `INVENTORY_COMMIT_REQUIRED` | Sí | `order_id`, `operation_id`, `items`, `sucursal_id` | Inventario físico. |
+| `INVENTORY_RELEASE_REQUIRED` | Sí | `order_id`, `operation_id`, `reason` | Reservas/inventario. |
+| `CUSTOMER_NOTIFICATION_REQUESTED` | Sí | `order_id`, `canal`, `template`, `params`, `cliente_tel` | Notifier WhatsApp/SMS. |
+| `DELIVERY_SCHEDULED_ORDER_ACTIVATED` | No | `order_id`, `workflow_type`, `usuario`, `sucursal_id` | UI, ventas projection, WA. |
+
+## Fuente de verdad
+
+| Dato | Fuente canónica | Proyección / compatibilidad |
+| --- | --- | --- |
+| Estado logístico | `delivery_orders.estado` | `ventas.estado` vía `SaleDeliveryProjectionService`. |
+| Total operativo delivery | `delivery_orders.total`, calculado desde `delivery_items` | `ventas.total` vía proyección cuando aplica. |
+| Items preparación | `delivery_items` | `detalles_venta` no debe ser mutado por preparación. |
+| Historial auditable | `delivery_order_history` | `delivery_orders.historial_cambios` deprecated temporal. |
+| Efectos críticos | `delivery_outbox_events` | `EventBus` solo como canal en memoria/compatibilidad. |
+
+## Integración con ventas
+
+`SaleDeliveryProjectionService` encapsula el mapping logístico → comercial:
+
+| Delivery | Ventas |
+| --- | --- |
+| `pendiente` | `pendiente_wa` |
+| `preparacion` | `en_preparacion` |
+| `en_ruta` | `en_ruta` |
+| `entregado` | `entregada` |
+| `cancelado` | `cancelada` |
+
+Regla: `DeliveryRepository` persiste delivery; no debe actualizar `ventas` directamente en nuevos flujos.
+
+## Integración con inventario
+
+- Puerto: `InventoryReservationPort`.
+- Adapter actual: `ReservationServiceInventoryAdapter` sobre `ReservationService` legacy.
+- Proyección: `DeliveryInventoryProjectionService` procesa `DELIVERY_ORDER_RESERVED`, `INVENTORY_RELEASE_REQUIRED` e `INVENTORY_COMMIT_REQUIRED`.
+- Idempotencia:
+  - Orden: `delivery:{order_id}`.
+  - Item commit: `delivery:{order_id}:item:{item_id}:commit`.
+- En entrega, commit usa `final_qty` o `prepared_qty` si existen; no debe descontar cantidad solicitada si hubo ajuste aplicado.
+
+## Integración con WhatsApp
+
+- Puerto: `DeliveryNotifierPort`.
+- Adapter actual: `WhatsAppDeliveryNotifier`.
+- Evento de salida: `CUSTOMER_NOTIFICATION_REQUESTED`.
+- `DeliveryWhatsAppService` permanece como fachada legacy y delega templates al notifier.
+- Los mensajes largos/templates viven en el notifier, no en dominio ni casos de uso principales.
+
+## Política de outbox
+
+Tabla: `delivery_outbox_events`.
+
+Campos clave:
+
+- `event_type`
+- `aggregate_type = delivery_order`
+- `aggregate_id`
+- `payload_json`
+- `operation_id`
+- `status = pending|done`
+- `retries`
+- `last_error`
+- `created_at`, `processed_at`
+
+Reglas:
+
+1. Eventos críticos se insertan en la misma transacción del cambio de estado/ajuste.
+2. Payloads no pueden incluir `db` ni objetos no serializables.
+3. `operation_id` evita duplicados.
+4. `ProcessDeliveryOutboxUseCase` procesa pendientes, marca `done` o incrementa retry/error.
+5. EventBus en memoria no es fuente de confiabilidad para inventario/notificaciones críticas.
+
+## Compatibilidad legacy
+
+- `DeliveryService` mantiene API legacy: `create_order`, `update_status`, `adjust_item_weight`, `list_orders` y aliases compatibles.
+- `LegacyDeliveryEventBridge` traduce temporalmente:
+  - `DELIVERY_ORDER_CREATED` → `pedido_delivery_creado`, `pedido_whatsapp_recibido`.
+  - `DELIVERY_OUT_FOR_DELIVERY` → `pedido_en_ruta`.
+  - `DELIVERY_ORDER_DELIVERED` → `pedido_entregado`.
+  - `INVENTORY_RELEASE_REQUIRED` → `stock_liberar_solicitado`.
+- `notificacion_whatsapp_enviada` no nace de `CUSTOMER_NOTIFICATION_REQUESTED`; solo confirma envíos directos legacy.
+
+## UI y PWA
+
+- `modulos/delivery.py` pide acciones a `DeliveryService.get_valid_actions()`; su fallback `DeliveryActionPolicy` delega en `DeliveryStateMachine`.
+- `integrations/delivery_pwa/pwa_server.py` adjunta `actions` calculadas por backend y cambia estado con `DeliveryService.update_status()`.
+- Deuda restante: asignación de repartidor, cobro, cortes, tickets y algunas consultas siguen con SQL directo en UI/legacy y deben migrarse a application services o repositories específicos.
+
+## TODOs pendientes
+
+1. Migrar asignación de driver a caso de uso `AssignDeliveryDriverUseCase` y emitir `DELIVERY_DRIVER_ASSIGNED`.
+2. Encapsular cobro de entrega en un caso de uso que coordine caja/finanzas.
+3. Migrar cortes/liquidaciones de repartidores fuera de UI.
+4. Completar worker outbox real en runtime, no solo uso desde tests/handlers.
+5. Retirar `historial_cambios` JSON cuando todas las pantallas lean `delivery_order_history`.
+6. Eliminar `LegacyDeliveryEventBridge` cuando consumidores usen eventos canónicos.
+7. Agregar proceso explícito de reverso para pedidos entregados.
+8. Reemplazar adapter de inventario legacy por motor unificado cuando esté disponible.

--- a/docs/audits/DELIVERY_REFACTOR_AUDIT.md
+++ b/docs/audits/DELIVERY_REFACTOR_AUDIT.md
@@ -1,0 +1,136 @@
+# Auditoría Fase 0 — Refactor Delivery/Pedidos/Entregas
+
+## Archivos y dependencias actuales revisados
+
+### Núcleo delivery
+- `core/services/delivery_service.py`: fachada y lógica principal actual; crea pedidos, geocodifica, publica eventos, notifica WhatsApp, valida workflow, ajusta peso, sincroniza ventas, activa programados y sincroniza ventas WhatsApp pendientes.
+- `repositories/delivery_repository.py`: persistencia SQLite de `delivery_orders`, `delivery_items`, `delivery_order_history`; históricamente también hacía migraciones defensivas y sincronizaba `ventas.estado`.
+- `core/services/order_total_service.py`: recalcula total desde `delivery_items`, actualiza `delivery_orders.total` y también `ventas.total`.
+- `core/services/reservation_service.py`: reservas, liberación y commit de inventario mediante `inventory_reservations`.
+- `core/services/delivery_whatsapp_service.py`: mensajes/status WhatsApp delivery.
+- `core/services/geocoding_service.py`: geocoding/autocomplete.
+- `core/events/event_bus.py` y `core/events/handlers/delivery_handler.py`: EventBus en memoria y handlers de reserva, commit, WhatsApp, auditoría y liquidación.
+
+### UI / módulos con acoplamiento delivery
+- `modulos/delivery.py`: pantalla principal; usa `DeliveryService` pero también ejecuta SQL directo sobre `delivery_orders`, `delivery_items`, `drivers`, `delivery_status_events`/historial y WhatsApp. En Fase 13 se revisaron sus botones de acción: `TarjetaPedido`, el detalle/lista y `DeliveryActionPolicy` quedan alimentados por `DeliveryService.get_valid_actions()` / `DeliveryStateMachine` en vez de duplicar reglas de workflow.
+- `integrations/delivery_pwa/pwa_server.py`: PWA de repartidores; antes fabricaba botones por strings legacy (`listo`, `en_camino`) y hacía `UPDATE delivery_orders` directo. En Fase 13 ahora expone acciones calculadas por backend y cambia estado vía `DeliveryService.update_status()`.
+- `delivery/ticket_delivery.py`: ticket de delivery con consultas directas a `delivery_orders`, `delivery_items`, `drivers`.
+- `delivery/asignacion_repartidor.py`: asignación de drivers con SQL directo sobre `drivers` y pedidos.
+- `repositories/driver_repository.py` y `core/services/driver_service.py`: actualizan asignación/estado en delivery.
+
+### Tests existentes relacionados
+- `tests/test_delivery_service.py`, `tests/test_delivery_weight.py`, `tests/test_order_totals_phase8.py`, `tests/test_delivery_lifecycle.py`, `tests/test_delivery_action_policy.py`, `tests/test_delivery_repository_list_orders.py`, `tests/test_delivery_service_action_policy.py`, `tests/test_delivery_service_sync_sales.py`, `tests/test_delivery_ui_filters.py`, `tests/test_delivery_ticket_uses_escpos.py`.
+
+## Tablas usadas
+
+| Tabla | Uso actual | Riesgo |
+| --- | --- | --- |
+| `delivery_orders` | Estado logístico, cliente, dirección, venta vinculada, programados, total, JSON `historial_cambios`. | Mezcla fuente logística con compatibilidad legacy. |
+| `delivery_items` | Items operativos, cantidades solicitadas/preparadas/finales, ajuste pendiente. | Duplica detalle comercial de `detalles_venta`. |
+| `delivery_order_history` | Historial auditable parcial. | Convive con JSON `historial_cambios`. |
+| `drivers` | Repartidores; usada por UI/repository/tickets. | Gestión mezclada con estado de pedido. |
+| `ventas` | Venta comercial/fiscal, canal WhatsApp, estado comercial, total. | Actualizada desde repository, total service y service. |
+| `detalles_venta` | Detalle comercial/fiscal. | Se copia hacia `delivery_items`. |
+| `inventory_reservations` | Reserva offline-first de stock. | Eventos en memoria pueden perder commit/release. |
+| `inventario_actual` | Stock físico calculado/cache. | No debe actualizarse directo desde delivery. |
+| WhatsApp (`whatsapp_queue`, `wa_message_queue`, `pedidos_whatsapp`, `bot_sessions`, `bot_mensajes_log`, según instalación) | Ingreso/notificación WA. | Múltiples historiales/colas. |
+
+## Eventos actuales encontrados
+
+### Legacy publicados por delivery
+- `pedido_delivery_creado`
+- `pedido_whatsapp_recibido`
+- `pedido_en_ruta`
+- `pedido_entregado`
+- `stock_liberar_solicitado`
+- `notificacion_whatsapp_enviada`
+
+### Canónicos/nuevos en uso parcial
+- `DELIVERY_ORDER_CREATED`
+- `DELIVERY_ORDER_RESERVED`
+- `DELIVERY_ORDER_PREPARING`
+- `DELIVERY_OUT_FOR_DELIVERY`
+- `DELIVERY_ORDER_DELIVERED`
+- `DELIVERY_ORDER_CANCELLED`
+- `DELIVERY_ADJUSTMENT_APPROVAL_REQUIRED`
+- `DELIVERY_ITEM_WEIGHT_ADJUSTED`
+- `DELIVERY_TOTAL_UPDATED`
+- `INVENTORY_COMMIT_REQUIRED`
+- `CUSTOMER_NOTIFICATION_REQUESTED`
+- `WHATSAPP_SCHEDULED_ORDER_ACTIVATED`
+
+## Handlers suscritos / consumidores
+
+- `core/events/handlers/delivery_handler.py` contiene handlers de reserva, liberación, ajuste de peso, pago, commit de inventario, notificación, auditoría, liquidación y sugerencias.
+- `modulos/spj_refresh_mixin.py`, `ui/dashboard.py` y pantallas de módulos se suscriben a EventBus para refrescos.
+- Algunos handlers aceptan `db` en payload como fallback; esto queda marcado como deuda porque rompe separación y transaccionalidad.
+
+## Flujos actuales
+
+### Crear pedido
+1. `DeliveryService.create_order` valida dirección.
+2. Geocodifica opcionalmente.
+3. `DeliveryRepository.create_order` inserta `delivery_orders`, `delivery_items` e historial.
+4. Publica eventos legacy y canónicos.
+5. Solicita reserva con `DELIVERY_ORDER_RESERVED`.
+6. Notifica WhatsApp directamente y publica `DELIVERY_ORDER_CREATED`.
+
+### Cambiar estado
+1. `DeliveryService.update_status` valida workflow con strings.
+2. Bloquea `en_ruta`/`entregado` si hay ajuste pendiente.
+3. `DeliveryRepository.update_status` actualiza `delivery_orders` y `ventas.estado`.
+4. DeliveryService publica eventos, notifica WA y en entregado publica commit inventario.
+
+### Ajuste de peso
+1. `DeliveryService.adjust_item_weight` consulta item directo.
+2. `ReservationService.compute_adjustment` decide tolerancia.
+3. Dentro de tolerancia actualiza item y recalcula total.
+4. Fuera de tolerancia guarda pending, bloquea pedido y notifica WA directo.
+
+## Fuentes duplicadas de verdad
+
+- Estado logístico: `delivery_orders.estado`, `ventas.estado`, UI hardcodeada.
+- Items: `delivery_items` vs `detalles_venta`.
+- Historial: `delivery_order_history` queda como fuente auditable; `delivery_orders.historial_cambios` se conserva temporalmente como compatibilidad deprecated.
+- Total: `delivery_orders.total` es el total operativo recalculado desde `delivery_items`; `ventas.total` queda como proyección secundaria. Riesgo legacy: consumidores antiguos aún pueden escuchar `DELIVERY_TOTAL_UPDATED`.
+- WhatsApp: `DeliveryWhatsAppService`, `WhatsAppClient` directo y colas/historiales WA.
+- Inventario: reservas + eventos in-memory sin outbox transaccional.
+
+## Riesgos detectados
+
+1. Pedido entregado puede quedar sin commit de inventario si falla EventBus/handler.
+2. `db` viaja en payloads, acoplando infraestructura a eventos.
+3. Migraciones defensivas con `except Exception: pass` ocultan problemas de schema.
+4. UI ejecuta SQL y puede saltarse reglas de dominio.
+5. Venta puede recibir estados/totales divergentes desde varios puntos.
+6. Ajustes pendientes bloquean estado en service, pero UI puede mostrar acciones por reglas propias.
+7. Reintentos inexistentes en notificaciones críticas.
+
+## Plan de migración por fases y archivos concretos
+
+1. **Dominio**: crear `core/delivery/domain/{states,entities,events,state_machine,policies}.py` y tests `tests/test_delivery_state_machine.py`, `tests/test_delivery_weight_policy.py`.
+2. **Schema**: crear `core/delivery/infrastructure/delivery_schema_migrator.py`, registrar `migrations/standalone/093_delivery_schema_migrator.py`, conservar `migrations/093_create_delivery_core.sql` como referencia SQL base y dejar `DeliveryRepository.ensure_schema` como shim deprecated. **Estado: implementado en Fase 2**.
+3. **Fuente única/proyecciones**: crear `core/delivery/projections/sale_delivery_projection.py` para encapsular mapping `delivery_orders.estado` → `ventas.estado` y `delivery_orders.total` → `ventas.total` cuando aplique; `DeliveryRepository` ya no actualiza `ventas`. **Estado: implementado en Fase 3**.
+4. **Use cases/application layer**: introducir `core/delivery/application/{create_delivery_order,change_delivery_status,adjust_delivery_weight,activate_scheduled_order,cancel_delivery_order,sync_whatsapp_orders}.py`; `DeliveryService` queda como fachada compatible que delega esos flujos. Los payloads emitidos desde estos casos de uso ya no transportan `db`. **Estado: implementado en Fase 4**.
+5. **Outbox**: crear `core/delivery/infrastructure/delivery_outbox_repository.py` y `core/delivery/application/process_delivery_outbox.py`; registrar eventos críticos sin `db`, con `operation_id` para idempotencia y reintentos controlados. **Estado: implementado en Fase 5**.
+6. **Inventario/reservas**: crear `InventoryReservationPort`, adapter `ReservationServiceInventoryAdapter` y `DeliveryInventoryProjectionService` para procesar reservas, liberaciones y commits desde eventos/outbox. El commit usa `final_qty`/`prepared_qty` cuando existen y `operation_id` por item para idempotencia. **Estado: implementado en Fase 6**.
+7. **WhatsApp/notificaciones**: crear `DeliveryNotifierPort` y `WhatsAppDeliveryNotifier`, centralizar templates y enrutar `CUSTOMER_NOTIFICATION_REQUESTED` por outbox/notification handler en vez de llamadas WhatsApp directas desde casos de uso. **Estado: implementado en Fase 7**.
+8. **Totales/pagos**: crear `core/delivery/application/delivery_total_service.py` como cálculo canónico desde `delivery_items`; mantener `OrderTotalService` como shim, proyectar `ventas.total` solo mediante `SaleDeliveryProjectionService` y registrar `DELIVERY_TOTAL_UPDATED` al aplicar/aceptar ajustes. **Estado: implementado en Fase 8**.
+9. **Historial/auditoría**: ampliar `delivery_order_history` con `reason`, `metadata_json`, `event_id`, `usuario` y `created_at`; escribir toda transición de estado en la tabla auditable y conservar `historial_cambios` solo como JSON legacy deprecated. **Estado: implementado en Fase 9**.
+10. **Compatibilidad DeliveryService**: mantener `DeliveryService` como fachada temporal con API legacy (`create_order`, `update_status`, `adjust_item_weight`, `list_orders`) y aliases explícitos (`create_delivery_order`, `update_order_status`, `adjust_weight`, `cancel_delivery_order`); marcar shims internos deprecated y delegar a use cases/outbox/proyecciones. **Estado: implementado en Fase 10**.
+11. **Eventos legacy**: publicar eventos canónicos desde casos de uso y traducir temporalmente a legacy con `LegacyDeliveryEventBridge` (`pedido_delivery_creado`, `pedido_whatsapp_recibido`, `pedido_en_ruta`, `pedido_entregado`, `stock_liberar_solicitado`). `notificacion_whatsapp_enviada` queda solo para confirmaciones directas del notifier legacy. **Estado: implementado en Fase 11**.
+12. **Tests obligatorios**: consolidar la matriz de creación, cambios de estado, inventario, ajustes, totales, outbox y compatibilidad en `tests/test_delivery_phase12_required.py`, cubriendo reglas críticas y deduplicación. **Estado: implementado en Fase 12**.
+13. **UI**: migrar `modulos/delivery.py` progresivamente para pedir acciones a state machine/service y retirar SQL directo. En Fase 13 se completó el primer corte: `DeliveryService.get_valid_actions()` se apoya en `DeliveryStateMachine`, el fallback `DeliveryActionPolicy` usa la misma state machine y la PWA consulta acciones backend + cambia estado por la fachada. Quedan SQL directos de asignación, cobro, tickets y cortes por migrar en fases posteriores. **Estado: implementado parcialmente en Fase 13**.
+14. **Documentación**: crear `docs/architecture/DELIVERY_ARCHITECTURE.md` con flujos, estados, eventos, fuentes de verdad, integraciones, outbox, compatibilidad y TODOs; crear/actualizar `docs/EVENT_CATALOG.md` con eventos canónicos delivery. **Estado: implementado en Fase 14**.
+15. **Legacy bridge cleanup**: eliminar listeners legacy cuando consumidores migren a canónicos.
+
+## Riesgos de compatibilidad
+
+- Algunos handlers legacy aún tienen fallback para `payload["db"]`; los casos de uso de Fase 4/5/6/7 ya no lo envían y dependen del `db` inyectado en wiring/container.
+- Durante la transición, los eventos canónicos pueden producir equivalentes legacy mediante `LegacyDeliveryEventBridge`; los consumidores deben ser idempotentes cuando el worker de outbox procese el mismo `operation_id`.
+- El adapter de inventario de Fase 6 conserva `ReservationService` legacy detrás de un puerto; una fase posterior puede sustituirlo por el motor unificado sin tocar casos de uso delivery.
+- `DeliveryService` sigue siendo la fachada temporal compatible; los aliases legacy y shims internos están documentados en `LEGACY_COMPATIBILITY_METHODS` y deben eliminarse solo cuando la UI/handlers hayan migrado.
+- La fachada legacy `DeliveryWhatsAppService` sigue existiendo, pero ahora delega templates a `WhatsAppDeliveryNotifier`; las llamadas directas solo quedan como compatibilidad cuando no hay outbox inyectado.
+- `DeliveryRepository.update_status` conserva compatibilidad, pero la proyección hacia ventas debe moverse en una fase posterior completa.
+- La Fase 13 quitó la duplicación de reglas de acciones en `modulos/delivery.py` y PWA, pero aún quedan SQL directos UI para asignación/cobro/cortes/tickets que deben encapsularse antes de considerar la UI completamente limpia.
+- Migraciones SQL son complementarias; en SQLite las columnas nuevas se agregan de forma segura por `DeliverySchemaMigrator`.

--- a/pos_spj_v13.4/core/delivery/application/__init__.py
+++ b/pos_spj_v13.4/core/delivery/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application-layer use cases for delivery workflows."""

--- a/pos_spj_v13.4/core/delivery/application/activate_scheduled_order.py
+++ b/pos_spj_v13.4/core/delivery/application/activate_scheduled_order.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+from core.delivery.projections.sale_delivery_projection import SaleDeliveryProjectionService
+
+from .ports import EventPublisher, NoopPublisher
+
+
+class ActivateScheduledOrderUseCase:
+    def __init__(
+        self,
+        *,
+        db,
+        repository,
+        sale_projection: SaleDeliveryProjectionService | None = None,
+        publisher: EventPublisher = NoopPublisher,
+    ) -> None:
+        self.db = db
+        self.repository = repository
+        self.sale_projection = sale_projection
+        self.publisher = publisher
+
+    def execute(self, order_id: int, usuario: str = "sistema") -> dict[str, Any]:
+        order = self.repository.get_order(order_id) or {}
+        if not order:
+            raise ValueError("Pedido no encontrado.")
+
+        current_status = (order.get("estado") or "").strip().lower()
+        if current_status not in ("programado", "scheduled"):
+            raise ValueError("Solo se pueden activar pedidos en estado programado.")
+
+        delivery_type = (order.get("delivery_type") or order.get("tipo_entrega") or "").strip().lower()
+        target_workflow = "counter" if delivery_type in ("pickup", "sucursal") else "delivery"
+
+        self.repository.activate_scheduled_order(order_id, target_workflow, usuario=usuario)
+        if self.sale_projection is not None:
+            self.sale_projection.project_scheduled_activation(order.get("venta_id"), target_workflow)
+
+        self.publisher("WHATSAPP_SCHEDULED_ORDER_ACTIVATED", {
+            "order_id": order_id,
+            "workflow_type": target_workflow,
+            "usuario": usuario,
+            "sucursal_id": int(order.get("sucursal_id") or 1),
+        })
+        return {"order_id": order_id, "workflow_type": target_workflow, "status": "pending"}

--- a/pos_spj_v13.4/core/delivery/application/adjust_delivery_weight.py
+++ b/pos_spj_v13.4/core/delivery/application/adjust_delivery_weight.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from core.delivery.domain.events import DeliveryEvents
+from core.delivery.domain.policies import WeightAdjustmentPolicy
+
+from .ports import EventPublisher, NoopPublisher
+
+logger = logging.getLogger("spj.delivery.application.adjustment")
+
+ADJUSTMENT_PENDING = "pending_customer"
+ADJUSTMENT_ACCEPTED = "accepted"
+TOLERANCE_UNITS = float(os.environ.get("DELIVERY_WEIGHT_TOLERANCE_UNITS", "0.2"))
+
+
+class AdjustDeliveryWeightUseCase:
+    def __init__(
+        self,
+        *,
+        db,
+        repository,
+        publisher: EventPublisher = NoopPublisher,
+        notify_adjustment_pending: Callable[[dict[str, Any], str, float, float, str, float, float], bool] | None = None,
+        recalculate_order_total: Callable[[int], float] | None = None,
+        sync_sale_total: Callable[[int, float], None] | None = None,
+        outbox_repository=None,
+    ) -> None:
+        self.db = db
+        self.repository = repository
+        self.publisher = publisher
+        self.notify_adjustment_pending = notify_adjustment_pending or (lambda *_args: False)
+        self.recalculate_order_total = recalculate_order_total
+        self.sync_sale_total = sync_sale_total or (lambda _order_id, _new_total: None)
+        self.outbox_repository = outbox_repository
+
+    def _enqueue(self, event_type: str, order_id: int, payload: dict[str, Any], operation_id: str | None = None) -> None:
+        if self.outbox_repository is None:
+            return
+        self.outbox_repository.enqueue(
+            event_type=event_type,
+            aggregate_id=order_id,
+            payload=payload,
+            operation_id=operation_id,
+            commit=False,
+        )
+
+    def execute(
+        self,
+        order_id: int,
+        item_id: int,
+        prepared_qty: float,
+        prepared_by: str,
+        adjustment_reason: str = "",
+        unit: str = "kg",
+    ) -> dict[str, Any]:
+        order = self.repository.get_order(order_id) or {}
+        estado = (order.get("estado") or "").lower()
+        if estado != "preparacion":
+            raise ValueError("El ajuste de peso/cantidad solo puede hacerse en estado 'preparacion'.")
+
+        item_row = self.repository.get_item_for_weight_adjustment(order_id, item_id)
+        if not item_row:
+            raise ValueError(f"delivery_items.id={item_id} not found for order={order_id}")
+
+        unit_price = float(item_row.get("precio_unitario") or 0)
+        requested_qty = float(item_row.get("cantidad") or prepared_qty)
+        item_name = item_row.get("nombre") or "Producto"
+        decision = WeightAdjustmentPolicy(tolerance_units=TOLERANCE_UNITS).evaluate(
+            requested_qty, prepared_qty, unit_price
+        )
+        adj = {
+            "diff_qty": decision.diff_qty,
+            "diff_abs": round(abs(decision.diff_qty), 4),
+            "diff_pct": decision.diff_pct,
+            "new_subtotal": decision.new_subtotal,
+            "tolerance_units": decision.tolerance_units,
+            "tolerance_exceeded": decision.tolerance_exceeded,
+        }
+
+        old_total = round(float(order.get("total") or 0), 2)
+
+        if adj["tolerance_exceeded"]:
+            token = uuid.uuid4().hex
+            self.repository.mark_item_adjustment_pending(
+                order_id=order_id,
+                item_id=item_id,
+                prepared_qty=prepared_qty,
+                pending_subtotal=adj["new_subtotal"],
+                token=token,
+                tolerance_units=adj["tolerance_units"],
+                prepared_by=prepared_by,
+                adjustment_reason=adjustment_reason,
+                commit=self.outbox_repository is None,
+            )
+            approval_payload = {
+                "order_id": order_id,
+                "item_id": item_id,
+                "folio": order.get("folio") or str(order_id),
+                "cliente_tel": order.get("cliente_tel", ""),
+                "requested_qty": requested_qty,
+                "prepared_qty": prepared_qty,
+                "new_subtotal": adj["new_subtotal"],
+                "diff_qty": adj["diff_qty"],
+                "tolerance_units": adj["tolerance_units"],
+            }
+            self._enqueue(
+                DeliveryEvents.ADJUSTMENT_APPROVAL_REQUIRED.value,
+                order_id,
+                approval_payload,
+                operation_id=f"delivery:{order_id}:item:{item_id}:adjustment:{token}",
+            )
+            self._enqueue(
+                DeliveryEvents.CUSTOMER_NOTIFICATION_REQUESTED.value,
+                order_id,
+                {
+                    "order_id": order_id,
+                    "canal": "whatsapp",
+                    "template": "adjustment_required",
+                    "params": approval_payload,
+                    "cliente_tel": order.get("cliente_tel", ""),
+                },
+                operation_id=f"delivery:{order_id}:item:{item_id}:notify_adjustment:{token}",
+            )
+            if self.outbox_repository is not None:
+                self.db.commit()
+            self.publisher("DELIVERY_ADJUSTMENT_APPROVAL_REQUIRED", approval_payload)
+            if self.outbox_repository is None:
+                self.notify_adjustment_pending(
+                    order, item_name, requested_qty, prepared_qty, unit,
+                    adj["new_subtotal"], adj["diff_qty"]
+                )
+            return {**adj, "status": ADJUSTMENT_PENDING, "applied": False}
+
+        self.repository.apply_item_weight_adjustment(
+            order_id=order_id,
+            item_id=item_id,
+            prepared_qty=prepared_qty,
+            subtotal=adj["new_subtotal"],
+            prepared_by=prepared_by,
+            adjustment_reason=adjustment_reason,
+        )
+        if self.recalculate_order_total is None:
+            raise RuntimeError("recalculate_order_total dependency is required")
+        new_total = self.recalculate_order_total(order_id)
+        self.sync_sale_total(order_id, new_total)
+        total_payload = {
+            "order_id": order_id,
+            "old_total": old_total,
+            "new_total": new_total,
+            "folio": order.get("folio") or str(order_id),
+            "cliente_tel": order.get("cliente_tel", ""),
+            "cliente_email": order.get("cliente_email", ""),
+        }
+        self._enqueue(
+            DeliveryEvents.TOTAL_UPDATED.value,
+            order_id,
+            total_payload,
+            operation_id=f"delivery:{order_id}:item:{item_id}:total:{prepared_qty}",
+        )
+        self.db.commit()
+
+        self.publisher(DeliveryEvents.ITEM_WEIGHT_ADJUSTED.value, {
+            "order_id": order_id,
+            "item_id": item_id,
+            "item_name": item_name,
+            "requested_qty": requested_qty,
+            "prepared_qty": prepared_qty,
+            "unit_price": unit_price,
+            "unit": unit,
+            "prepared_by": prepared_by,
+            "adjustment_reason": adjustment_reason,
+            "new_total": new_total,
+            "folio": order.get("folio") or str(order_id),
+            "cliente_tel": order.get("cliente_tel", ""),
+            "cliente_email": order.get("cliente_email", ""),
+        })
+        self.publisher(DeliveryEvents.TOTAL_UPDATED.value, total_payload)
+        logger.info(
+            "adjust_item_weight: order=%s item=%s requested=%.3f prepared=%.3f diff=%.3f tolerance_units=%.3f exceeded=%s",
+            order_id, item_id, requested_qty, prepared_qty,
+            adj["diff_qty"], adj["tolerance_units"], adj["tolerance_exceeded"],
+        )
+        return {**adj, "status": ADJUSTMENT_ACCEPTED, "applied": True, "new_total": new_total}

--- a/pos_spj_v13.4/core/delivery/application/approve_delivery_adjustment.py
+++ b/pos_spj_v13.4/core/delivery/application/approve_delivery_adjustment.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+class ApproveDeliveryAdjustmentUseCase:
+    """Adapter use case for customer adjustment responses.
+
+    The current production flow is implemented in whatsapp_service.erp.adjustment_approval
+    because WhatsApp runs as a separate process. This use case provides the
+    application-layer entry point expected by Delivery without importing PyQt/UI.
+    """
+
+    def __init__(self, approval_service) -> None:
+        self.approval_service = approval_service
+
+    def execute(self, phone: str, accepted: bool):
+        return self.approval_service.respond_latest_for_phone(phone, accepted=accepted)

--- a/pos_spj_v13.4/core/delivery/application/cancel_delivery_order.py
+++ b/pos_spj_v13.4/core/delivery/application/cancel_delivery_order.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .change_delivery_status import ChangeDeliveryStatusUseCase
+
+
+class CancelDeliveryOrderUseCase:
+    def __init__(self, change_status_use_case: ChangeDeliveryStatusUseCase) -> None:
+        self.change_status_use_case = change_status_use_case
+
+    def execute(self, order_id: int, usuario: str = "sistema", motivo: str = "") -> dict[str, Any]:
+        self.change_status_use_case.execute(order_id, "cancelado", usuario=usuario, responsable="", observacion=motivo)
+        return {"order_id": order_id, "status": "cancelado", "motivo": motivo}

--- a/pos_spj_v13.4/core/delivery/application/change_delivery_status.py
+++ b/pos_spj_v13.4/core/delivery/application/change_delivery_status.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from core.delivery.domain.events import DeliveryEvents
+from core.delivery.domain.state_machine import DeliveryStateMachine
+from core.delivery.projections.sale_delivery_projection import SaleDeliveryProjectionService
+
+from .ports import EventPublisher, NoopPublisher, StatusNotifier
+
+logger = logging.getLogger("spj.delivery.application.status")
+
+
+class ChangeDeliveryStatusUseCase:
+    def __init__(
+        self,
+        *,
+        db,
+        repository,
+        sale_projection: SaleDeliveryProjectionService | None = None,
+        whatsapp_service: StatusNotifier | None = None,
+        publisher: EventPublisher = NoopPublisher,
+        get_order_items: Callable[[int], list[dict[str, Any]]] | None = None,
+        outbox_repository=None,
+    ) -> None:
+        self.db = db
+        self.repository = repository
+        self.sale_projection = sale_projection
+        self.whatsapp_service = whatsapp_service
+        self.publisher = publisher
+        self.get_order_items = get_order_items or (lambda _order_id: [])
+        self.outbox_repository = outbox_repository
+
+    def execute(self, order_id: int, status: str, usuario: str, responsable: str = "", observacion: str = "") -> None:
+        target = DeliveryStateMachine().normalize_status(status).value
+        self._validate_workflow_transition(order_id, target)
+
+        if target == "entregado" and not responsable:
+            raise ValueError("No se puede entregar sin responsable")
+
+        if target in ("en_ruta", "entregado") and self._has_pending_adjustment(order_id):
+            self.repository.mark_adjustment_blocked(order_id, target)
+            raise ValueError(
+                "No se puede cambiar de estado: hay un ajuste de peso/cantidad pendiente de aceptación del cliente."
+            )
+
+        self.repository.update_status(
+            order_id,
+            target,
+            usuario=usuario,
+            observacion=observacion,
+            responsable=responsable,
+            reason=f"delivery_status_{target}",
+            metadata={"target_status": target, "source": "ChangeDeliveryStatusUseCase"},
+            commit=self.outbox_repository is None,
+        )
+        order = self.repository.get_order(order_id) or {}
+        if self.sale_projection is not None:
+            self.sale_projection.project_status_for_order(order, target)
+
+        folio = order.get("folio") or f"DEL-{order_id}"
+        sucursal_id = int(order.get("sucursal_id") or 1)
+        cliente_tel = order.get("cliente_tel") or ""
+        base = {
+            "_event_type": f"DELIVERY_ORDER_{target.upper()}",
+            "order_id": order_id,
+            "folio": folio,
+            "usuario": usuario,
+            "sucursal_id": sucursal_id,
+            "total": order.get("total"),
+        }
+
+        events_to_publish: list[tuple[str, dict[str, Any]]] = []
+
+        inventory_operation_id = f"delivery:{order_id}"
+
+        if target == "cancelado":
+            release_payload = {"order_id": order_id, "operation_id": inventory_operation_id, "reason": observacion or "cancelado"}
+            cancelled_payload = {**base, "motivo": observacion or ""}
+            self._enqueue(
+                DeliveryEvents.INVENTORY_RELEASE_REQUIRED.value,
+                order_id,
+                release_payload,
+                operation_id=release_payload["operation_id"],
+            )
+            self._enqueue(
+                DeliveryEvents.ORDER_CANCELLED.value,
+                order_id,
+                cancelled_payload,
+                operation_id=f"delivery:{order_id}:cancelado",
+            )
+            events_to_publish.append((DeliveryEvents.INVENTORY_RELEASE_REQUIRED.value, release_payload))
+            events_to_publish.append((DeliveryEvents.ORDER_CANCELLED.value, cancelled_payload))
+        if target == "preparacion":
+            events_to_publish.append((DeliveryEvents.ORDER_PREPARING.value, base))
+        if target == "en_ruta":
+            events_to_publish.append((
+                DeliveryEvents.OUT_FOR_DELIVERY.value,
+                {**base, "_event_type": "DELIVERY_OUT_FOR_DELIVERY", "driver_id": order.get("driver_id"), "cliente_tel": cliente_tel},
+            ))
+        if target == "entregado":
+            delivered_payload = {
+                **base,
+                "_event_type": "DELIVERY_ORDER_DELIVERED",
+                "responsable": responsable,
+                "driver_id": order.get("driver_id"),
+            }
+            self._enqueue(
+                DeliveryEvents.ORDER_DELIVERED.value,
+                order_id,
+                delivered_payload,
+                operation_id=f"delivery:{order_id}:entregado",
+            )
+            events_to_publish.append((DeliveryEvents.ORDER_DELIVERED.value, delivered_payload))
+            items = self.get_order_items(order_id)
+            commit_payload = {
+                "order_id": order_id,
+                "operation_id": inventory_operation_id,
+                "items": items,
+                "sucursal_id": sucursal_id,
+                "branch_id": sucursal_id,
+            }
+            self._enqueue(
+                DeliveryEvents.INVENTORY_COMMIT_REQUIRED.value,
+                order_id,
+                commit_payload,
+                operation_id=inventory_operation_id,
+            )
+            events_to_publish.append((DeliveryEvents.INVENTORY_COMMIT_REQUIRED.value, commit_payload))
+
+        notification_payload = {
+            "order_id": order_id,
+            "canal": "whatsapp",
+            "template": target,
+            "params": {"folio": folio, "status": target},
+            "cliente_tel": cliente_tel,
+        }
+        self._enqueue(
+            DeliveryEvents.CUSTOMER_NOTIFICATION_REQUESTED.value,
+            order_id,
+            notification_payload,
+            operation_id=f"delivery:{order_id}:notify:{target}",
+        )
+        if self.outbox_repository is not None:
+            self.db.commit()
+
+        for event_name, event_payload in events_to_publish:
+            self.publisher(event_name, event_payload)
+
+        self._safe_wa_notify(order, target)
+        if self.whatsapp_service is not None:
+            self.whatsapp_service.sync_status(str(order.get("whatsapp_order_id") or ""), target)
+
+    def _enqueue(self, event_type: str, order_id: int, payload: dict[str, Any], operation_id: str | None = None) -> None:
+        if self.outbox_repository is None:
+            return
+        self.outbox_repository.enqueue(
+            event_type=event_type,
+            aggregate_id=order_id,
+            payload=payload,
+            operation_id=operation_id,
+            commit=False,
+        )
+
+    def _has_pending_adjustment(self, order_id: int) -> bool:
+        return self.repository.has_pending_adjustment(order_id)
+
+    def _validate_workflow_transition(self, order_id: int, target_status: str) -> None:
+        order = self.repository.get_order(order_id) or {}
+        workflow_type = (order.get("workflow_type") or "").strip().lower()
+        delivery_type = (order.get("delivery_type") or "").strip().lower()
+        scheduled_at = order.get("scheduled_at")
+
+        if not workflow_type:
+            if scheduled_at:
+                workflow_type = "scheduled"
+            elif delivery_type in ("pickup", "sucursal"):
+                workflow_type = "counter"
+            else:
+                workflow_type = "delivery"
+
+        if workflow_type == "scheduled" and target_status in ("preparacion", "en_ruta", "entregado"):
+            raise ValueError("Pedido programado: primero debe activarse antes de pasar a flujo operativo.")
+        if workflow_type == "counter" and target_status == "en_ruta":
+            raise ValueError("Flujo mostrador no permite estado 'en_ruta'.")
+
+    def _safe_wa_notify(self, order: dict[str, Any], status: str) -> None:
+        if self.outbox_repository is not None or self.whatsapp_service is None:
+            return
+        ok = self.whatsapp_service.notify_status(
+            phone=order.get("cliente_tel", ""),
+            folio=order.get("folio") or str(order.get("id") or ""),
+            status=status,
+        )
+        self.publisher("notificacion_whatsapp_enviada", {"order_id": order.get("id"), "status": status, "ok": bool(ok)})

--- a/pos_spj_v13.4/core/delivery/application/create_delivery_order.py
+++ b/pos_spj_v13.4/core/delivery/application/create_delivery_order.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any
+
+from core.delivery.domain.events import DeliveryEvents
+
+from .ports import EventPublisher, GeocodingPort, NoopPublisher, StatusNotifier
+
+
+class CreateDeliveryOrderUseCase:
+    def __init__(
+        self,
+        *,
+        db,
+        repository,
+        geocoding_service: GeocodingPort | None = None,
+        whatsapp_service: StatusNotifier | None = None,
+        publisher: EventPublisher = NoopPublisher,
+        outbox_repository=None,
+    ) -> None:
+        self.db = db
+        self.repository = repository
+        self.geocoding_service = geocoding_service
+        self.whatsapp_service = whatsapp_service
+        self.publisher = publisher
+        self.outbox_repository = outbox_repository
+
+    def execute(self, data: dict[str, Any], usuario: str = "sistema") -> int:
+        payload = dict(data or {})
+        direccion = (payload.get("direccion") or "").strip()
+        if not direccion:
+            raise ValueError("No se puede crear pedido sin dirección válida")
+
+        coords = payload.get("coords")
+        if coords is None and self.geocoding_service is not None:
+            coords = self.geocoding_service.geocode(direccion)
+        if coords:
+            payload["lat"] = coords.get("lat")
+            payload["lng"] = coords.get("lng")
+        else:
+            payload["lat"] = payload.get("lat")
+            payload["lng"] = payload.get("lng")
+
+        payload["usuario"] = usuario
+        order_id = self.repository.create_order(payload, commit=self.outbox_repository is None)
+        events_to_publish: list[tuple[str, dict[str, Any]]] = []
+
+        operation_id = f"delivery:{order_id}"
+        items = payload.get("items") or []
+        if items:
+            reserved_payload = {
+                "order_id": order_id,
+                "operation_id": operation_id,
+                "items": items,
+                "branch_id": payload.get("sucursal_id", 1),
+            }
+            self._enqueue(DeliveryEvents.ORDER_RESERVED.value, order_id, reserved_payload, operation_id=operation_id)
+            events_to_publish.append(("DELIVERY_ORDER_RESERVED", reserved_payload))
+
+        order = self.repository.get_order(order_id) or {}
+        notification_payload = {
+            "order_id": order_id,
+            "canal": "whatsapp",
+            "template": "pedido_recibido",
+            "params": {"folio": order.get("folio") or payload.get("folio") or f"DEL-{order_id}"},
+            "cliente_tel": order.get("cliente_tel", ""),
+        }
+        self._enqueue(
+            DeliveryEvents.CUSTOMER_NOTIFICATION_REQUESTED.value,
+            order_id,
+            notification_payload,
+            operation_id=f"delivery:{order_id}:notify:pedido_recibido",
+        )
+        created_payload = {
+            "_event_type": "DELIVERY_ORDER_CREATED",
+            "order_id": order_id,
+            "folio": order.get("folio") or payload.get("folio") or f"DEL-{order_id}",
+            "direccion": payload.get("direccion"),
+            "total": payload.get("total", 0),
+            "sucursal_id": payload.get("sucursal_id", 1),
+            "usuario": usuario,
+        }
+        events_to_publish.append(("DELIVERY_ORDER_CREATED", created_payload))
+        if self.outbox_repository is not None:
+            self.db.commit()
+
+        for event_name, event_payload in events_to_publish:
+            self.publisher(event_name, event_payload)
+        self._safe_wa_notify(order, "pedido_recibido")
+        return order_id
+
+    def _enqueue(self, event_type: str, order_id: int, payload: dict[str, Any], operation_id: str | None = None) -> None:
+        if self.outbox_repository is None:
+            return
+        self.outbox_repository.enqueue(
+            event_type=event_type,
+            aggregate_id=order_id,
+            payload=payload,
+            operation_id=operation_id,
+            commit=False,
+        )
+
+    def _safe_wa_notify(self, order: dict[str, Any], status: str) -> None:
+        if self.outbox_repository is not None or self.whatsapp_service is None:
+            return
+        ok = self.whatsapp_service.notify_status(
+            phone=order.get("cliente_tel", ""),
+            folio=order.get("folio") or str(order.get("id") or ""),
+            status=status,
+        )
+        self.publisher(
+            "notificacion_whatsapp_enviada",
+            {"order_id": order.get("id"), "status": status, "ok": bool(ok)},
+        )

--- a/pos_spj_v13.4/core/delivery/application/delivery_total_service.py
+++ b/pos_spj_v13.4/core/delivery/application/delivery_total_service.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from core.delivery.domain.policies import DeliveryTotalPolicy
+
+
+class DeliveryTotalRepositoryPort(Protocol):
+    def get_order_total(self, order_id: int) -> float: ...
+
+    def list_item_subtotals_for_order(self, order_id: int) -> list[float]: ...
+
+    def update_order_total(
+        self,
+        order_id: int,
+        total: float,
+        *,
+        mark_weight_adjusted: bool = True,
+        commit: bool = True,
+    ) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class DeliveryTotalResult:
+    order_id: int
+    old_total: float
+    new_total: float
+    changed: bool
+
+
+class DeliveryTotalService:
+    """Canonical application service for delivery order totals.
+
+    `delivery_items.subtotal` is the operational source used to recalculate
+    `delivery_orders.total`. Commercial sale totals remain a projection owned by
+    `SaleDeliveryProjectionService`; this service never writes `ventas`.
+    """
+
+    def __init__(self, repository: DeliveryTotalRepositoryPort) -> None:
+        self.repository = repository
+
+    def recalculate_order_total_details(
+        self,
+        order_id: int,
+        *,
+        mark_weight_adjusted: bool = True,
+        commit: bool = True,
+    ) -> DeliveryTotalResult:
+        old_total = self.repository.get_order_total(order_id)
+        subtotals = self.repository.list_item_subtotals_for_order(order_id)
+        new_total = DeliveryTotalPolicy.calculate_total(subtotals)
+        self.repository.update_order_total(
+            order_id,
+            new_total,
+            mark_weight_adjusted=mark_weight_adjusted,
+            commit=commit,
+        )
+        return DeliveryTotalResult(
+            order_id=order_id,
+            old_total=old_total,
+            new_total=new_total,
+            changed=old_total != new_total,
+        )
+
+    def recalculate_order_total(
+        self,
+        order_id: int,
+        *,
+        mark_weight_adjusted: bool = True,
+        commit: bool = True,
+    ) -> float:
+        return self.recalculate_order_total_details(
+            order_id,
+            mark_weight_adjusted=mark_weight_adjusted,
+            commit=commit,
+        ).new_total

--- a/pos_spj_v13.4/core/delivery/application/legacy_event_bridge.py
+++ b/pos_spj_v13.4/core/delivery/application/legacy_event_bridge.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from core.delivery.domain.events import DeliveryEvents
+
+logger = logging.getLogger("spj.delivery.application.legacy_event_bridge")
+
+LegacyPublisher = Callable[[str, dict[str, Any]], None]
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyDeliveryEvent:
+    event_type: str
+    payload: dict[str, Any]
+
+
+LEGACY_DELIVERY_EVENT_DEPRECATION: dict[str, str] = {
+    "pedido_delivery_creado": "Bridge temporal desde DELIVERY_ORDER_CREATED; eliminar cuando UI/handlers consuman canónico.",
+    "pedido_whatsapp_recibido": "Bridge temporal desde DELIVERY_ORDER_CREATED para consumidores WhatsApp legacy.",
+    "pedido_en_ruta": "Bridge temporal desde DELIVERY_OUT_FOR_DELIVERY.",
+    "pedido_entregado": "Bridge temporal desde DELIVERY_ORDER_DELIVERED.",
+    "stock_liberar_solicitado": "Bridge temporal desde INVENTORY_RELEASE_REQUIRED.",
+    "notificacion_whatsapp_enviada": "No se emite desde CUSTOMER_NOTIFICATION_REQUESTED; conservar solo cuando el notifier confirme envío directo legacy.",
+}
+
+
+class LegacyDeliveryEventBridge:
+    """Translates canonical delivery events to legacy EventBus names.
+
+    This bridge is intentionally one-way and temporary. Application use cases
+    should publish canonical events; old subscribers can keep listening to the
+    Spanish legacy names until they migrate.
+    """
+
+    CANONICAL_EVENTS: tuple[str, ...] = (
+        DeliveryEvents.ORDER_CREATED.value,
+        DeliveryEvents.OUT_FOR_DELIVERY.value,
+        DeliveryEvents.ORDER_DELIVERED.value,
+        DeliveryEvents.INVENTORY_RELEASE_REQUIRED.value,
+    )
+
+    def __init__(self, publisher: LegacyPublisher) -> None:
+        self.publisher = publisher
+
+    def handle(self, event_type: str, payload: dict[str, Any] | None) -> list[LegacyDeliveryEvent]:
+        translated = self.translate(event_type, payload or {})
+        for legacy in translated:
+            self.publisher(legacy.event_type, legacy.payload)
+        return translated
+
+    def translate(self, event_type: str, payload: dict[str, Any]) -> list[LegacyDeliveryEvent]:
+        clean = self._without_db(payload)
+        order_id = clean.get("order_id")
+        if not order_id:
+            return []
+
+        if event_type == DeliveryEvents.ORDER_CREATED.value:
+            return [
+                LegacyDeliveryEvent("pedido_delivery_creado", {"order_id": order_id}),
+                LegacyDeliveryEvent(
+                    "pedido_whatsapp_recibido",
+                    {"order_id": order_id, "canal": clean.get("canal") or clean.get("source_channel") or "whatsapp"},
+                ),
+            ]
+        if event_type == DeliveryEvents.OUT_FOR_DELIVERY.value:
+            return [LegacyDeliveryEvent("pedido_en_ruta", {"order_id": order_id})]
+        if event_type == DeliveryEvents.ORDER_DELIVERED.value:
+            return [
+                LegacyDeliveryEvent(
+                    "pedido_entregado",
+                    {"order_id": order_id, "responsable": clean.get("responsable") or clean.get("usuario") or ""},
+                )
+            ]
+        if event_type == DeliveryEvents.INVENTORY_RELEASE_REQUIRED.value:
+            return [LegacyDeliveryEvent("stock_liberar_solicitado", {"order_id": order_id})]
+        return []
+
+    @staticmethod
+    def _without_db(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {key: LegacyDeliveryEventBridge._without_db(val) for key, val in value.items() if key != "db"}
+        if isinstance(value, list):
+            return [LegacyDeliveryEventBridge._without_db(item) for item in value]
+        if isinstance(value, tuple):
+            return [LegacyDeliveryEventBridge._without_db(item) for item in value]
+        return value
+
+
+def register_legacy_delivery_event_bridge(bus) -> LegacyDeliveryEventBridge:
+    """Subscribe bridge handlers to canonical delivery events on an EventBus."""
+    bridge = LegacyDeliveryEventBridge(lambda event, payload: bus.publish(event, payload))
+    for event_type in LegacyDeliveryEventBridge.CANONICAL_EVENTS:
+        bus.subscribe(
+            event_type,
+            lambda payload, _event_type=event_type: bridge.handle(_event_type, payload),
+            priority=-100,
+            label=f"legacy_delivery_bridge:{event_type}",
+        )
+    return bridge

--- a/pos_spj_v13.4/core/delivery/application/ports.py
+++ b/pos_spj_v13.4/core/delivery/application/ports.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol
+
+
+class EventPublisher(Protocol):
+    def __call__(self, event: str, payload: dict[str, Any]) -> None: ...
+
+
+class StatusNotifier(Protocol):
+    def notify_status(self, *, phone: str, folio: str, status: str) -> bool: ...
+    def sync_status(self, whatsapp_order_id: str, status: str) -> bool: ...
+
+
+class DeliveryNotifierPort(Protocol):
+    def notify_status(self, *, phone: str, folio: str, status: str) -> bool: ...
+
+    def notify_adjustment_required(self, **kwargs: Any) -> bool: ...
+
+    def notify_weight_adjustment(self, **kwargs: Any) -> bool: ...
+
+    def notify_out_for_delivery(self, *, phone: str, folio: str, driver_name: str = "", eta: str = "") -> bool: ...
+
+    def notify_delivered(self, *, phone: str, folio: str) -> bool: ...
+
+    def notify_from_event(self, payload: dict[str, Any]) -> bool: ...
+
+
+class GeocodingPort(Protocol):
+    def geocode(self, address: str) -> dict[str, Any] | None: ...
+
+
+class InventoryReservationPort(Protocol):
+    def reserve_for_order(
+        self, *, order_id: int, items: list[dict[str, Any]], branch_id: int, operation_id: str
+    ) -> dict[str, int]: ...
+
+    def release_for_order(self, *, order_id: int, operation_id: str, reason: str = "") -> dict[str, int]: ...
+
+    def commit_for_order(
+        self, *, order_id: int, items: list[dict[str, Any]], branch_id: int, operation_id: str
+    ) -> dict[str, int]: ...
+
+
+NoopPublisher: Callable[[str, dict[str, Any]], None] = lambda _event, _payload: None

--- a/pos_spj_v13.4/core/delivery/application/process_delivery_outbox.py
+++ b/pos_spj_v13.4/core/delivery/application/process_delivery_outbox.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from typing import Any
+
+logger = logging.getLogger("spj.delivery.application.outbox")
+
+
+class ProcessDeliveryOutboxUseCase:
+    """Processes pending delivery outbox events with controlled retries."""
+
+    def __init__(
+        self,
+        *,
+        outbox_repository,
+        handlers: Mapping[str, Callable[[dict[str, Any]], None]] | None = None,
+        publisher: Callable[[str, dict[str, Any]], None] | None = None,
+    ) -> None:
+        self.outbox_repository = outbox_repository
+        self.handlers = dict(handlers or {})
+        self.publisher = publisher
+
+    def execute(self, *, limit: int = 50) -> dict[str, int]:
+        processed = 0
+        failed = 0
+        for event in self.outbox_repository.fetch_pending(limit=limit):
+            event_id = int(event["id"])
+            event_type = str(event["event_type"])
+            payload = event.get("payload") or {}
+            try:
+                handler = self.handlers.get(event_type)
+                if handler is not None:
+                    handler(payload)
+                elif self.publisher is not None:
+                    self.publisher(event_type, payload)
+                else:
+                    raise RuntimeError(f"No hay handler registrado para {event_type}")
+                self.outbox_repository.mark_done(event_id)
+                processed += 1
+            except Exception as exc:
+                logger.warning("delivery outbox event failed id=%s type=%s: %s", event_id, event_type, exc)
+                self.outbox_repository.mark_error(event_id, str(exc))
+                failed += 1
+        return {"processed": processed, "failed": failed}

--- a/pos_spj_v13.4/core/delivery/application/sync_whatsapp_orders.py
+++ b/pos_spj_v13.4/core/delivery/application/sync_whatsapp_orders.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+
+from core.delivery.domain.events import DeliveryEvents
+
+from .ports import EventPublisher, NoopPublisher
+
+logger = logging.getLogger("spj.delivery.application.sync_whatsapp")
+
+
+class SyncWhatsAppOrdersUseCase:
+    def __init__(self, *, db, repository, whatsapp_service=None, publisher: EventPublisher = NoopPublisher) -> None:
+        self.db = db
+        self.repository = repository
+        self.whatsapp_service = whatsapp_service
+        self.publisher = publisher
+
+    def pull_orders_from_whatsapp(self) -> None:
+        pulled = False
+        if self.whatsapp_service is not None:
+            for item in self.whatsapp_service.pull_orders():
+                try:
+                    oid = self.repository.upsert_order_from_whatsapp(item)
+                    self.publisher(
+                        DeliveryEvents.ORDER_CREATED.value,
+                        {"order_id": oid, "payload": item, "source_channel": "whatsapp", "canal": "whatsapp"},
+                    )
+                    pulled = True
+                except Exception as exc:
+                    logger.warning("pull_orders_from_whatsapp upsert failed: %s", exc)
+        if not pulled:
+            self.sync_pending_sales_to_delivery_orders()
+
+    def sync_pending_sales_to_delivery_orders(self) -> int:
+        imported = 0
+        try:
+            sales = self.repository.iter_pending_whatsapp_sales(limit=200)
+        except Exception as exc:
+            logger.warning("sync_pending_sales_to_delivery_orders query failed: %s", exc)
+            return 0
+
+        for data in sales:
+            venta_id = data.get("id")
+            if not venta_id:
+                continue
+            payload = {
+                "id": venta_id,
+                "venta_id": venta_id,
+                "folio": data.get("folio") or data.get("codigo"),
+                "cliente_id": data.get("cliente_id"),
+                "cliente_nombre": data.get("cliente_nombre") or data.get("cliente"),
+                "cliente_tel": data.get("cliente_tel") or data.get("telefono") or data.get("cliente_telefono"),
+                "direccion": data.get("direccion") or data.get("direccion_entrega"),
+                "total": data.get("total") or 0,
+                "sucursal_id": data.get("sucursal_id") or 1,
+                "delivery_type": data.get("delivery_type") or data.get("tipo_entrega"),
+                "workflow_type": data.get("workflow_type"),
+                "scheduled_at": data.get("scheduled_at") or data.get("fecha_entrega_programada"),
+                "items": data.get("items") or [],
+                "source_channel": "whatsapp",
+            }
+            try:
+                self.repository.upsert_order_from_whatsapp(payload, usuario="sync_local_ventas")
+                imported += 1
+            except Exception as exc:
+                logger.warning("sync_pending_sales_to_delivery_orders upsert failed venta_id=%s: %s", venta_id, exc)
+        return imported

--- a/pos_spj_v13.4/core/delivery/domain/entities.py
+++ b/pos_spj_v13.4/core/delivery/domain/entities.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping, Sequence
+
+from .states import (
+    AdjustmentStatus,
+    DeliveryStatus,
+    DeliveryType,
+    DeliveryWorkflowType,
+    normalize_adjustment_status,
+    normalize_delivery_type,
+    normalize_status,
+    normalize_workflow_type,
+)
+
+
+@dataclass(slots=True)
+class DeliveryItem:
+    id: int | None = None
+    delivery_id: int | None = None
+    producto_id: int | None = None
+    nombre: str = "Producto"
+    cantidad: float = 0.0
+    precio_unitario: float = 0.0
+    subtotal: float = 0.0
+    unidad: str = "kg"
+    requested_qty: float | None = None
+    prepared_qty: float | None = None
+    final_qty: float | None = None
+    adjustment_status: AdjustmentStatus = AdjustmentStatus.NONE
+
+    def __post_init__(self) -> None:
+        self.adjustment_status = normalize_adjustment_status(self.adjustment_status)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "DeliveryItem":
+        qty = float(data.get("cantidad") or data.get("qty") or 0)
+        price = float(data.get("precio_unitario") or data.get("precio") or data.get("unit_price") or 0)
+        subtotal = float(data.get("subtotal") or qty * price)
+        return cls(
+            id=data.get("id"),
+            delivery_id=data.get("delivery_id"),
+            producto_id=data.get("producto_id") or data.get("product_id"),
+            nombre=data.get("nombre") or data.get("producto_nombre") or data.get("name") or "Producto",
+            cantidad=qty,
+            precio_unitario=price,
+            subtotal=subtotal,
+            unidad=data.get("unidad") or "kg",
+            requested_qty=data.get("requested_qty"),
+            prepared_qty=data.get("prepared_qty"),
+            final_qty=data.get("final_qty"),
+            adjustment_status=normalize_adjustment_status(data.get("adjustment_status")),
+        )
+
+    @property
+    def has_pending_adjustment(self) -> bool:
+        return self.adjustment_status == AdjustmentStatus.PENDING_CUSTOMER
+
+
+@dataclass(slots=True)
+class DeliveryAdjustment:
+    item_id: int
+    requested_qty: float
+    prepared_qty: float
+    unit_price: float
+    new_subtotal: float
+    diff_qty: float
+    tolerance_units: float
+    status: AdjustmentStatus
+    reason: str = ""
+    token: str = ""
+
+    @property
+    def requires_customer_approval(self) -> bool:
+        return self.status == AdjustmentStatus.PENDING_CUSTOMER
+
+
+@dataclass(slots=True)
+class DeliveryDriver:
+    id: int
+    nombre: str
+    telefono: str = ""
+    vehiculo: str = ""
+    activo: bool = True
+
+
+@dataclass(slots=True)
+class DeliveryOrder:
+    id: int | None = None
+    venta_id: int | None = None
+    folio: str = ""
+    whatsapp_order_id: str | None = None
+    cliente_id: int | None = None
+    cliente_nombre: str = ""
+    cliente_tel: str = ""
+    direccion: str = ""
+    estado: DeliveryStatus = DeliveryStatus.PENDIENTE
+    workflow_type: DeliveryWorkflowType | None = None
+    delivery_type: DeliveryType | None = None
+    scheduled_at: str | datetime | None = None
+    driver_id: int | None = None
+    responsable_entrega: str = ""
+    total: float = 0.0
+    sucursal_id: int = 1
+    adjustment_pending: bool = False
+    activated: bool = False
+    items: list[DeliveryItem] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.estado = normalize_status(self.estado)
+        self.workflow_type = normalize_workflow_type(self.workflow_type)
+        self.delivery_type = normalize_delivery_type(self.delivery_type)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "DeliveryOrder":
+        items: Sequence[Mapping[str, Any] | DeliveryItem] = data.get("items") or ()
+        parsed_items = [item if isinstance(item, DeliveryItem) else DeliveryItem.from_mapping(item) for item in items]
+        return cls(
+            id=data.get("id"),
+            venta_id=data.get("venta_id"),
+            folio=data.get("folio") or "",
+            whatsapp_order_id=data.get("whatsapp_order_id"),
+            cliente_id=data.get("cliente_id"),
+            cliente_nombre=data.get("cliente_nombre") or data.get("cliente") or "",
+            cliente_tel=data.get("cliente_tel") or data.get("telefono") or "",
+            direccion=data.get("direccion") or data.get("direccion_entrega") or "",
+            estado=normalize_status(data.get("estado")),
+            workflow_type=normalize_workflow_type(data.get("workflow_type")),
+            delivery_type=normalize_delivery_type(data.get("delivery_type") or data.get("tipo_entrega")),
+            scheduled_at=data.get("scheduled_at") or data.get("fecha_entrega_programada"),
+            driver_id=data.get("driver_id"),
+            responsable_entrega=data.get("responsable_entrega") or data.get("responsable") or "",
+            total=float(data.get("total") or 0),
+            sucursal_id=int(data.get("sucursal_id") or 1),
+            adjustment_pending=bool(data.get("adjustment_pending")),
+            activated=bool(data.get("activated") or data.get("activated_at")),
+            items=parsed_items,
+        )
+
+    @property
+    def has_pending_adjustment(self) -> bool:
+        return self.adjustment_pending or any(item.has_pending_adjustment for item in self.items)
+
+    @property
+    def has_responsible_party(self) -> bool:
+        return bool(self.responsable_entrega or self.driver_id)

--- a/pos_spj_v13.4/core/delivery/domain/events.py
+++ b/pos_spj_v13.4/core/delivery/domain/events.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Mapping
+
+
+class DeliveryEvents(StrEnum):
+    ORDER_CREATED = "DELIVERY_ORDER_CREATED"
+    ORDER_RESERVED = "DELIVERY_ORDER_RESERVED"
+    ORDER_PREPARING = "DELIVERY_ORDER_PREPARING"
+    DRIVER_ASSIGNED = "DELIVERY_DRIVER_ASSIGNED"
+    OUT_FOR_DELIVERY = "DELIVERY_OUT_FOR_DELIVERY"
+    ORDER_DELIVERED = "DELIVERY_ORDER_DELIVERED"
+    ORDER_CANCELLED = "DELIVERY_ORDER_CANCELLED"
+    ADJUSTMENT_APPROVAL_REQUIRED = "DELIVERY_ADJUSTMENT_APPROVAL_REQUIRED"
+    ITEM_WEIGHT_ADJUSTED = "DELIVERY_ITEM_WEIGHT_ADJUSTED"
+    TOTAL_UPDATED = "DELIVERY_TOTAL_UPDATED"
+    INVENTORY_COMMIT_REQUIRED = "INVENTORY_COMMIT_REQUIRED"
+    INVENTORY_RELEASE_REQUIRED = "INVENTORY_RELEASE_REQUIRED"
+    CUSTOMER_NOTIFICATION_REQUESTED = "CUSTOMER_NOTIFICATION_REQUESTED"
+    SCHEDULED_ORDER_ACTIVATED = "DELIVERY_SCHEDULED_ORDER_ACTIVATED"
+
+
+@dataclass(frozen=True, slots=True)
+class EventContract:
+    payload_fields: tuple[str, ...]
+    description: str
+    critical: bool = False
+
+
+EVENT_PAYLOAD_CONTRACTS: Mapping[DeliveryEvents, EventContract] = {
+    DeliveryEvents.ORDER_CREATED: EventContract(("order_id", "folio", "direccion", "total", "sucursal_id", "usuario"), "Pedido delivery creado."),
+    DeliveryEvents.ORDER_RESERVED: EventContract(("order_id", "operation_id", "items", "branch_id"), "Reserva lógica de inventario solicitada."),
+    DeliveryEvents.ORDER_PREPARING: EventContract(("order_id", "folio", "usuario", "sucursal_id"), "Pedido pasó a preparación."),
+    DeliveryEvents.DRIVER_ASSIGNED: EventContract(("order_id", "driver_id", "driver_nombre", "tiempo_estimado"), "Repartidor asignado."),
+    DeliveryEvents.OUT_FOR_DELIVERY: EventContract(("order_id", "driver_id", "folio", "cliente_tel"), "Pedido salió a ruta."),
+    DeliveryEvents.ORDER_DELIVERED: EventContract(("order_id", "folio", "driver_id", "total", "sucursal_id", "responsable"), "Pedido entregado.", critical=True),
+    DeliveryEvents.ORDER_CANCELLED: EventContract(("order_id", "folio", "usuario", "motivo"), "Pedido cancelado.", critical=True),
+    DeliveryEvents.ADJUSTMENT_APPROVAL_REQUIRED: EventContract(("order_id", "item_id", "folio", "cliente_tel", "requested_qty", "prepared_qty", "new_subtotal"), "Ajuste requiere aprobación del cliente.", critical=True),
+    DeliveryEvents.ITEM_WEIGHT_ADJUSTED: EventContract(("order_id", "item_id", "requested_qty", "prepared_qty", "new_total"), "Peso/cantidad aplicado."),
+    DeliveryEvents.TOTAL_UPDATED: EventContract(("order_id", "old_total", "new_total", "folio", "cliente_tel"), "Total recalculado."),
+    DeliveryEvents.INVENTORY_COMMIT_REQUIRED: EventContract(("order_id", "operation_id", "items", "sucursal_id"), "Commit físico de inventario requerido.", critical=True),
+    DeliveryEvents.INVENTORY_RELEASE_REQUIRED: EventContract(("order_id", "operation_id", "reason"), "Liberación de reserva requerida.", critical=True),
+    DeliveryEvents.CUSTOMER_NOTIFICATION_REQUESTED: EventContract(("order_id", "canal", "template", "params", "cliente_tel"), "Notificación a cliente requerida.", critical=True),
+    DeliveryEvents.SCHEDULED_ORDER_ACTIVATED: EventContract(("order_id", "workflow_type", "usuario", "sucursal_id"), "Pedido programado activado."),
+}
+
+CRITICAL_OUTBOX_EVENTS = frozenset(event for event, contract in EVENT_PAYLOAD_CONTRACTS.items() if contract.critical)
+
+
+def required_payload_fields(event: DeliveryEvents | str) -> tuple[str, ...]:
+    return EVENT_PAYLOAD_CONTRACTS[DeliveryEvents(event)].payload_fields

--- a/pos_spj_v13.4/core/delivery/domain/policies.py
+++ b/pos_spj_v13.4/core/delivery/domain/policies.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Iterable
+
+from .states import AdjustmentStatus, DeliveryWorkflowType, normalize_workflow_type
+
+
+@dataclass(frozen=True, slots=True)
+class WeightAdjustmentDecision:
+    requested_qty: float
+    prepared_qty: float
+    diff_qty: float
+    diff_pct: float
+    unit_price: float
+    old_subtotal: float
+    new_subtotal: float
+    tolerance_units: float
+    tolerance_exceeded: bool
+    status: AdjustmentStatus
+    apply_immediately: bool
+
+
+class WeightAdjustmentPolicy:
+    """Decides whether a prepared quantity can be applied automatically."""
+
+    def __init__(self, tolerance_units: float = 0.2) -> None:
+        if tolerance_units < 0:
+            raise ValueError("La tolerancia de ajuste no puede ser negativa.")
+        self.tolerance_units = float(tolerance_units)
+
+    def evaluate(self, requested_qty: float, prepared_qty: float, unit_price: float) -> WeightAdjustmentDecision:
+        requested = float(requested_qty or 0)
+        prepared = float(prepared_qty or 0)
+        price = float(unit_price or 0)
+        if prepared < 0:
+            raise ValueError("La cantidad preparada no puede ser negativa.")
+        if requested < 0:
+            raise ValueError("La cantidad solicitada no puede ser negativa.")
+        if price < 0:
+            raise ValueError("El precio unitario no puede ser negativo.")
+
+        diff = round(prepared - requested, 6)
+        diff_pct = round((abs(diff) / requested) * 100, 2) if requested else 0.0
+        exceeded = requested > 0 and abs(diff) > self.tolerance_units
+        return WeightAdjustmentDecision(
+            requested_qty=requested,
+            prepared_qty=prepared,
+            diff_qty=diff,
+            diff_pct=diff_pct,
+            unit_price=price,
+            old_subtotal=self._money(requested * price),
+            new_subtotal=self._money(prepared * price),
+            tolerance_units=self.tolerance_units,
+            tolerance_exceeded=exceeded,
+            status=AdjustmentStatus.PENDING_CUSTOMER if exceeded else AdjustmentStatus.AUTO_ACCEPTED,
+            apply_immediately=not exceeded,
+        )
+
+    @staticmethod
+    def _money(value: float) -> float:
+        return float(Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+
+
+class DeliveryWorkflowPolicy:
+    @staticmethod
+    def requires_driver(workflow_type: str | DeliveryWorkflowType | None) -> bool:
+        return normalize_workflow_type(workflow_type) == DeliveryWorkflowType.DELIVERY
+
+
+class DeliveryTotalPolicy:
+    @staticmethod
+    def calculate_total(subtotals: Iterable[float]) -> float:
+        total = sum(Decimal(str(s or 0)) for s in subtotals)
+        return float(total.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))

--- a/pos_spj_v13.4/core/delivery/domain/state_machine.py
+++ b/pos_spj_v13.4/core/delivery/domain/state_machine.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping
+
+from .entities import DeliveryOrder
+from .states import (
+    AdjustmentStatus,
+    DeliveryStatus,
+    DeliveryType,
+    DeliveryWorkflowType,
+    normalize_adjustment_status,
+    normalize_delivery_type,
+    normalize_status,
+    normalize_workflow_type,
+)
+
+ACTION_PREPARE = "preparacion"
+ACTION_SEND_TO_ROUTE = "en_ruta"
+ACTION_DELIVER = "entregado"
+ACTION_CANCEL = "cancelado"
+ACTION_REACTIVATE = "reactivar"
+ACTION_ACTIVATE_SCHEDULED = "activar_programado"
+ACTION_RESCHEDULE = "reprogramar"
+ACTION_ADJUST_WEIGHT = "ajustar_peso"
+ACTION_ASSIGN_DRIVER = "asignar"
+ACTION_NOTIFY_WHATSAPP = "notificar_wa"
+ACTION_PRINT = "imprimir"
+
+
+class DeliveryStateMachine:
+    """Pure delivery workflow rules.
+
+    This class intentionally returns domain action keys only. UI labels/icons must
+    be mapped outside the domain layer.
+    """
+
+    def __init__(self, *, allow_cancelled_reactivation: bool = True) -> None:
+        self.allow_cancelled_reactivation = allow_cancelled_reactivation
+
+    @staticmethod
+    def _data(order: DeliveryOrder | Mapping[str, Any]) -> dict[str, Any]:
+        if isinstance(order, DeliveryOrder):
+            return asdict(order)
+        if isinstance(order, Mapping):
+            return dict(order)
+        if is_dataclass(order):
+            return asdict(order)
+        return dict(getattr(order, "__dict__", {}))
+
+    def normalize_status(self, status: Any) -> DeliveryStatus:
+        return normalize_status(status)
+
+    @staticmethod
+    def _has_pending_adjustment(data: Mapping[str, Any]) -> bool:
+        if data.get("adjustment_pending") or data.get("has_pending_adjustment"):
+            return True
+        for item in data.get("items") or ():
+            item_data = item if isinstance(item, Mapping) else getattr(item, "__dict__", {})
+            try:
+                if normalize_adjustment_status(item_data.get("adjustment_status")) == AdjustmentStatus.PENDING_CUSTOMER:
+                    return True
+            except ValueError:
+                continue
+        return False
+
+    def infer_workflow(self, order: DeliveryOrder | Mapping[str, Any]) -> DeliveryWorkflowType:
+        data = self._data(order)
+        explicit_workflow = normalize_workflow_type(data.get("workflow_type"))
+        if explicit_workflow:
+            return explicit_workflow
+
+        status = normalize_status(data.get("estado"))
+        if status == DeliveryStatus.PROGRAMADO and not data.get("activated"):
+            return DeliveryWorkflowType.SCHEDULED
+
+        delivery_type = normalize_delivery_type(data.get("delivery_type") or data.get("tipo_entrega"))
+        if delivery_type in {DeliveryType.PICKUP, DeliveryType.SUCURSAL}:
+            return DeliveryWorkflowType.COUNTER
+        return DeliveryWorkflowType.DELIVERY
+
+    def assert_can_transition(self, order: DeliveryOrder | Mapping[str, Any], target_status: Any) -> None:
+        data = self._data(order)
+        current = normalize_status(data.get("estado"))
+        target = normalize_status(target_status)
+        workflow = self.infer_workflow(order)
+        has_pending_adjustment = self._has_pending_adjustment(data)
+        has_responsible = bool(
+            data.get("responsable_entrega")
+            or data.get("responsable")
+            or data.get("driver_id")
+            or data.get("has_responsible_party")
+        )
+
+        if current == target:
+            return
+        if current == DeliveryStatus.ENTREGADO:
+            raise ValueError("Pedido entregado no puede regresar sin proceso explícito de reverso.")
+        if current == DeliveryStatus.CANCELADO:
+            if not self.allow_cancelled_reactivation or target != DeliveryStatus.PENDIENTE:
+                raise ValueError("Pedido cancelado solo puede reactivarse a pendiente.")
+            return
+        if workflow == DeliveryWorkflowType.SCHEDULED and target in {
+            DeliveryStatus.PREPARACION,
+            DeliveryStatus.EN_RUTA,
+            DeliveryStatus.ENTREGADO,
+        }:
+            raise ValueError("Pedido programado: primero debe activarse antes de pasar a flujo operativo.")
+        if workflow == DeliveryWorkflowType.COUNTER and target == DeliveryStatus.EN_RUTA:
+            raise ValueError("Flujo mostrador no permite estado 'en_ruta'.")
+        if workflow == DeliveryWorkflowType.DELIVERY and current == DeliveryStatus.PREPARACION and target == DeliveryStatus.ENTREGADO:
+            raise ValueError("Flujo delivery debe pasar por 'en_ruta' antes de entregarse.")
+        if target == DeliveryStatus.ENTREGADO and not has_responsible:
+            raise ValueError("No se puede entregar sin responsable.")
+        if target in {DeliveryStatus.EN_RUTA, DeliveryStatus.ENTREGADO} and has_pending_adjustment:
+            raise ValueError("Hay un ajuste de peso/cantidad pendiente de aceptación del cliente.")
+
+        allowed: dict[DeliveryStatus, tuple[DeliveryStatus, ...]] = {
+            DeliveryStatus.PENDIENTE: (DeliveryStatus.PREPARACION, DeliveryStatus.CANCELADO),
+            DeliveryStatus.PREPARACION: (DeliveryStatus.EN_RUTA, DeliveryStatus.ENTREGADO, DeliveryStatus.CANCELADO),
+            DeliveryStatus.EN_RUTA: (DeliveryStatus.ENTREGADO, DeliveryStatus.CANCELADO),
+            DeliveryStatus.PROGRAMADO: (DeliveryStatus.PENDIENTE, DeliveryStatus.CANCELADO),
+            DeliveryStatus.CANCELADO: (DeliveryStatus.PENDIENTE,),
+            DeliveryStatus.ENTREGADO: (),
+        }
+        if target not in allowed[current]:
+            raise ValueError(f"Transición delivery inválida: {current.value} -> {target.value}.")
+
+    def get_valid_actions(self, order: DeliveryOrder | Mapping[str, Any]) -> list[str]:
+        data = self._data(order)
+        status = normalize_status(data.get("estado"))
+        workflow = self.infer_workflow(order)
+        has_pending_adjustment = self._has_pending_adjustment(data)
+
+        if status == DeliveryStatus.PROGRAMADO:
+            return [ACTION_ACTIVATE_SCHEDULED, ACTION_RESCHEDULE, ACTION_CANCEL]
+        if status == DeliveryStatus.PENDIENTE:
+            return [ACTION_PREPARE, ACTION_CANCEL]
+        if status == DeliveryStatus.PREPARACION:
+            actions = [ACTION_ADJUST_WEIGHT, ACTION_CANCEL]
+            if workflow == DeliveryWorkflowType.COUNTER:
+                actions.insert(1, ACTION_DELIVER)
+            else:
+                actions[1:1] = [ACTION_ASSIGN_DRIVER, ACTION_SEND_TO_ROUTE]
+            if has_pending_adjustment:
+                actions = [a for a in actions if a not in {ACTION_SEND_TO_ROUTE, ACTION_DELIVER}]
+            return actions
+        if status == DeliveryStatus.EN_RUTA:
+            actions = [ACTION_DELIVER, ACTION_NOTIFY_WHATSAPP]
+            if has_pending_adjustment:
+                actions = [a for a in actions if a != ACTION_DELIVER]
+            return actions
+        if status == DeliveryStatus.ENTREGADO:
+            return [ACTION_PRINT]
+        if status == DeliveryStatus.CANCELADO:
+            return [ACTION_REACTIVATE] if self.allow_cancelled_reactivation else []
+        return []

--- a/pos_spj_v13.4/core/delivery/domain/states.py
+++ b/pos_spj_v13.4/core/delivery/domain/states.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Mapping, TypeVar
+
+
+class DeliveryStatus(StrEnum):
+    PENDIENTE = "pendiente"
+    PREPARACION = "preparacion"
+    EN_RUTA = "en_ruta"
+    ENTREGADO = "entregado"
+    CANCELADO = "cancelado"
+    PROGRAMADO = "programado"
+
+
+class DeliveryWorkflowType(StrEnum):
+    DELIVERY = "delivery"
+    COUNTER = "counter"
+    SCHEDULED = "scheduled"
+
+
+class DeliveryType(StrEnum):
+    HOME_DELIVERY = "home_delivery"
+    PICKUP = "pickup"
+    SUCURSAL = "sucursal"
+
+
+class AdjustmentStatus(StrEnum):
+    NONE = "none"
+    AUTO_ACCEPTED = "auto_accepted"
+    PENDING_CUSTOMER = "pending_customer"
+    CUSTOMER_ACCEPTED = "customer_accepted"
+    CUSTOMER_REJECTED = "customer_rejected"
+    EXPIRED = "expired"
+
+
+LEGACY_STATUS_MAP: Mapping[str, DeliveryStatus] = {
+    "asignado": DeliveryStatus.PREPARACION,
+    "listo": DeliveryStatus.PREPARACION,
+    "en_camino": DeliveryStatus.EN_RUTA,
+    "pendiente_wa": DeliveryStatus.PENDIENTE,
+    "en_preparacion": DeliveryStatus.PREPARACION,
+    "entregada": DeliveryStatus.ENTREGADO,
+    "cancelada": DeliveryStatus.CANCELADO,
+}
+
+WORKFLOW_ALIASES: Mapping[str, DeliveryWorkflowType] = {
+    "delivery": DeliveryWorkflowType.DELIVERY,
+    "domicilio": DeliveryWorkflowType.DELIVERY,
+    "home_delivery": DeliveryWorkflowType.DELIVERY,
+    "counter": DeliveryWorkflowType.COUNTER,
+    "mostrador": DeliveryWorkflowType.COUNTER,
+    "pickup": DeliveryWorkflowType.COUNTER,
+    "sucursal": DeliveryWorkflowType.COUNTER,
+    "scheduled": DeliveryWorkflowType.SCHEDULED,
+    "programado": DeliveryWorkflowType.SCHEDULED,
+}
+
+DELIVERY_TYPE_ALIASES: Mapping[str, DeliveryType] = {
+    "home_delivery": DeliveryType.HOME_DELIVERY,
+    "delivery": DeliveryType.HOME_DELIVERY,
+    "domicilio": DeliveryType.HOME_DELIVERY,
+    "envio": DeliveryType.HOME_DELIVERY,
+    "pickup": DeliveryType.PICKUP,
+    "recoger": DeliveryType.PICKUP,
+    "mostrador": DeliveryType.PICKUP,
+    "counter": DeliveryType.PICKUP,
+    "sucursal": DeliveryType.SUCURSAL,
+}
+
+T = TypeVar("T", bound=StrEnum)
+
+
+def _enum_value(value: Any) -> str:
+    return str(value.value if isinstance(value, StrEnum) else value or "").strip().lower()
+
+
+def normalize_status(status: Any) -> DeliveryStatus:
+    raw = _enum_value(status)
+    if not raw:
+        return DeliveryStatus.PENDIENTE
+    if raw in LEGACY_STATUS_MAP:
+        return LEGACY_STATUS_MAP[raw]
+    try:
+        return DeliveryStatus(raw)
+    except ValueError as exc:
+        raise ValueError(f"Estado delivery desconocido: {status!r}") from exc
+
+
+def normalize_workflow_type(workflow_type: Any) -> DeliveryWorkflowType | None:
+    raw = _enum_value(workflow_type)
+    if not raw:
+        return None
+    if raw in WORKFLOW_ALIASES:
+        return WORKFLOW_ALIASES[raw]
+    try:
+        return DeliveryWorkflowType(raw)
+    except ValueError as exc:
+        raise ValueError(f"Workflow delivery desconocido: {workflow_type!r}") from exc
+
+
+def normalize_delivery_type(delivery_type: Any) -> DeliveryType | None:
+    raw = _enum_value(delivery_type)
+    if not raw:
+        return None
+    if raw in DELIVERY_TYPE_ALIASES:
+        return DELIVERY_TYPE_ALIASES[raw]
+    try:
+        return DeliveryType(raw)
+    except ValueError as exc:
+        raise ValueError(f"Tipo delivery desconocido: {delivery_type!r}") from exc
+
+
+def normalize_adjustment_status(status: Any) -> AdjustmentStatus:
+    raw = _enum_value(status)
+    if not raw:
+        return AdjustmentStatus.NONE
+    # Backwards-compatible values currently persisted by DeliveryService.
+    if raw == "accepted":
+        return AdjustmentStatus.CUSTOMER_ACCEPTED
+    if raw == "rejected":
+        return AdjustmentStatus.CUSTOMER_REJECTED
+    try:
+        return AdjustmentStatus(raw)
+    except ValueError as exc:
+        raise ValueError(f"Estado de ajuste desconocido: {status!r}") from exc

--- a/pos_spj_v13.4/core/delivery/domain/value_objects.py
+++ b/pos_spj_v13.4/core/delivery/domain/value_objects.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+
+
+@dataclass(frozen=True, slots=True)
+class Quantity:
+    value: Decimal
+    unit: str = "u"
+
+    def __init__(self, value: float | int | str | Decimal, unit: str = "u") -> None:
+        decimal_value = Decimal(str(value or 0))
+        if decimal_value < 0:
+            raise ValueError("La cantidad delivery no puede ser negativa.")
+        object.__setattr__(self, "value", decimal_value)
+        object.__setattr__(self, "unit", (unit or "u").strip().lower())
+
+    def as_float(self) -> float:
+        return float(self.value)
+
+
+@dataclass(frozen=True, slots=True)
+class Money:
+    amount: Decimal
+
+    def __init__(self, amount: float | int | str | Decimal) -> None:
+        quantized = Decimal(str(amount or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        object.__setattr__(self, "amount", quantized)
+
+    def as_float(self) -> float:
+        return float(self.amount)
+
+
+@dataclass(frozen=True, slots=True)
+class GeoPoint:
+    lat: float
+    lng: float
+
+    def __post_init__(self) -> None:
+        if not -90 <= float(self.lat) <= 90:
+            raise ValueError("Latitud delivery fuera de rango.")
+        if not -180 <= float(self.lng) <= 180:
+            raise ValueError("Longitud delivery fuera de rango.")

--- a/pos_spj_v13.4/core/delivery/infrastructure/__init__.py
+++ b/pos_spj_v13.4/core/delivery/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure adapters for the delivery module."""

--- a/pos_spj_v13.4/core/delivery/infrastructure/delivery_outbox_repository.py
+++ b/pos_spj_v13.4/core/delivery/infrastructure/delivery_outbox_repository.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from core.delivery.infrastructure.delivery_schema_migrator import DeliverySchemaMigrator
+
+
+class DeliveryOutboxRepository:
+    """SQLite repository for transactional delivery outbox events."""
+
+    def __init__(self, db) -> None:
+        if db is None:
+            raise ValueError("DeliveryOutboxRepository requiere una conexión SQLite válida.")
+        self.db = db
+        DeliverySchemaMigrator(db).ensure_schema()
+
+    def enqueue(
+        self,
+        *,
+        event_type: str,
+        aggregate_id: int,
+        payload: dict[str, Any],
+        aggregate_type: str = "delivery_order",
+        operation_id: str | None = None,
+        commit: bool = False,
+    ) -> int:
+        clean_payload = self._without_db(payload)
+        effective_operation_id = operation_id or clean_payload.get("operation_id")
+        if effective_operation_id:
+            existing = self.db.execute(
+                """
+                SELECT id FROM delivery_outbox_events
+                WHERE event_type=? AND aggregate_id=? AND operation_id=?
+                LIMIT 1
+                """,
+                (event_type, int(aggregate_id), str(effective_operation_id)),
+            ).fetchone()
+            if existing:
+                return int(existing[0])
+        cur = self.db.execute(
+            """
+            INSERT INTO delivery_outbox_events(
+                event_type, aggregate_type, aggregate_id, payload_json,
+                status, retries, operation_id
+            ) VALUES(?,?,?,?, 'pending', 0, ?)
+            """,
+            (
+                event_type,
+                aggregate_type,
+                int(aggregate_id),
+                json.dumps(clean_payload, ensure_ascii=False, sort_keys=True),
+                str(effective_operation_id) if effective_operation_id else None,
+            ),
+        )
+        if commit:
+            self.db.commit()
+        return int(cur.lastrowid)
+
+    def fetch_pending(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        rows = self.db.execute(
+            """
+            SELECT * FROM delivery_outbox_events
+            WHERE status='pending'
+            ORDER BY id ASC
+            LIMIT ?
+            """,
+            (int(limit),),
+        ).fetchall()
+        return [self._row_to_dict(row) for row in rows]
+
+    def mark_done(self, event_id: int, *, commit: bool = True) -> None:
+        self.db.execute(
+            """
+            UPDATE delivery_outbox_events
+            SET status='done', processed_at=datetime('now'), last_error=NULL
+            WHERE id=?
+            """,
+            (int(event_id),),
+        )
+        if commit:
+            self.db.commit()
+
+    def mark_error(self, event_id: int, error: str, *, commit: bool = True) -> None:
+        self.db.execute(
+            """
+            UPDATE delivery_outbox_events
+            SET retries=COALESCE(retries, 0) + 1, last_error=?, status='pending'
+            WHERE id=?
+            """,
+            (str(error)[:1000], int(event_id)),
+        )
+        if commit:
+            self.db.commit()
+
+    def payload_for(self, event_id: int) -> dict[str, Any] | None:
+        row = self.db.execute(
+            "SELECT payload_json FROM delivery_outbox_events WHERE id=?",
+            (int(event_id),),
+        ).fetchone()
+        if not row:
+            return None
+        return json.loads(row[0] or "{}")
+
+    def _row_to_dict(self, row) -> dict[str, Any]:
+        data = dict(row)
+        data["payload"] = json.loads(data.get("payload_json") or "{}")
+        return data
+
+    def _without_db(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {k: self._without_db(v) for k, v in value.items() if k != "db"}
+        if isinstance(value, list):
+            return [self._without_db(v) for v in value]
+        if isinstance(value, tuple):
+            return [self._without_db(v) for v in value]
+        return value

--- a/pos_spj_v13.4/core/delivery/infrastructure/delivery_schema_migrator.py
+++ b/pos_spj_v13.4/core/delivery/infrastructure/delivery_schema_migrator.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+logger = logging.getLogger("spj.delivery.schema")
+
+
+class DeliverySchemaMigrator:
+    """Owns SQLite schema compatibility for delivery tables.
+
+    The legacy repository and service may call this as a temporary shim, but all
+    create/alter/index SQL is centralized here so repository methods stay focused
+    on persistence operations.
+    """
+
+    DELIVERY_ORDER_COLUMNS: tuple[str, ...] = (
+        "venta_id INTEGER",
+        "folio TEXT",
+        "whatsapp_order_id TEXT",
+        "cliente_id INTEGER",
+        "cliente_nombre TEXT",
+        "cliente_tel TEXT",
+        "direccion TEXT NOT NULL DEFAULT 'Sin dirección'",
+        "lat REAL",
+        "lng REAL",
+        "estado TEXT DEFAULT 'pendiente'",
+        "notas TEXT",
+        "total REAL DEFAULT 0",
+        "responsable_entrega TEXT",
+        "usuario TEXT",
+        "fecha DATETIME",
+        "fecha_actualizacion DATETIME",
+        "historial_cambios TEXT",
+        "driver_id INTEGER",
+        "sucursal_id INTEGER DEFAULT 1",
+        "workflow_type TEXT",
+        "delivery_type TEXT",
+        "scheduled_at DATETIME",
+        "source_channel TEXT DEFAULT 'whatsapp'",
+        "weight_adjusted INTEGER DEFAULT 0",
+        "pago_metodo TEXT DEFAULT ''",
+        "pago_monto REAL DEFAULT 0",
+        "costo_envio REAL DEFAULT 0",
+        "adjustment_pending INTEGER DEFAULT 0",
+        "adjustment_blocked_state TEXT DEFAULT ''",
+    )
+    DELIVERY_ITEM_COLUMNS: tuple[str, ...] = (
+        "delivery_id INTEGER NOT NULL DEFAULT 0",
+        "producto_id INTEGER",
+        "nombre TEXT NOT NULL DEFAULT 'Producto'",
+        "cantidad REAL NOT NULL DEFAULT 0",
+        "precio_unitario REAL NOT NULL DEFAULT 0",
+        "subtotal REAL NOT NULL DEFAULT 0",
+        "unidad TEXT DEFAULT 'kg'",
+        "requested_qty REAL",
+        "prepared_qty REAL",
+        "final_qty REAL",
+        "prepared_by TEXT",
+        "prepared_at DATETIME",
+        "adjustment_reason TEXT",
+        "tolerance_exceeded INTEGER DEFAULT 0",
+        "pending_prepared_qty REAL",
+        "pending_subtotal REAL",
+        "adjustment_status TEXT DEFAULT 'none'",
+        "adjustment_requested_at DATETIME",
+        "adjustment_responded_at DATETIME",
+        "adjustment_response TEXT",
+        "adjustment_token TEXT",
+        "tolerance_units REAL DEFAULT 0.2",
+    )
+    DELIVERY_HISTORY_COLUMNS: tuple[str, ...] = (
+        "order_id INTEGER NOT NULL DEFAULT 0",
+        "estado_anterior TEXT",
+        "estado_nuevo TEXT",
+        "usuario TEXT",
+        "fecha DATETIME",
+        "observacion TEXT",
+        "reason TEXT",
+        "metadata_json TEXT",
+        "event_id INTEGER",
+        "created_at DATETIME",
+    )
+    DRIVER_COLUMNS: tuple[str, ...] = (
+        "nombre TEXT NOT NULL DEFAULT ''",
+        "telefono TEXT",
+        "vehiculo TEXT",
+        "activo INTEGER DEFAULT 1",
+        "en_ruta INTEGER DEFAULT 0",
+        "sucursal_id INTEGER DEFAULT 1",
+        "usuario_id INTEGER",
+    )
+
+    DELIVERY_OUTBOX_COLUMNS: tuple[str, ...] = (
+        "event_type TEXT NOT NULL DEFAULT ''",
+        "aggregate_type TEXT DEFAULT 'delivery_order'",
+        "aggregate_id INTEGER NOT NULL DEFAULT 0",
+        "payload_json TEXT NOT NULL DEFAULT '{}'",
+        "status TEXT DEFAULT 'pending'",
+        "retries INTEGER DEFAULT 0",
+        "last_error TEXT",
+        "created_at DATETIME DEFAULT CURRENT_TIMESTAMP",
+        "processed_at DATETIME",
+        "operation_id TEXT",
+    )
+
+    def __init__(self, db) -> None:
+        if db is None:
+            raise ValueError("DeliverySchemaMigrator requiere una conexión SQLite válida.")
+        self.db = db
+
+    def ensure_schema(self) -> None:
+        self._create_base_tables()
+        self._add_missing_columns("delivery_orders", self.DELIVERY_ORDER_COLUMNS)
+        self._add_missing_columns("delivery_items", self.DELIVERY_ITEM_COLUMNS)
+        self._add_missing_columns("delivery_order_history", self.DELIVERY_HISTORY_COLUMNS)
+        self._add_missing_columns("drivers", self.DRIVER_COLUMNS)
+        self._add_missing_columns("delivery_outbox_events", self.DELIVERY_OUTBOX_COLUMNS)
+        self._create_indexes()
+        self.db.commit()
+
+    def _create_base_tables(self) -> None:
+        self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS delivery_orders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                venta_id INTEGER,
+                folio TEXT,
+                whatsapp_order_id TEXT,
+                cliente_id INTEGER,
+                cliente_nombre TEXT,
+                cliente_tel TEXT,
+                direccion TEXT NOT NULL,
+                lat REAL,
+                lng REAL,
+                estado TEXT DEFAULT 'pendiente',
+                notas TEXT,
+                total REAL DEFAULT 0,
+                responsable_entrega TEXT,
+                usuario TEXT,
+                fecha DATETIME DEFAULT (datetime('now')),
+                fecha_actualizacion DATETIME,
+                historial_cambios TEXT,
+                driver_id INTEGER,
+                sucursal_id INTEGER DEFAULT 1,
+                workflow_type TEXT,
+                delivery_type TEXT,
+                scheduled_at DATETIME,
+                source_channel TEXT DEFAULT 'whatsapp'
+            )
+            """
+        )
+        self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS delivery_items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                delivery_id INTEGER NOT NULL,
+                producto_id INTEGER,
+                nombre TEXT NOT NULL,
+                cantidad REAL NOT NULL DEFAULT 0,
+                precio_unitario REAL NOT NULL DEFAULT 0,
+                subtotal REAL NOT NULL DEFAULT 0,
+                unidad TEXT DEFAULT 'kg',
+                requested_qty REAL,
+                prepared_qty REAL,
+                final_qty REAL,
+                prepared_by TEXT,
+                prepared_at DATETIME,
+                adjustment_reason TEXT,
+                tolerance_exceeded INTEGER DEFAULT 0
+            )
+            """
+        )
+        self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS delivery_order_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                order_id INTEGER NOT NULL,
+                estado_anterior TEXT,
+                estado_nuevo TEXT,
+                usuario TEXT,
+                fecha DATETIME DEFAULT (datetime('now')),
+                observacion TEXT,
+                reason TEXT,
+                metadata_json TEXT,
+                event_id INTEGER,
+                created_at DATETIME DEFAULT (datetime('now'))
+            )
+            """
+        )
+        self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS drivers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                nombre TEXT NOT NULL,
+                telefono TEXT,
+                vehiculo TEXT,
+                activo INTEGER DEFAULT 1,
+                en_ruta INTEGER DEFAULT 0,
+                sucursal_id INTEGER DEFAULT 1,
+                usuario_id INTEGER
+            )
+            """
+        )
+
+        self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS delivery_outbox_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT NOT NULL,
+                aggregate_type TEXT DEFAULT 'delivery_order',
+                aggregate_id INTEGER NOT NULL,
+                payload_json TEXT NOT NULL,
+                status TEXT DEFAULT 'pending',
+                retries INTEGER DEFAULT 0,
+                last_error TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                processed_at DATETIME,
+                operation_id TEXT
+            )
+            """
+        )
+
+    def _add_missing_columns(self, table: str, column_definitions: Iterable[str]) -> None:
+        existing = self._column_names(table)
+        for definition in column_definitions:
+            column_name = definition.strip().split()[0]
+            if column_name in existing:
+                continue
+            self.db.execute(f"ALTER TABLE {table} ADD COLUMN {definition}")
+            existing.add(column_name)
+
+    def _column_names(self, table: str) -> set[str]:
+        rows = self.db.execute(f"PRAGMA table_info({table})").fetchall()
+        return {row[1] for row in rows}
+
+    def _create_indexes(self) -> None:
+        for sql in (
+            "CREATE INDEX IF NOT EXISTS idx_delivery_estado ON delivery_orders(estado, fecha)",
+            "CREATE INDEX IF NOT EXISTS idx_delivery_wa ON delivery_orders(whatsapp_order_id)",
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_delivery_venta ON delivery_orders(venta_id) WHERE venta_id IS NOT NULL",
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_delivery_wa_order ON delivery_orders(whatsapp_order_id) WHERE whatsapp_order_id IS NOT NULL",
+            "CREATE INDEX IF NOT EXISTS idx_delivery_items_delivery_id ON delivery_items(delivery_id)",
+            "CREATE INDEX IF NOT EXISTS idx_delivery_items_adjustment_status ON delivery_items(adjustment_status, delivery_id)",
+            "CREATE INDEX IF NOT EXISTS idx_delivery_items_adjustment_token ON delivery_items(adjustment_token)",
+            "CREATE INDEX IF NOT EXISTS idx_delivery_orders_adjustment_pending ON delivery_orders(adjustment_pending, estado)",
+            "CREATE INDEX IF NOT EXISTS idx_delivery_workflow_status ON delivery_orders(workflow_type, estado)",
+            "CREATE INDEX IF NOT EXISTS idx_delivery_history_order_created ON delivery_order_history(order_id, created_at)",
+            "CREATE INDEX IF NOT EXISTS idx_delivery_history_event_id ON delivery_order_history(event_id)",
+            "CREATE INDEX IF NOT EXISTS idx_delivery_outbox_pending ON delivery_outbox_events(status, id)",
+            "CREATE INDEX IF NOT EXISTS idx_delivery_outbox_aggregate ON delivery_outbox_events(aggregate_type, aggregate_id)",
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_delivery_outbox_operation ON delivery_outbox_events(event_type, aggregate_id, operation_id) WHERE operation_id IS NOT NULL",
+        ):
+            self.db.execute(sql)

--- a/pos_spj_v13.4/core/delivery/infrastructure/inventory_reservation_adapter.py
+++ b/pos_spj_v13.4/core/delivery/infrastructure/inventory_reservation_adapter.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.services.reservation_service import ReservationService
+
+logger = logging.getLogger("spj.delivery.inventory.adapter")
+
+
+class ReservationServiceInventoryAdapter:
+    """InventoryReservationPort implementation backed by ReservationService.
+
+    It keeps delivery application code independent from the concrete inventory
+    implementation while preserving the legacy reservation tables.
+    """
+
+    def __init__(self, db, reservation_service: ReservationService | None = None) -> None:
+        if db is None:
+            raise ValueError("ReservationServiceInventoryAdapter requiere una conexión SQLite válida.")
+        self.db = db
+        self.reservation_service = reservation_service or ReservationService()
+        self._ensure_reservation_schema()
+
+
+    def _ensure_reservation_schema(self) -> None:
+        self.db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS inventory_reservations (
+                id TEXT PRIMARY KEY,
+                branch_id INTEGER NOT NULL,
+                product_id INTEGER NOT NULL,
+                reserved_qty REAL NOT NULL CHECK(reserved_qty > 0),
+                operation_id TEXT NOT NULL,
+                operation_type TEXT NOT NULL,
+                expires_at DATETIME NOT NULL,
+                released INTEGER NOT NULL DEFAULT 0,
+                created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+            )
+            """
+        )
+        self.db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_inventory_reservations_operation "
+            "ON inventory_reservations(operation_id, product_id, branch_id, released)"
+        )
+        self.db.commit()
+
+    def reserve_for_order(
+        self,
+        *,
+        order_id: int,
+        items: list[dict[str, Any]],
+        branch_id: int,
+        operation_id: str,
+    ) -> dict[str, int]:
+        reserved = 0
+        skipped = 0
+        for item in items or []:
+            product_id = item.get("producto_id") or item.get("product_id")
+            qty = float(item.get("cantidad") or item.get("qty") or 0)
+            if not product_id or qty <= 0:
+                skipped += 1
+                continue
+            if self._active_reservation_exists(operation_id, int(product_id), branch_id):
+                skipped += 1
+                continue
+            self.reservation_service.reserve(
+                db=self.db,
+                product_id=int(product_id),
+                qty=qty,
+                operation_id=operation_id,
+                branch_id=branch_id,
+                operation_type="delivery",
+            )
+            reserved += 1
+        return {"reserved": reserved, "skipped": skipped}
+
+    def release_for_order(self, *, order_id: int, operation_id: str, reason: str = "") -> dict[str, int]:
+        released = self.reservation_service.release_by_operation(self.db, operation_id=operation_id)
+        return {"released": int(released or 0)}
+
+    def commit_for_order(
+        self,
+        *,
+        order_id: int,
+        items: list[dict[str, Any]],
+        branch_id: int,
+        operation_id: str,
+    ) -> dict[str, int]:
+        committed = 0
+        skipped = 0
+        from core.services.inventory_service import InventoryService
+
+        inventory_service = InventoryService(self.db)
+        for item in items or []:
+            product_id = item.get("producto_id") or item.get("product_id")
+            qty = self._commit_qty(item)
+            if not product_id or qty <= 0:
+                skipped += 1
+                continue
+            item_operation_id = self._item_operation_id(order_id, item, int(product_id))
+            if self._movement_exists(item_operation_id):
+                skipped += 1
+                continue
+            inventory_service.deduct_stock(
+                product_id=int(product_id),
+                branch_id=branch_id,
+                qty=qty,
+                reference_type="delivery_prepared",
+                reference_id=str(order_id),
+                operation_id=item_operation_id,
+                user="sistema",
+                notes=f"delivery final/prepared qty={qty:.3f} source_op={operation_id}",
+            )
+            committed += 1
+        released = self.reservation_service.release_by_operation(self.db, operation_id=operation_id)
+        return {"committed": committed, "skipped": skipped, "released": int(released or 0)}
+
+    def _active_reservation_exists(self, operation_id: str, product_id: int, branch_id: int) -> bool:
+        row = self.db.execute(
+            """
+            SELECT 1 FROM inventory_reservations
+            WHERE operation_id=? AND product_id=? AND branch_id=? AND released=0
+            LIMIT 1
+            """,
+            (operation_id, product_id, branch_id),
+        ).fetchone()
+        return row is not None
+
+    def _movement_exists(self, operation_id: str) -> bool:
+        try:
+            row = self.db.execute(
+                "SELECT 1 FROM movimientos_inventario WHERE operation_id=? LIMIT 1",
+                (operation_id,),
+            ).fetchone()
+            return row is not None
+        except Exception as exc:
+            logger.debug("movement idempotency check skipped op=%s: %s", operation_id, exc)
+            return False
+
+    @staticmethod
+    def _commit_qty(item: dict[str, Any]) -> float:
+        return float(item.get("final_qty") or item.get("prepared_qty") or item.get("cantidad") or item.get("qty") or 0)
+
+    @staticmethod
+    def _item_operation_id(order_id: int, item: dict[str, Any], product_id: int) -> str:
+        item_id = item.get("id") or item.get("item_id") or product_id
+        return f"delivery:{order_id}:item:{item_id}:commit"

--- a/pos_spj_v13.4/core/delivery/infrastructure/whatsapp_delivery_notifier.py
+++ b/pos_spj_v13.4/core/delivery/infrastructure/whatsapp_delivery_notifier.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.integrations.whatsapp_client import WhatsAppClient
+
+logger = logging.getLogger("spj.delivery.whatsapp_notifier")
+
+
+class WhatsAppDeliveryNotifier:
+    """DeliveryNotifierPort implementation backed by WhatsAppClient.
+
+    Message templates live here so application use cases emit notification
+    requests instead of building long WhatsApp strings inline.
+    """
+
+    STATUS_TEMPLATES: dict[str, str] = {
+        "pedido_recibido": "✅ Recibimos tu pedido {folio}. Lo estamos validando.",
+        "pendiente": "✅ Tu pedido {folio} quedó registrado.",
+        "preparacion": "👩‍🍳 Tu pedido {folio} está en preparación.",
+        "en_ruta": "🛵 Tu pedido {folio} va en ruta.",
+        "entregado": "🎉 Tu pedido {folio} fue entregado. ¡Gracias!",
+        "cancelado": "❌ Tu pedido {folio} fue cancelado.",
+    }
+
+    def __init__(self, client: WhatsAppClient | None = None) -> None:
+        self.client = client or WhatsAppClient()
+
+    def notify_status(self, *, phone: str, folio: str, status: str) -> bool:
+        template = self.STATUS_TEMPLATES.get((status or "").strip().lower())
+        if not template:
+            return False
+        return self._send(phone, template.format(folio=folio or ""), template=status)
+
+    def notify_adjustment_required(
+        self,
+        *,
+        phone: str,
+        folio: str,
+        item_name: str = "Producto",
+        requested_qty: float = 0,
+        prepared_qty: float = 0,
+        unit: str = "kg",
+        new_subtotal: float = 0,
+        diff_qty: float | None = None,
+    ) -> bool:
+        diff = prepared_qty - requested_qty if diff_qty is None else float(diff_qty)
+        sign = "+" if diff >= 0 else ""
+        message = (
+            f"⚖️ *Ajuste de tu pedido {folio}*\n\n"
+            f"Producto: {item_name}\n"
+            f"Solicitado: {requested_qty:.3g} {unit}\n"
+            f"Preparado: {prepared_qty:.3g} {unit} ({sign}{diff:.3g} {unit})\n"
+            f"Nuevo subtotal: ${new_subtotal:,.2f}\n\n"
+            "Responde *ACEPTAR AJUSTE* para autorizarlo o *RECHAZAR AJUSTE* para mantener el pedido sin ese cambio."
+        )
+        return self._send(phone, message, template="adjustment_required")
+
+    def notify_weight_adjustment(
+        self,
+        *,
+        phone: str,
+        folio: str,
+        requested_qty: float,
+        prepared_qty: float,
+        unit: str = "kg",
+        new_total: float = 0,
+        payment_url: str = "",
+    ) -> bool:
+        diff = prepared_qty - requested_qty
+        sign = "+" if diff >= 0 else ""
+        message = (
+            f"📦 Actualización pedido #{folio}\n"
+            f"Peso solicitado: {requested_qty:.3g} {unit}\n"
+            f"Peso real: {prepared_qty:.3g} {unit} ({sign}{diff:.3g} {unit})\n"
+            f"Total: ${new_total:,.2f}"
+        )
+        if payment_url:
+            message += f"\nPago: {payment_url}"
+        message += "\n🛵 ¡Pronto en camino!"
+        return self._send(phone, message, template="weight_adjustment")
+
+    def notify_out_for_delivery(self, *, phone: str, folio: str, driver_name: str = "", eta: str = "") -> bool:
+        details = []
+        if driver_name:
+            details.append(f"Repartidor: {driver_name}")
+        if eta:
+            details.append(f"ETA: {eta}")
+        suffix = "\n" + "\n".join(details) if details else ""
+        return self._send(phone, f"🛵 Tu pedido {folio} va en ruta.{suffix}", template="out_for_delivery")
+
+    def notify_delivered(self, *, phone: str, folio: str) -> bool:
+        return self._send(phone, f"🎉 Tu pedido {folio} fue entregado. ¡Gracias!", template="delivered")
+
+    def notify_from_event(self, payload: dict[str, Any]) -> bool:
+        template = str(payload.get("template") or "").strip().lower()
+        params = payload.get("params") or {}
+        phone = str(payload.get("cliente_tel") or params.get("cliente_tel") or "")
+        folio = str(payload.get("folio") or params.get("folio") or payload.get("order_id") or "")
+
+        if template == "adjustment_required":
+            return self.notify_adjustment_required(
+                phone=phone,
+                folio=folio,
+                item_name=str(params.get("item_name") or "Producto"),
+                requested_qty=float(params.get("requested_qty") or 0),
+                prepared_qty=float(params.get("prepared_qty") or 0),
+                unit=str(params.get("unit") or "kg"),
+                new_subtotal=float(params.get("new_subtotal") or 0),
+                diff_qty=float(params.get("diff_qty") or 0),
+            )
+        if template in {"weight_adjustment", "item_weight_adjusted"}:
+            return self.notify_weight_adjustment(
+                phone=phone,
+                folio=folio,
+                requested_qty=float(params.get("requested_qty") or 0),
+                prepared_qty=float(params.get("prepared_qty") or 0),
+                unit=str(params.get("unit") or "kg"),
+                new_total=float(params.get("new_total") or params.get("total") or 0),
+                payment_url=str(params.get("payment_url") or ""),
+            )
+        if template in {"en_ruta", "out_for_delivery"}:
+            return self.notify_out_for_delivery(
+                phone=phone,
+                folio=folio,
+                driver_name=str(params.get("driver_name") or params.get("driver_nombre") or ""),
+                eta=str(params.get("eta") or ""),
+            )
+        if template in {"entregado", "delivered"}:
+            return self.notify_delivered(phone=phone, folio=folio)
+        return self.notify_status(phone=phone, folio=folio, status=template)
+
+    def _send(self, phone: str, message: str, *, template: str) -> bool:
+        if not phone:
+            return False
+        try:
+            ok = bool(self.client.enviar_mensaje(phone, message))
+            logger.info("whatsapp delivery template=%s phone=%s ok=%s", template, phone[-4:], ok)
+            return ok
+        except Exception as exc:
+            logger.warning("whatsapp delivery template=%s failed: %s", template, exc)
+            return False

--- a/pos_spj_v13.4/core/delivery/projections/__init__.py
+++ b/pos_spj_v13.4/core/delivery/projections/__init__.py
@@ -1,0 +1,1 @@
+"""Read/write projections for delivery integration boundaries."""

--- a/pos_spj_v13.4/core/delivery/projections/delivery_inventory_projection.py
+++ b/pos_spj_v13.4/core/delivery/projections/delivery_inventory_projection.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from core.delivery.domain.events import DeliveryEvents
+from core.delivery.application.ports import InventoryReservationPort
+
+
+class DeliveryInventoryProjectionService:
+    """Routes delivery inventory events to an InventoryReservationPort."""
+
+    def __init__(self, inventory_reservations: InventoryReservationPort) -> None:
+        self.inventory_reservations = inventory_reservations
+
+    def handlers(self):
+        return {
+            DeliveryEvents.ORDER_RESERVED.value: self.handle_order_reserved,
+            DeliveryEvents.INVENTORY_RELEASE_REQUIRED.value: self.handle_inventory_release_required,
+            DeliveryEvents.INVENTORY_COMMIT_REQUIRED.value: self.handle_inventory_commit_required,
+        }
+
+    def handle_order_reserved(self, payload: dict[str, Any]) -> dict[str, int]:
+        order_id = int(payload.get("order_id") or 0)
+        operation_id = str(payload.get("operation_id") or f"delivery:{order_id}")
+        return self.inventory_reservations.reserve_for_order(
+            order_id=order_id,
+            items=list(payload.get("items") or []),
+            branch_id=int(payload.get("branch_id") or payload.get("sucursal_id") or 1),
+            operation_id=operation_id,
+        )
+
+    def handle_inventory_release_required(self, payload: dict[str, Any]) -> dict[str, int]:
+        order_id = int(payload.get("order_id") or 0)
+        operation_id = str(payload.get("operation_id") or f"delivery:{order_id}")
+        return self.inventory_reservations.release_for_order(
+            order_id=order_id,
+            operation_id=operation_id,
+            reason=str(payload.get("reason") or ""),
+        )
+
+    def handle_inventory_commit_required(self, payload: dict[str, Any]) -> dict[str, int]:
+        order_id = int(payload.get("order_id") or 0)
+        operation_id = str(payload.get("operation_id") or f"delivery:{order_id}")
+        return self.inventory_reservations.commit_for_order(
+            order_id=order_id,
+            items=list(payload.get("items") or []),
+            branch_id=int(payload.get("branch_id") or payload.get("sucursal_id") or 1),
+            operation_id=operation_id,
+        )

--- a/pos_spj_v13.4/core/delivery/projections/sale_delivery_projection.py
+++ b/pos_spj_v13.4/core/delivery/projections/sale_delivery_projection.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from core.delivery.domain.states import DeliveryStatus, normalize_status
+
+logger = logging.getLogger("spj.delivery.projections.sales")
+
+
+class SaleDeliveryProjectionService:
+    """Projects logistical delivery state into the commercial sale record.
+
+    Source of truth remains `delivery_orders` for logistics. `ventas` is updated
+    only through this projection as a secondary commercial/fiscal view.
+    """
+
+    STATUS_TO_SALE_STATUS: Mapping[DeliveryStatus, str] = {
+        DeliveryStatus.PENDIENTE: "pendiente_wa",
+        DeliveryStatus.PREPARACION: "en_preparacion",
+        DeliveryStatus.EN_RUTA: "en_ruta",
+        DeliveryStatus.ENTREGADO: "entregada",
+        DeliveryStatus.CANCELADO: "cancelada",
+    }
+
+    def __init__(self, db) -> None:
+        self.db = db
+
+    def project_status_for_order(self, order: Mapping[str, Any] | None, status: str | DeliveryStatus) -> bool:
+        if not order:
+            return False
+        return self.project_status(order.get("venta_id"), status)
+
+    def project_status(self, venta_id: Any, status: str | DeliveryStatus) -> bool:
+        if not venta_id or not self._has_column("ventas", "estado"):
+            return False
+        sale_status = self.STATUS_TO_SALE_STATUS.get(normalize_status(status))
+        if not sale_status:
+            return False
+        self.db.execute("UPDATE ventas SET estado=? WHERE id=?", (sale_status, int(venta_id)))
+        return True
+
+    def project_total_for_order(self, order: Mapping[str, Any] | None, total: float) -> bool:
+        if not order:
+            return False
+        return self.project_total(order.get("venta_id"), total)
+
+    def project_total(self, venta_id: Any, total: float) -> bool:
+        if not venta_id or not self._has_column("ventas", "total"):
+            return False
+        self.db.execute("UPDATE ventas SET total=? WHERE id=?", (float(total), int(venta_id)))
+        return True
+
+    def project_scheduled_activation(self, venta_id: Any, workflow_type: str) -> bool:
+        if not venta_id:
+            return False
+        columns = self._columns("ventas")
+        assignments: list[str] = []
+        values: list[Any] = []
+        if "workflow_type" in columns:
+            assignments.append("workflow_type=?")
+            values.append(workflow_type)
+        if "estado" in columns:
+            assignments.append("estado=?")
+            values.append("pendiente")
+        if not assignments:
+            return False
+        values.append(int(venta_id))
+        self.db.execute(f"UPDATE ventas SET {', '.join(assignments)} WHERE id=?", tuple(values))
+        return True
+
+    def _has_column(self, table: str, column: str) -> bool:
+        return column in self._columns(table)
+
+    def _columns(self, table: str) -> set[str]:
+        try:
+            return {row[1] for row in self.db.execute(f"PRAGMA table_info({table})").fetchall()}
+        except Exception as exc:
+            logger.debug("No se pudieron consultar columnas de %s: %s", table, exc)
+            return set()

--- a/pos_spj_v13.4/core/events/event_bus.py
+++ b/pos_spj_v13.4/core/events/event_bus.py
@@ -179,6 +179,7 @@ DELIVERY_OUT_FOR_DELIVERY     = "DELIVERY_OUT_FOR_DELIVERY"       # order_id, dr
 DELIVERY_ORDER_DELIVERED      = "DELIVERY_ORDER_DELIVERED"        # order_id, folio, driver_id, total, sucursal_id
 DELIVERY_ORDER_CANCELLED      = "DELIVERY_ORDER_CANCELLED"        # order_id, folio, usuario, motivo
 INVENTORY_COMMIT_REQUIRED     = "INVENTORY_COMMIT_REQUIRED"       # order_id, items[], sucursal_id, operation_id
+INVENTORY_RELEASE_REQUIRED    = "INVENTORY_RELEASE_REQUIRED"      # order_id, operation_id, reason
 CUSTOMER_NOTIFICATION_REQUESTED = "CUSTOMER_NOTIFICATION_REQUESTED"  # order_id, canal, template, params, cliente_tel
 DRIVER_SETTLEMENT_CREATED     = "DRIVER_SETTLEMENT_CREATED"       # cut_id, driver_id, driver_nombre, efectivo, diferencia, fecha
 PURCHASE_SUGGESTION_CREATED   = "PURCHASE_SUGGESTION_CREATED"     # producto_id, cantidad_sugerida, motivo, sucursal_id

--- a/pos_spj_v13.4/core/events/handlers/delivery_handler.py
+++ b/pos_spj_v13.4/core/events/handlers/delivery_handler.py
@@ -137,32 +137,14 @@ class DeliveryWeightAdjustmentHandler:
                 ),
             )
 
-            # Recalculate order total from all items
-            row = db.execute(
-                """SELECT COALESCE(SUM(
-                       CASE WHEN prepared_qty IS NOT NULL AND prepared_qty > 0
-                            THEN prepared_qty * precio_unitario
-                            ELSE subtotal
-                       END), 0)
-                   FROM delivery_items WHERE delivery_id=?""",
-                (order_id,),
-            ).fetchone()
-            new_total = round(float(row[0]) if row else 0.0, 2)
-
             old_row = db.execute(
                 "SELECT total, cliente_tel, folio FROM delivery_orders WHERE id=?",
                 (order_id,),
             ).fetchone()
             old_total = float(old_row[0]) if old_row else 0.0
 
-            db.execute(
-                "UPDATE delivery_orders SET total=?, weight_adjusted=1 WHERE id=?",
-                (new_total, order_id),
-            )
-            try:
-                db.commit()
-            except Exception:
-                pass
+            from core.services.order_total_service import OrderTotalService
+            new_total = OrderTotalService(db).recalculate_order_total(int(order_id))
 
             logger.info(
                 "WeightAdjust: order=%s item=%s req=%.3f prep=%.3f "
@@ -182,7 +164,6 @@ class DeliveryWeightAdjustmentHandler:
                 "folio": folio or str(order_id),
                 "cliente_tel": cliente_tel or "",
                 "cliente_email": payload.get("cliente_email", ""),
-                "db": db,
             })
 
         except Exception as exc:
@@ -353,9 +334,11 @@ class DeliveryNotificationDispatchHandler:
     Payload: {order_id, canal, template, params, cliente_tel, folio, sucursal_id}
     """
 
-    def __init__(self, notification_service=None) -> None:
+    def __init__(self, notification_service=None, whatsapp_notifier=None) -> None:
         self._svc = notification_service
+        self._wa_notifier = whatsapp_notifier
         self._svc_init_failed = False
+        self._wa_init_failed = False
 
     def _get_service(self):
         if self._svc is not None:
@@ -371,12 +354,37 @@ class DeliveryNotificationDispatchHandler:
             self._svc_init_failed = True
             return None
 
+
+    def _get_whatsapp_notifier(self):
+        if self._wa_notifier is not None:
+            return self._wa_notifier
+        if self._wa_init_failed:
+            return None
+        try:
+            from core.delivery.infrastructure.whatsapp_delivery_notifier import WhatsAppDeliveryNotifier
+            self._wa_notifier = WhatsAppDeliveryNotifier()
+            return self._wa_notifier
+        except Exception as exc:
+            logger.warning("NotificationDispatch: WhatsApp notifier init failed: %s", exc)
+            self._wa_init_failed = True
+            return None
+
     def handle(self, payload: Dict[str, Any]) -> None:
+        canal = str(payload.get("canal") or "all").lower()
+        if canal == "whatsapp":
+            notifier = self._get_whatsapp_notifier()
+            if notifier is None:
+                return
+            try:
+                notifier.notify_from_event(payload)
+            except Exception as exc:
+                logger.warning("NotificationDispatch WhatsApp failed: %s", exc)
+            return
+
         from notifications.base import NotificationPayload
         svc = self._get_service()
         if svc is None:
             return
-        canal    = str(payload.get("canal") or "all")
         template = str(payload.get("template") or "")
         params   = payload.get("params") or {}
         title    = params.get("title") or template.replace("_", " ").title()

--- a/pos_spj_v13.4/core/events/wiring.py
+++ b/pos_spj_v13.4/core/events/wiring.py
@@ -259,6 +259,7 @@ def wire_all(container: "AppContainer") -> None:
 
     # v13.5: Delivery weight adjustments + inventory reservations
     _wire_delivery_handlers(bus, container)
+    _wire_legacy_delivery_event_bridge(bus, container)
 
     # v13.30: Delivery lifecycle + inventory commit + driver settlement + notifications
     _wire_delivery_lifecycle_handlers(bus, container)
@@ -1155,6 +1156,14 @@ def _wire_delivery_handlers(bus, container) -> None:
         "Registered delivery handlers: reserve, release, weight, WA-notify, payment-update"
         # appended below by _wire_delivery_lifecycle_handlers
     )
+
+
+def _wire_legacy_delivery_event_bridge(bus, container) -> None:
+    """Bridge canonical delivery events to legacy Spanish event names temporarily."""
+    from core.delivery.application.legacy_event_bridge import register_legacy_delivery_event_bridge
+
+    register_legacy_delivery_event_bridge(bus)
+    logger.debug("Registered LegacyDeliveryEventBridge for canonical delivery events")
 
 
 # ── v13.30: Delivery lifecycle handlers ──────────────────────────────────────

--- a/pos_spj_v13.4/core/services/delivery_service.py
+++ b/pos_spj_v13.4/core/services/delivery_service.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from typing import Any, Dict, List, Optional
 
 from repositories.delivery_repository import DeliveryRepository
 from core.services.delivery_whatsapp_service import DeliveryWhatsAppService
 from core.services.geocoding_service import GeocodingService
-from core.services.order_total_service import OrderTotalService
+from core.delivery.application.delivery_total_service import DeliveryTotalService
+from core.delivery.domain.events import DeliveryEvents
+from core.delivery.domain.state_machine import DeliveryStateMachine
+from core.delivery.infrastructure.whatsapp_delivery_notifier import WhatsAppDeliveryNotifier
+from core.events.event_bus import get_bus
+from core.delivery.infrastructure.delivery_outbox_repository import DeliveryOutboxRepository
+from core.delivery.infrastructure.delivery_schema_migrator import DeliverySchemaMigrator
+from core.delivery.projections.sale_delivery_projection import SaleDeliveryProjectionService
+from core.delivery.application.activate_scheduled_order import ActivateScheduledOrderUseCase
+from core.delivery.application.adjust_delivery_weight import AdjustDeliveryWeightUseCase
+from core.delivery.application.cancel_delivery_order import CancelDeliveryOrderUseCase
+from core.delivery.application.change_delivery_status import ChangeDeliveryStatusUseCase
+from core.delivery.application.create_delivery_order import CreateDeliveryOrderUseCase
+from core.delivery.application.sync_whatsapp_orders import SyncWhatsAppOrdersUseCase
 
 logger = logging.getLogger("spj.services.delivery")
 
@@ -16,8 +28,24 @@ ADJUSTMENT_ACCEPTED = "accepted"
 ADJUSTMENT_REJECTED = "rejected"
 ADJUSTMENT_NONE = "none"
 
+LEGACY_COMPATIBILITY_METHODS = frozenset({
+    "_ensure_adjustment_columns",
+    "_sync_venta_total",
+    "_notify_adjustment_pending",
+    "_validate_workflow_transition",
+    "_release_stock",
+    "sync_pending_sales_to_delivery_orders",
+})
+
 
 class DeliveryService:
+    """Backward-compatible facade for the delivery bounded context.
+
+    Public methods keep the legacy service API stable while delegating real
+    behavior to application use cases, projections and infrastructure adapters.
+    Internal methods listed in `LEGACY_COMPATIBILITY_METHODS` are deprecated
+    shims retained for UI/tests/handlers during the phased migration.
+    """
     def __init__(
         self,
         db,
@@ -29,44 +57,39 @@ class DeliveryService:
         self.repository = repository or DeliveryRepository(db)
         self.whatsapp_service = whatsapp_service or DeliveryWhatsAppService()
         self.geocoding_service = geocoding_service or GeocodingService()
-        self.order_total_service = OrderTotalService(db)
+        self.order_total_service = DeliveryTotalService(self.repository)
+        self.sale_projection = SaleDeliveryProjectionService(db) if db is not None else None
+        self.outbox_repository = DeliveryOutboxRepository(db) if db is not None else None
         self._ensure_adjustment_columns()
 
     def _ensure_adjustment_columns(self) -> None:
-        """Asegura columnas de aprobación sin depender de que la migración ya haya corrido."""
-        cols_items = [
-            "pending_prepared_qty REAL",
-            "pending_subtotal REAL",
-            "adjustment_status TEXT DEFAULT 'none'",
-            "adjustment_requested_at DATETIME",
-            "adjustment_responded_at DATETIME",
-            "adjustment_response TEXT",
-            "adjustment_token TEXT",
-            "tolerance_units REAL DEFAULT 0.2",
-        ]
-        cols_orders = [
-            "adjustment_pending INTEGER DEFAULT 0",
-            "adjustment_blocked_state TEXT DEFAULT ''",
-        ]
-        for col in cols_items:
-            try:
-                self.db.execute(f"ALTER TABLE delivery_items ADD COLUMN {col}")
-            except Exception:
-                pass
-        for col in cols_orders:
-            try:
-                self.db.execute(f"ALTER TABLE delivery_orders ADD COLUMN {col}")
-            except Exception:
-                pass
-        try:
-            self.db.execute("CREATE INDEX IF NOT EXISTS idx_delivery_items_adjustment_status ON delivery_items(adjustment_status, delivery_id)")
-            self.db.execute("CREATE INDEX IF NOT EXISTS idx_delivery_items_adjustment_token ON delivery_items(adjustment_token)")
-            self.db.commit()
-        except Exception:
-            pass
+        """Deprecated compatibility shim; schema changes live in DeliverySchemaMigrator."""
+        if self.db is None:
+            return
+        DeliverySchemaMigrator(self.db).ensure_schema()
 
     def list_orders(self, estado: Optional[str] = None) -> List[Dict[str, Any]]:
         return self.repository.list_orders(estado=estado)
+
+    def get_order(self, order_id: int) -> Optional[Dict[str, Any]]:
+        """Legacy convenience accessor; repository remains the owner of reads."""
+        return self.repository.get_order(order_id)
+
+    _UI_ACTION_METADATA: Dict[str, Dict[str, str]] = {
+        "preparacion": {"icon": "👨‍🍳", "label": "Enviar a preparación", "style": "primary"},
+        "cancelado": {"icon": "✖", "label": "Cancelar pedido", "style": "danger"},
+        "ver_detalle": {"icon": "🔍", "label": "Ver detalle", "style": "secondary"},
+        "ajustar_peso": {"icon": "⚖️", "label": "Ajustar peso", "style": "warning"},
+        "en_ruta": {"icon": "🛵", "label": "Enviar a ruta", "style": "primary"},
+        "asignar": {"icon": "👤", "label": "Asignar repartidor", "style": "primary"},
+        "entregado": {"icon": "✅", "label": "Marcar entregado", "style": "success"},
+        "notificar_wa": {"icon": "📲", "label": "Notificar por WA", "style": "secondary"},
+        "imprimir": {"icon": "🖨️", "label": "Imprimir ticket", "style": "secondary"},
+        "reactivar": {"icon": "♻️", "label": "Reactivar pedido", "style": "warning"},
+        "activar_programado": {"icon": "▶", "label": "Activar ahora", "style": "success"},
+        "reprogramar": {"icon": "🗓️", "label": "Reprogramar", "style": "warning"},
+        "ver_forecast": {"icon": "📈", "label": "Ver forecast", "style": "secondary"},
+    }
 
     def get_valid_actions(
         self,
@@ -79,216 +102,108 @@ class DeliveryService:
     ) -> List[Dict[str, str]]:
         """Return valid UI actions for an order context.
 
-        Backend-facing contract in English so UI does not handcraft action rules.
+        The action keys come from ``DeliveryStateMachine`` so widgets/PWA views
+        do not duplicate workflow rules. This facade only adds UI metadata
+        (icon, label and style) and non-transition read actions.
         """
-        base = {
-            "pendiente": [
-                {"icon": "👨‍🍳", "label": "Enviar a preparación", "key": "preparacion", "style": "primary"},
-                {"icon": "✖", "label": "Cancelar pedido", "key": "cancelado", "style": "danger"},
-                {"icon": "🔍", "label": "Ver detalle", "key": "ver_detalle", "style": "secondary"},
-            ],
-            "preparacion": [
-                {"icon": "⚖️", "label": "Ajustar peso", "key": "ajustar_peso", "style": "warning"},
-                {"icon": "🛵", "label": "Enviar a ruta", "key": "en_ruta", "style": "primary"},
-                {"icon": "👤", "label": "Asignar repartidor", "key": "asignar", "style": "primary"},
-                {"icon": "✖", "label": "Cancelar pedido", "key": "cancelado", "style": "danger"},
-            ],
-            "en_ruta": [
-                {"icon": "✅", "label": "Marcar entregado", "key": "entregado", "style": "success"},
-                {"icon": "📲", "label": "Notificar por WA", "key": "notificar_wa", "style": "secondary"},
-            ],
-            "entregado": [
-                {"icon": "🖨️", "label": "Imprimir ticket", "key": "imprimir", "style": "secondary"},
-            ],
-            "cancelado": [
-                {"icon": "♻️", "label": "Reactivar pedido", "key": "reactivar", "style": "warning"},
-            ],
+        order_context = {
+            "estado": status,
+            "workflow_type": workflow_type,
+            "delivery_type": delivery_type,
+            "scheduled_at": scheduled_at,
+            "adjustment_pending": adjustment_pending,
         }
-        s = (status or "").strip().lower()
-        wf = (workflow_type or "").strip().lower()
-        actions = list(base.get(s, []))
-        if wf == "counter":
-            actions = [a for a in actions if a["key"] not in ("en_ruta", "asignar")]
-            if s == "preparacion":
-                actions.insert(1, {"icon": "✅", "label": "Marcar entregado", "key": "entregado", "style": "success"})
-        if wf == "scheduled" and s in ("programado", "scheduled"):
-            actions = [
-                {"icon": "▶", "label": "Activar ahora", "key": "activar_programado", "style": "success"},
-                {"icon": "🗓️", "label": "Reprogramar", "key": "reprogramar", "style": "warning"},
-                {"icon": "📈", "label": "Ver forecast", "key": "ver_forecast", "style": "secondary"},
-                {"icon": "✖", "label": "Cancelar pedido", "key": "cancelado", "style": "danger"},
-            ]
-        if adjustment_pending:
-            actions = [a for a in actions if a["key"] not in ("en_ruta", "entregado")]
-        return actions
+        action_keys = DeliveryStateMachine().get_valid_actions(order_context)
+        if (status or "").strip().lower() in {"programado", "scheduled"} and "ver_forecast" not in action_keys:
+            action_keys.insert(2, "ver_forecast")
+        if (status or "").strip().lower() == "pendiente" and "ver_detalle" not in action_keys:
+            action_keys.append("ver_detalle")
+        return [
+            {
+                "key": key,
+                "icon": self._UI_ACTION_METADATA.get(key, {}).get("icon", ""),
+                "label": self._UI_ACTION_METADATA.get(key, {}).get("label", key),
+                "style": self._UI_ACTION_METADATA.get(key, {}).get("style", "secondary"),
+            }
+            for key in action_keys
+        ]
+
+    def _create_order_use_case(self) -> CreateDeliveryOrderUseCase:
+        return CreateDeliveryOrderUseCase(
+            db=self.db,
+            repository=self.repository,
+            geocoding_service=self.geocoding_service,
+            whatsapp_service=self.whatsapp_service,
+            publisher=self._publish,
+            outbox_repository=self.outbox_repository,
+        )
 
     def create_order(self, data: Dict[str, Any], usuario: str = "sistema") -> int:
-        direccion = (data.get("direccion") or "").strip()
-        if not direccion:
-            raise ValueError("No se puede crear pedido sin dirección válida")
+        return self._create_order_use_case().execute(data, usuario=usuario)
 
-        coords = data.get("coords") or self.geocoding_service.geocode(direccion)
-        if coords:
-            data["lat"] = coords.get("lat")
-            data["lng"] = coords.get("lng")
-        else:
-            data["lat"] = data.get("lat")
-            data["lng"] = data.get("lng")
-
-        data["usuario"] = usuario
-        order_id = self.repository.create_order(data)
-        self._publish("pedido_delivery_creado", {"order_id": order_id})
-        self._publish("pedido_whatsapp_recibido", {"order_id": order_id, "canal": "whatsapp"})
-
-        items = data.get("items") or []
-        if items:
-            self._publish(
-                "DELIVERY_ORDER_RESERVED",
-                {
-                    "order_id": order_id,
-                    "operation_id": str(order_id),
-                    "items": items,
-                    "branch_id": data.get("sucursal_id", 1),
-                    "db": self.db,
-                },
-            )
-
-        order = self.repository.get_order(order_id) or {}
-        self._safe_wa_notify(order, "pedido_recibido")
-
-        self._publish("DELIVERY_ORDER_CREATED", {
-            "_event_type": "DELIVERY_ORDER_CREATED",
-            "order_id": order_id,
-            "folio": order.get("folio") or data.get("folio") or f"DEL-{order_id}",
-            "direccion": data.get("direccion"),
-            "total": data.get("total", 0),
-            "sucursal_id": data.get("sucursal_id", 1),
-            "usuario": usuario,
-            "db": self.db,
-        })
-        return order_id
+    def create_delivery_order(self, data: Dict[str, Any], usuario: str = "sistema") -> int:
+        """Legacy alias kept for callers that adopted the explicit name."""
+        return self.create_order(data, usuario=usuario)
 
     def _has_pending_adjustment(self, order_id: int) -> bool:
         try:
-            row = self.db.execute(
-                """SELECT 1 FROM delivery_items
-                   WHERE delivery_id=? AND adjustment_status=? LIMIT 1""",
-                (order_id, ADJUSTMENT_PENDING),
-            ).fetchone()
-            return row is not None
-        except Exception:
+            return self.repository.has_pending_adjustment(order_id)
+        except Exception as exc:
+            logger.warning("No se pudo validar ajuste pendiente delivery order=%s: %s", order_id, exc)
             return False
 
-    def update_status(self, order_id: int, status: str, usuario: str, responsable: str = "") -> None:
-        self._validate_workflow_transition(order_id, status)
+    def _change_status_use_case(self) -> ChangeDeliveryStatusUseCase:
+        return ChangeDeliveryStatusUseCase(
+            db=self.db,
+            repository=self.repository,
+            sale_projection=self.sale_projection,
+            whatsapp_service=self.whatsapp_service,
+            publisher=self._publish,
+            get_order_items=self.get_order_items,
+            outbox_repository=self.outbox_repository,
+        )
 
-        if status == "entregado" and not responsable:
-            raise ValueError("No se puede entregar sin responsable")
+    def update_status(
+        self,
+        order_id: int,
+        status: str,
+        usuario: str,
+        responsable: str = "",
+        observacion: str = "",
+    ) -> None:
+        return self._change_status_use_case().execute(
+            order_id, status, usuario=usuario, responsable=responsable, observacion=observacion
+        )
 
-        if status in ("en_ruta", "entregado") and self._has_pending_adjustment(order_id):
-            try:
-                self.db.execute(
-                    "UPDATE delivery_orders SET adjustment_pending=1, adjustment_blocked_state=? WHERE id=?",
-                    (status, order_id),
-                )
-                self.db.commit()
-            except Exception:
-                pass
-            raise ValueError(
-                "No se puede cambiar de estado: hay un ajuste de peso/cantidad pendiente de aceptación del cliente."
-            )
-
-        self.repository.update_status(order_id, status, usuario=usuario, responsable=responsable)
-        order = self.repository.get_order(order_id) or {}
-        folio = order.get("folio") or f"DEL-{order_id}"
-        sucursal_id = int(order.get("sucursal_id") or 1)
-        cliente_tel = order.get("cliente_tel") or ""
-        _base = {
-            "_event_type": f"DELIVERY_ORDER_{status.upper()}",
-            "order_id": order_id,
-            "folio": folio,
-            "usuario": usuario,
-            "sucursal_id": sucursal_id,
-            "total": order.get("total"),
-            "db": self.db,
-        }
-
-        if status == "cancelado":
-            self._release_stock(order_id)
-            self._publish("DELIVERY_ORDER_CANCELLED", {**_base, "motivo": ""})
-        if status == "preparacion":
-            self._publish("DELIVERY_ORDER_PREPARING", _base)
-        if status == "en_ruta":
-            self._publish("pedido_en_ruta", {"order_id": order_id})
-            self._publish("DELIVERY_OUT_FOR_DELIVERY", {
-                **_base, "_event_type": "DELIVERY_OUT_FOR_DELIVERY",
-                "driver_id": order.get("driver_id"),
-                "cliente_tel": cliente_tel,
-            })
-        if status == "entregado":
-            self._publish("pedido_entregado", {"order_id": order_id, "responsable": responsable})
-            self._publish("DELIVERY_ORDER_DELIVERED", {
-                **_base, "_event_type": "DELIVERY_ORDER_DELIVERED",
-                "responsable": responsable,
-                "driver_id": order.get("driver_id"),
-            })
-            items = self.get_order_items(order_id)
-            self._publish("INVENTORY_COMMIT_REQUIRED", {
-                "order_id": order_id,
-                "operation_id": str(order_id),
-                "items": items,
-                "sucursal_id": sucursal_id,
-                "branch_id": sucursal_id,
-                "db": self.db,
-            })
-
-        self._safe_wa_notify(order, status)
-        wa_id = order.get("whatsapp_order_id")
-        self.whatsapp_service.sync_status(str(wa_id or ""), status)
+    def update_order_status(
+        self,
+        order_id: int,
+        status: str,
+        usuario: str = "sistema",
+        responsable: str = "",
+        observacion: str = "",
+    ) -> None:
+        """Legacy alias for callers using a more explicit method name."""
+        return self.update_status(
+            order_id, status, usuario=usuario, responsable=responsable, observacion=observacion
+        )
 
     def activate_scheduled_order(self, order_id: int, usuario: str = "sistema") -> Dict[str, Any]:
-        """Activate a scheduled order into its operational flow.
+        return ActivateScheduledOrderUseCase(
+            db=self.db,
+            repository=self.repository,
+            sale_projection=self.sale_projection,
+            publisher=self._publish,
+        ).execute(order_id, usuario=usuario)
 
-        - scheduled + pickup/sucursal -> counter workflow
-        - scheduled + domicilio/home_delivery -> delivery workflow
-        - status changes from programado/scheduled to pendiente
-        """
-        order = self.repository.get_order(order_id) or {}
-        if not order:
-            raise ValueError("Pedido no encontrado.")
-
-        current_status = (order.get("estado") or "").strip().lower()
-        if current_status not in ("programado", "scheduled"):
-            raise ValueError("Solo se pueden activar pedidos en estado programado.")
-
-        delivery_type = (order.get("delivery_type") or order.get("tipo_entrega") or "").strip().lower()
-        target_workflow = "counter" if delivery_type in ("pickup", "sucursal") else "delivery"
-
-        self.db.execute(
-            """
-            UPDATE delivery_orders
-            SET workflow_type=?, estado='pendiente', fecha_actualizacion=datetime('now')
-            WHERE id=?
-            """,
-            (target_workflow, order_id),
+    def cancel_order(self, order_id: int, usuario: str = "sistema", motivo: str = "") -> Dict[str, Any]:
+        return CancelDeliveryOrderUseCase(self._change_status_use_case()).execute(
+            order_id, usuario=usuario, motivo=motivo
         )
-        try:
-            self.db.execute(
-                "UPDATE ventas SET workflow_type=?, estado='pendiente' WHERE id=?",
-                (target_workflow, order.get("venta_id")),
-            )
-        except Exception:
-            pass
-        self.db.commit()
 
-        self._publish("WHATSAPP_SCHEDULED_ORDER_ACTIVATED", {
-            "order_id": order_id,
-            "workflow_type": target_workflow,
-            "usuario": usuario,
-            "sucursal_id": int(order.get("sucursal_id") or 1),
-            "db": self.db,
-        })
-        return {"order_id": order_id, "workflow_type": target_workflow, "status": "pending"}
+    def cancel_delivery_order(self, order_id: int, usuario: str = "sistema", motivo: str = "") -> Dict[str, Any]:
+        """Legacy alias retained while callers migrate to cancel_order."""
+        return self.cancel_order(order_id, usuario=usuario, motivo=motivo)
 
     def _validate_workflow_transition(self, order_id: int, target_status: str) -> None:
         order = self.repository.get_order(order_id) or {}
@@ -311,14 +226,14 @@ class DeliveryService:
             raise ValueError("Flujo mostrador no permite estado 'en_ruta'.")
 
     def _recalculate_order_total(self, order_id: int) -> float:
-        return self.order_total_service.recalculate_order_total(order_id)
+        return self.order_total_service.recalculate_order_total(order_id, commit=False)
 
     def _sync_venta_total(self, order_id: int, new_total: float) -> None:
         try:
             order = self.repository.get_order(order_id) or {}
             venta_id = order.get("venta_id")
-            if venta_id:
-                self.db.execute("UPDATE ventas SET total=? WHERE id=?", (new_total, venta_id))
+            if venta_id and self.sale_projection is not None:
+                self.sale_projection.project_total(venta_id, new_total)
         except Exception as exc:
             logger.debug("_sync_venta_total: %s", exc)
 
@@ -329,19 +244,17 @@ class DeliveryService:
         if not phone:
             return False
         folio = order.get("folio") or f"DEL-{order.get('id','')}"
-        sign = "+" if diff_qty >= 0 else ""
-        msg = (
-            f"⚖️ *Ajuste de tu pedido {folio}*\n\n"
-            f"Producto: {item_name}\n"
-            f"Solicitado: {requested_qty:.3g} {unit}\n"
-            f"Preparado: {prepared_qty:.3g} {unit} ({sign}{diff_qty:.3g} {unit})\n"
-            f"Nuevo subtotal: ${new_subtotal:,.2f}\n\n"
-            "La diferencia supera la tolerancia permitida de ±0.2 unidades.\n"
-            "Responde *ACEPTAR AJUSTE* para autorizarlo o *RECHAZAR AJUSTE* para mantener el pedido sin ese cambio."
-        )
         try:
-            from core.integrations.whatsapp_client import WhatsAppClient
-            return bool(WhatsAppClient().enviar_mensaje(phone, msg))
+            return WhatsAppDeliveryNotifier().notify_adjustment_required(
+                phone=phone,
+                folio=folio,
+                item_name=item_name,
+                requested_qty=requested_qty,
+                prepared_qty=prepared_qty,
+                unit=unit,
+                new_subtotal=new_subtotal,
+                diff_qty=diff_qty,
+            )
         except Exception as exc:
             logger.warning("No se pudo notificar ajuste pendiente por WhatsApp: %s", exc)
             return False
@@ -355,119 +268,36 @@ class DeliveryService:
         adjustment_reason: str = "",
         unit: str = "kg",
     ) -> Dict[str, Any]:
-        """Registra ajuste de peso/cantidad.
-
-        Reglas:
-        - Solo se permite en estado `preparacion`.
-        - Tolerancia en unidades: ±0.2 por defecto.
-        - Si excede tolerancia, NO aplica el ajuste: queda pendiente de aceptación.
-        - Si está dentro de tolerancia, aplica cantidad/subtotal/total inmediatamente.
-        """
-        from core.services.reservation_service import ReservationService, TOLERANCE_UNITS
-
-        order = self.repository.get_order(order_id) or {}
-        estado = (order.get("estado") or "").lower()
-        if estado != "preparacion":
-            raise ValueError("El ajuste de peso/cantidad solo puede hacerse en estado 'preparacion'.")
-
-        item_row = self.db.execute(
-            "SELECT precio_unitario, cantidad, nombre FROM delivery_items WHERE id=? AND delivery_id=?",
-            (item_id, order_id),
-        ).fetchone()
-        if not item_row:
-            raise ValueError(f"delivery_items.id={item_id} not found for order={order_id}")
-
-        unit_price = float(item_row[0] or 0)
-        requested_qty = float(item_row[1] or prepared_qty)
-        item_name = item_row[2] or "Producto"
-        adj = ReservationService.compute_adjustment(
-            requested_qty, prepared_qty, unit_price, tolerance_units=TOLERANCE_UNITS
+        return AdjustDeliveryWeightUseCase(
+            db=self.db,
+            repository=self.repository,
+            publisher=self._publish,
+            notify_adjustment_pending=self._notify_adjustment_pending,
+            recalculate_order_total=self._recalculate_order_total,
+            sync_sale_total=self._sync_venta_total,
+            outbox_repository=self.outbox_repository,
+        ).execute(
+            order_id=order_id,
+            item_id=item_id,
+            prepared_qty=prepared_qty,
+            prepared_by=prepared_by,
+            adjustment_reason=adjustment_reason,
+            unit=unit,
         )
 
-        if adj["tolerance_exceeded"]:
-            token = uuid.uuid4().hex
-            self.db.execute(
-                """UPDATE delivery_items
-                   SET pending_prepared_qty=?, pending_subtotal=?,
-                       adjustment_status=?, adjustment_requested_at=datetime('now'),
-                       adjustment_response='', adjustment_token=?, tolerance_units=?,
-                       prepared_by=?, adjustment_reason=?, tolerance_exceeded=1
-                   WHERE id=? AND delivery_id=?""",
-                (
-                    prepared_qty, adj["new_subtotal"], ADJUSTMENT_PENDING,
-                    token, adj["tolerance_units"], prepared_by, adjustment_reason,
-                    item_id, order_id,
-                ),
-            )
-            self.db.execute(
-                "UPDATE delivery_orders SET adjustment_pending=1, adjustment_blocked_state='en_ruta' WHERE id=?",
-                (order_id,),
-            )
-            try:
-                self.db.commit()
-            except Exception:
-                pass
-            self._notify_adjustment_pending(
-                order, item_name, requested_qty, prepared_qty, unit,
-                adj["new_subtotal"], adj["diff_qty"]
-            )
-            self._publish("DELIVERY_ADJUSTMENT_APPROVAL_REQUIRED", {
-                "order_id": order_id,
-                "item_id": item_id,
-                "folio": order.get("folio") or str(order_id),
-                "cliente_tel": order.get("cliente_tel", ""),
-                "requested_qty": requested_qty,
-                "prepared_qty": prepared_qty,
-                "diff_qty": adj["diff_qty"],
-                "tolerance_units": adj["tolerance_units"],
-                "db": self.db,
-            })
-            return {**adj, "status": ADJUSTMENT_PENDING, "applied": False}
-
-        # Dentro de tolerancia: aplicar inmediatamente.
-        self.db.execute(
-            """UPDATE delivery_items
-               SET cantidad=?, prepared_qty=?, final_qty=?, subtotal=?,
-                   prepared_by=?, prepared_at=datetime('now'),
-                   adjustment_reason=?, tolerance_exceeded=0,
-                   adjustment_status=?, pending_prepared_qty=NULL, pending_subtotal=NULL,
-                   adjustment_responded_at=datetime('now'), adjustment_response='auto_accepted'
-               WHERE id=? AND delivery_id=?""",
-            (
-                prepared_qty, prepared_qty, prepared_qty, adj["new_subtotal"],
-                prepared_by, adjustment_reason, ADJUSTMENT_ACCEPTED,
-                item_id, order_id,
-            ),
+    def adjust_weight(
+        self,
+        order_id: int,
+        item_id: int,
+        prepared_qty: float,
+        prepared_by: str,
+        adjustment_reason: str = "",
+        unit: str = "kg",
+    ) -> Dict[str, Any]:
+        """Legacy alias for adjust_item_weight."""
+        return self.adjust_item_weight(
+            order_id, item_id, prepared_qty, prepared_by, adjustment_reason=adjustment_reason, unit=unit
         )
-        new_total = self._recalculate_order_total(order_id)
-        self._sync_venta_total(order_id, new_total)
-        try:
-            self.db.commit()
-        except Exception:
-            pass
-
-        self._publish("DELIVERY_ITEM_WEIGHT_ADJUSTED", {
-            "order_id": order_id,
-            "item_id": item_id,
-            "item_name": item_name,
-            "requested_qty": requested_qty,
-            "prepared_qty": prepared_qty,
-            "unit_price": unit_price,
-            "unit": unit,
-            "prepared_by": prepared_by,
-            "adjustment_reason": adjustment_reason,
-            "new_total": new_total,
-            "folio": order.get("folio") or str(order_id),
-            "cliente_tel": order.get("cliente_tel", ""),
-            "cliente_email": order.get("cliente_email", ""),
-            "db": self.db,
-        })
-        logger.info(
-            "adjust_item_weight: order=%s item=%s requested=%.3f prepared=%.3f diff=%.3f tolerance_units=%.3f exceeded=%s",
-            order_id, item_id, requested_qty, prepared_qty,
-            adj["diff_qty"], adj["tolerance_units"], adj["tolerance_exceeded"],
-        )
-        return {**adj, "status": ADJUSTMENT_ACCEPTED, "applied": True, "new_total": new_total}
 
     def get_order_items(self, order_id: int) -> List[Dict[str, Any]]:
         try:
@@ -496,89 +326,44 @@ class DeliveryService:
         return self.geocoding_service.autocomplete(query)
 
     def pull_orders_from_whatsapp(self) -> None:
-        pulled = False
-        for item in self.whatsapp_service.pull_orders():
-            try:
-                oid = self.repository.upsert_order_from_whatsapp(item)
-                self._publish("pedido_whatsapp_recibido", {"order_id": oid, "payload": item})
-                pulled = True
-            except Exception as exc:
-                logger.debug("pull_orders_from_whatsapp error: %s", exc)
-        if not pulled:
-            self.sync_pending_sales_to_delivery_orders()
+        return SyncWhatsAppOrdersUseCase(
+            db=self.db,
+            repository=self.repository,
+            whatsapp_service=self.whatsapp_service,
+            publisher=self._publish,
+        ).pull_orders_from_whatsapp()
 
     def sync_pending_sales_to_delivery_orders(self) -> int:
-        """Fallback sync from local ventas -> delivery_orders for WhatsApp pending sales."""
-        try:
-            table_exists = lambda t: bool(self.db.execute(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1", (t,)
-            ).fetchone())
-            if not table_exists("ventas") or not table_exists("delivery_orders"):
-                return 0
-            cols_ventas = {r[1] for r in self.db.execute("PRAGMA table_info(ventas)").fetchall()}
-            cols_det = {r[1] for r in self.db.execute("PRAGMA table_info(detalles_venta)").fetchall()} if table_exists("detalles_venta") else set()
-            if "id" not in cols_ventas:
-                return 0
-
-            estado_col = "estado" if "estado" in cols_ventas else None
-            canal_col = "canal" if "canal" in cols_ventas else None
-            where = ["1=1"]
-            params: List[Any] = []
-            if canal_col:
-                where.append("lower(canal)='whatsapp'")
-            if estado_col:
-                where.append("lower(estado) IN ('pendiente','pendiente_wa','en_preparacion','preparacion','en_ruta','programado')")
-            rows = self.db.execute(
-                f"SELECT * FROM ventas WHERE {' AND '.join(where)} ORDER BY id DESC LIMIT 200",
-                tuple(params),
-            ).fetchall()
-            imported = 0
-            for row in rows:
-                data = dict(row)
-                venta_id = data.get("id")
-                if not venta_id:
-                    continue
-                items: List[Dict[str, Any]] = []
-                if cols_det and "venta_id" in cols_det:
-                    det_rows = self.db.execute(
-                        "SELECT producto_id, COALESCE(producto_nombre,'') AS producto_nombre, "
-                        "COALESCE(cantidad,0) AS cantidad, COALESCE(precio_unitario,0) AS precio_unitario, "
-                        "COALESCE(subtotal,0) AS subtotal "
-                        "FROM detalles_venta WHERE venta_id=?",
-                        (venta_id,),
-                    ).fetchall()
-                    items = [dict(r) for r in det_rows]
-
-                payload = {
-                    "id": venta_id,
-                    "venta_id": venta_id,
-                    "folio": data.get("folio") or data.get("codigo"),
-                    "cliente_id": data.get("cliente_id"),
-                    "cliente_nombre": data.get("cliente_nombre") or data.get("cliente"),
-                    "cliente_tel": data.get("cliente_tel") or data.get("telefono") or data.get("cliente_telefono"),
-                    "direccion": data.get("direccion") or data.get("direccion_entrega"),
-                    "total": data.get("total") or 0,
-                    "sucursal_id": data.get("sucursal_id") or 1,
-                    "delivery_type": data.get("delivery_type") or data.get("tipo_entrega"),
-                    "workflow_type": data.get("workflow_type"),
-                    "scheduled_at": data.get("scheduled_at") or data.get("fecha_entrega_programada"),
-                    "items": items,
-                    "source_channel": "whatsapp",
-                }
-                try:
-                    self.repository.upsert_order_from_whatsapp(payload, usuario="sync_local_ventas")
-                    imported += 1
-                except Exception as exc:
-                    logger.debug("sync_pending_sales_to_delivery_orders upsert failed venta_id=%s: %s", venta_id, exc)
-            return imported
-        except Exception as exc:
-            logger.debug("sync_pending_sales_to_delivery_orders failed: %s", exc)
-            return 0
+        """Deprecated compatibility shim for local ventas -> delivery_orders sync."""
+        return SyncWhatsAppOrdersUseCase(
+            db=self.db,
+            repository=self.repository,
+            whatsapp_service=self.whatsapp_service,
+            publisher=self._publish,
+        ).sync_pending_sales_to_delivery_orders()
 
     def _safe_wa_notify(self, order: Dict[str, Any], status: str) -> None:
+        """Deprecated notification shim. Prefer CUSTOMER_NOTIFICATION_REQUESTED outbox events."""
+        order_id = order.get("id")
+        folio = order.get("folio") or str(order_id or "")
+        if self.outbox_repository is not None and order_id:
+            self.outbox_repository.enqueue(
+                event_type=DeliveryEvents.CUSTOMER_NOTIFICATION_REQUESTED.value,
+                aggregate_id=int(order_id),
+                payload={
+                    "order_id": int(order_id),
+                    "canal": "whatsapp",
+                    "template": status,
+                    "params": {"folio": folio, "status": status},
+                    "cliente_tel": order.get("cliente_tel", ""),
+                },
+                operation_id=f"delivery:{order_id}:legacy_notify:{status}",
+                commit=True,
+            )
+            return
         ok = self.whatsapp_service.notify_status(
             phone=order.get("cliente_tel", ""),
-            folio=order.get("folio") or str(order.get("id") or ""),
+            folio=folio,
             status=status,
         )
         self._publish("notificacion_whatsapp_enviada", {
@@ -586,11 +371,20 @@ class DeliveryService:
         })
 
     def _release_stock(self, order_id: int) -> None:
+        """Deprecated release shim; emits legacy event and records outbox release when available."""
+        payload = {"order_id": order_id, "operation_id": f"delivery:{order_id}", "reason": "legacy_release_stock"}
+        if self.outbox_repository is not None:
+            self.outbox_repository.enqueue(
+                event_type=DeliveryEvents.INVENTORY_RELEASE_REQUIRED.value,
+                aggregate_id=order_id,
+                payload=payload,
+                operation_id=payload["operation_id"],
+                commit=True,
+            )
         self._publish("stock_liberar_solicitado", {"order_id": order_id})
 
     def _publish(self, event: str, payload: Dict[str, Any]) -> None:
         try:
-            from core.events.event_bus import get_bus
             get_bus().publish(event, payload)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("DeliveryService._publish failed event=%s: %s", event, exc)

--- a/pos_spj_v13.4/core/services/delivery_whatsapp_service.py
+++ b/pos_spj_v13.4/core/services/delivery_whatsapp_service.py
@@ -3,34 +3,26 @@ from __future__ import annotations
 import logging
 from typing import Dict, Iterable
 
+from core.delivery.infrastructure.whatsapp_delivery_notifier import WhatsAppDeliveryNotifier
 from core.integrations.whatsapp_client import WhatsAppClient
 
 logger = logging.getLogger("spj.services.delivery_whatsapp")
 
 
 class DeliveryWhatsAppService:
-    STATUS_MESSAGES = {
-        "pedido_recibido": "✅ Recibimos tu pedido {folio}. Lo estamos validando.",
-        "preparacion": "👩‍🍳 Tu pedido {folio} está en preparación.",
-        "en_ruta": "🛵 Tu pedido {folio} va en ruta.",
-        "entregado": "🎉 Tu pedido {folio} fue entregado. ¡Gracias!",
-        "cancelado": "❌ Tu pedido {folio} fue cancelado.",
-    }
+    """Legacy-compatible façade over the centralized WhatsApp delivery notifier."""
 
-    def __init__(self, client: WhatsAppClient | None = None):
+    STATUS_MESSAGES = WhatsAppDeliveryNotifier.STATUS_TEMPLATES
+
+    def __init__(self, client: WhatsAppClient | None = None, notifier: WhatsAppDeliveryNotifier | None = None):
         self.client = client or WhatsAppClient()
+        self.notifier = notifier or WhatsAppDeliveryNotifier(self.client)
 
     def notify_status(self, phone: str, folio: str, status: str) -> bool:
-        if not phone:
-            return False
-        msg_template = self.STATUS_MESSAGES.get(status)
-        if not msg_template:
-            return False
-        try:
-            return bool(self.client.enviar_mensaje(phone, msg_template.format(folio=folio or "")))
-        except Exception as exc:
-            logger.warning("notify_status failed (%s): %s", status, exc)
-            return False
+        return self.notifier.notify_status(phone=phone, folio=folio, status=status)
+
+    def notify_adjustment_required(self, **kwargs) -> bool:
+        return self.notifier.notify_adjustment_required(**kwargs)
 
     def notify_weight_adjustment(
         self,
@@ -42,30 +34,24 @@ class DeliveryWhatsAppService:
         new_total: float,
         payment_url: str = "",
     ) -> bool:
-        """Send a weight-adjustment summary to the customer via WhatsApp."""
-        if not phone:
-            return False
-        diff = prepared_qty - requested_qty
-        sign = "+" if diff >= 0 else ""
-        msg = (
-            f"📦 Actualización pedido #{folio}\n"
-            f"Peso solicitado: {requested_qty:.3g} {unit}\n"
-            f"Peso real: {prepared_qty:.3g} {unit}  ({sign}{diff:.3g} {unit})\n"
-            f"Total: ${new_total:,.2f}"
+        return self.notifier.notify_weight_adjustment(
+            phone=phone,
+            folio=folio,
+            requested_qty=requested_qty,
+            prepared_qty=prepared_qty,
+            unit=unit,
+            new_total=new_total,
+            payment_url=payment_url,
         )
-        if payment_url:
-            msg += f"\nPago: {payment_url}"
-        msg += "\n🛵 ¡Pronto en camino!"
-        try:
-            ok = bool(self.client.enviar_mensaje(phone, msg))
-            logger.info(
-                "notify_weight_adjustment phone=%s folio=%s ok=%s",
-                phone[-4:], folio, ok,
-            )
-            return ok
-        except Exception as exc:
-            logger.warning("notify_weight_adjustment failed: %s", exc)
-            return False
+
+    def notify_out_for_delivery(self, *, phone: str, folio: str, driver_name: str = "", eta: str = "") -> bool:
+        return self.notifier.notify_out_for_delivery(phone=phone, folio=folio, driver_name=driver_name, eta=eta)
+
+    def notify_delivered(self, *, phone: str, folio: str) -> bool:
+        return self.notifier.notify_delivered(phone=phone, folio=folio)
+
+    def notify_from_event(self, payload: dict) -> bool:
+        return self.notifier.notify_from_event(payload)
 
     def pull_orders(self) -> Iterable[Dict]:
         try:

--- a/pos_spj_v13.4/core/services/order_total_service.py
+++ b/pos_spj_v13.4/core/services/order_total_service.py
@@ -1,34 +1,21 @@
 from __future__ import annotations
 
+from core.delivery.application.delivery_total_service import DeliveryTotalService
+from repositories.delivery_repository import DeliveryRepository
+
 
 class OrderTotalService:
-    """Single source of truth for recalculating delivery/sale totals."""
+    """Compatibility shim for legacy imports.
 
-    def __init__(self, db):
+    The canonical implementation lives in `DeliveryTotalService`. This shim is
+    intentionally kept so existing UI/WhatsApp code can still import
+    `core.services.order_total_service.OrderTotalService` during migration.
+    """
+
+    def __init__(self, db, repository: DeliveryRepository | None = None):
         self.db = db
+        self.repository = repository or DeliveryRepository(db)
+        self.delivery_total_service = DeliveryTotalService(self.repository)
 
-    def recalculate_order_total(self, order_id: int) -> float:
-        row = self.db.execute(
-            "SELECT COALESCE(SUM(subtotal), 0) FROM delivery_items WHERE delivery_id=?",
-            (order_id,),
-        ).fetchone()
-        new_total = round(float(row[0]) if row else 0.0, 2)
-
-        cols = {r[1] for r in self.db.execute("PRAGMA table_info(delivery_orders)").fetchall()}
-        if "weight_adjusted" in cols:
-            self.db.execute(
-                "UPDATE delivery_orders SET total=?, weight_adjusted=1 WHERE id=?",
-                (new_total, order_id),
-            )
-        else:
-            self.db.execute(
-                "UPDATE delivery_orders SET total=? WHERE id=?",
-                (new_total, order_id),
-            )
-
-        venta_row = self.db.execute("SELECT venta_id FROM delivery_orders WHERE id=?", (order_id,)).fetchone()
-        if venta_row and venta_row[0]:
-            self.db.execute("UPDATE ventas SET total=? WHERE id=?", (new_total, int(venta_row[0])))
-
-        self.db.commit()
-        return new_total
+    def recalculate_order_total(self, order_id: int, *, commit: bool = True) -> float:
+        return self.delivery_total_service.recalculate_order_total(order_id, commit=commit)

--- a/pos_spj_v13.4/integrations/delivery_pwa/pwa_server.py
+++ b/pos_spj_v13.4/integrations/delivery_pwa/pwa_server.py
@@ -10,6 +10,7 @@ import json, threading, logging
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 from core.db.connection import get_connection, close_thread_connection
+from core.services.delivery_service import DeliveryService
 
 logger = logging.getLogger("spj.pwa")
 _server_instance = None
@@ -57,18 +58,31 @@ class DeliveryAPIHandler(BaseHTTPRequestHandler):
     def _get_pedidos(self, chofer_id: str) -> list:
         try:
             conn = get_connection()
-            sql  = """SELECT d.id, d.estado, d.direccion_entrega, d.notas,
-                             d.total, d.fecha_pedido,
+            service = DeliveryService(conn)
+            sql  = """SELECT d.id, d.estado, d.direccion AS direccion_entrega, d.notas,
+                             d.total, d.fecha AS fecha_pedido, d.workflow_type, d.delivery_type,
+                             d.scheduled_at, d.adjustment_pending, d.driver_id,
                              c.nombre as cliente, c.telefono as tel_cliente
                       FROM delivery_orders d
                       LEFT JOIN clientes c ON c.id=d.cliente_id
                       WHERE d.estado NOT IN ('entregado','cancelado')"""
             params = []
             if chofer_id:
-                sql += " AND d.chofer_id=?"; params.append(chofer_id)
-            sql += " ORDER BY d.fecha_pedido ASC LIMIT 50"
+                sql += " AND d.driver_id=?"; params.append(chofer_id)
+            sql += " ORDER BY d.fecha ASC LIMIT 50"
             rows = conn.execute(sql, params).fetchall()
-            return [dict(r) for r in rows]
+            pedidos = []
+            for row in rows:
+                pedido = dict(row)
+                pedido["actions"] = service.get_valid_actions(
+                    status=pedido.get("estado", ""),
+                    workflow_type=pedido.get("workflow_type", ""),
+                    adjustment_pending=bool(int(pedido.get("adjustment_pending") or 0)),
+                    scheduled_at=pedido.get("scheduled_at"),
+                    delivery_type=pedido.get("delivery_type", ""),
+                )
+                pedidos.append(pedido)
+            return pedidos
         except Exception as e:
             logger.warning("get_pedidos: %s", e)
             return []
@@ -80,11 +94,13 @@ class DeliveryAPIHandler(BaseHTTPRequestHandler):
             estado   = body.get("estado")
             if not pedido_id or not estado:
                 return False
-            conn.execute(
-                "UPDATE delivery_orders SET estado=? WHERE id=?",
-                (estado, pedido_id))
-            try: conn.commit()
-            except Exception: pass
+            responsable = str(body.get("responsable") or body.get("chofer_id") or "pwa")
+            DeliveryService(conn).update_status(
+                int(pedido_id),
+                str(estado),
+                usuario="pwa_delivery",
+                responsable=responsable if str(estado).strip().lower() in {"entregado", "entregada"} else "",
+            )
             logger.info("PWA: pedido %s -> %s", pedido_id, estado)
             return True
         except Exception as e:
@@ -173,8 +189,8 @@ _PWA_HTML = """<!DOCTYPE html>
   #chofer-input{background:#334155;color:#E2E8F0;border:none;border-radius:8px;padding:8px 12px;font-size:14px}
   #pedidos{padding:12px;display:flex;flex-direction:column;gap:12px}
   .card{background:#1E293B;border-radius:12px;padding:16px;border-left:4px solid #3B82F6}
-  .card.en_camino{border-color:#F59E0B}
-  .card.listo{border-color:#10B981}
+  .card.en_ruta{border-color:#F59E0B}
+  .card.preparacion{border-color:#10B981}
   .card h3{font-size:15px;font-weight:600;margin-bottom:4px}
   .card .addr{color:#94A3B8;font-size:13px;margin-bottom:8px}
   .card .meta{display:flex;justify-content:space-between;font-size:12px;color:#64748B;margin-bottom:10px}
@@ -185,8 +201,8 @@ _PWA_HTML = """<!DOCTYPE html>
   .btn-problema{background:#EF4444;color:#fff}
   .badge{display:inline-block;padding:3px 8px;border-radius:12px;font-size:11px;font-weight:600;margin-bottom:6px}
   .badge.pendiente{background:#334155;color:#94A3B8}
-  .badge.listo{background:#064E3B;color:#10B981}
-  .badge.en_camino{background:#451A03;color:#F59E0B}
+  .badge.preparacion{background:#064E3B;color:#10B981}
+  .badge.en_ruta{background:#451A03;color:#F59E0B}
   #empty{text-align:center;color:#64748B;padding:48px;display:none}
   #refresh-btn{background:#3B82F6;color:#fff;border:none;border-radius:8px;padding:8px 16px;cursor:pointer;font-size:14px}
 </style>
@@ -201,7 +217,7 @@ _PWA_HTML = """<!DOCTYPE html>
 </header>
 <div id="pedidos"><div id="empty">No hay pedidos asignados</div></div>
 <script>
-const ESTADOS = {pendiente:'Pendiente',listo:'Listo para enviar',en_camino:'En camino',entregado:'Entregado'};
+const ESTADOS = {pendiente:'Pendiente',preparacion:'En preparación',en_ruta:'En ruta',entregado:'Entregado',cancelado:'Cancelado'};
 let timer;
 
 async function cargar(){
@@ -230,9 +246,9 @@ function renderizar(pedidos){
       </div>
       ${p.notas?`<div class="addr" style="color:#F59E0B">📝 ${p.notas}</div>`:''}
       <div class="btns">
-        ${p.estado==='listo'?`<button class="btn btn-camino" onclick="cambiarEstado(${p.id},'en_camino')">🚚 Salir a entregar</button>`:''}
-        ${p.estado==='en_camino'?`<button class="btn btn-entregado" onclick="cambiarEstado(${p.id},'entregado')">✅ Entregado</button>`:''}
-        <button class="btn btn-problema" onclick="cambiarEstado(${p.id},'cancelado')" style="flex:0;padding:8px">⚠</button>
+        ${(p.actions||[]).filter(a => ['en_ruta','entregado','cancelado'].includes(a.key)).map(a =>
+          `<button class="btn ${a.key==='entregado'?'btn-entregado':(a.key==='cancelado'?'btn-problema':'btn-camino')}" onclick="cambiarEstado(${p.id},'${a.key}')">${a.icon||''} ${a.label||a.key}</button>`
+        ).join('')}
       </div>`;
     c.appendChild(div);
   });
@@ -240,8 +256,9 @@ function renderizar(pedidos){
 
 async function cambiarEstado(id, estado){
   if(!confirm(`¿Cambiar pedido #${id} a "${estado}"?`)) return;
+  const chofer = document.getElementById('chofer-input').value || 'pwa';
   await fetch('/api/estado',{method:'POST',headers:{'Content-Type':'application/json'},
-    body:JSON.stringify({id,estado})});
+    body:JSON.stringify({id,estado,chofer_id:chofer,responsable:chofer})});
   cargar();
 }
 

--- a/pos_spj_v13.4/migrations/093_create_delivery_core.sql
+++ b/pos_spj_v13.4/migrations/093_create_delivery_core.sql
@@ -1,0 +1,80 @@
+-- Delivery core schema extracted from repositories/delivery_repository.py.
+-- Idempotent for existing SQLite databases; column backfills are handled by
+-- core.delivery.infrastructure.delivery_schema_migrator.DeliverySchemaMigrator.
+CREATE TABLE IF NOT EXISTS delivery_orders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    venta_id INTEGER,
+    folio TEXT,
+    whatsapp_order_id TEXT,
+    cliente_id INTEGER,
+    cliente_nombre TEXT,
+    cliente_tel TEXT,
+    direccion TEXT NOT NULL,
+    lat REAL,
+    lng REAL,
+    estado TEXT DEFAULT 'pendiente',
+    notas TEXT,
+    total REAL DEFAULT 0,
+    responsable_entrega TEXT,
+    usuario TEXT,
+    fecha DATETIME DEFAULT (datetime('now')),
+    fecha_actualizacion DATETIME,
+    historial_cambios TEXT,
+    driver_id INTEGER,
+    sucursal_id INTEGER DEFAULT 1,
+    workflow_type TEXT,
+    delivery_type TEXT,
+    scheduled_at DATETIME,
+    source_channel TEXT DEFAULT 'whatsapp'
+);
+
+CREATE TABLE IF NOT EXISTS delivery_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    delivery_id INTEGER NOT NULL,
+    producto_id INTEGER,
+    nombre TEXT NOT NULL,
+    cantidad REAL NOT NULL DEFAULT 0,
+    precio_unitario REAL NOT NULL DEFAULT 0,
+    subtotal REAL NOT NULL DEFAULT 0,
+    unidad TEXT DEFAULT 'kg',
+    requested_qty REAL,
+    prepared_qty REAL,
+    final_qty REAL,
+    prepared_by TEXT,
+    prepared_at DATETIME,
+    adjustment_reason TEXT,
+    tolerance_exceeded INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS delivery_order_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id INTEGER NOT NULL,
+    estado_anterior TEXT,
+    estado_nuevo TEXT,
+    usuario TEXT,
+    fecha DATETIME DEFAULT (datetime('now')),
+    observacion TEXT,
+    reason TEXT,
+    metadata_json TEXT,
+    event_id INTEGER,
+    created_at DATETIME DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS drivers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    nombre TEXT NOT NULL,
+    telefono TEXT,
+    vehiculo TEXT,
+    activo INTEGER DEFAULT 1,
+    en_ruta INTEGER DEFAULT 0,
+    sucursal_id INTEGER DEFAULT 1,
+    usuario_id INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_delivery_estado ON delivery_orders(estado, fecha);
+CREATE INDEX IF NOT EXISTS idx_delivery_wa ON delivery_orders(whatsapp_order_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_delivery_venta ON delivery_orders(venta_id) WHERE venta_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_delivery_wa_order ON delivery_orders(whatsapp_order_id) WHERE whatsapp_order_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_delivery_items_delivery_id ON delivery_items(delivery_id);
+CREATE INDEX IF NOT EXISTS idx_delivery_history_order_created ON delivery_order_history(order_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_delivery_history_event_id ON delivery_order_history(event_id);

--- a/pos_spj_v13.4/migrations/094_add_delivery_outbox.sql
+++ b/pos_spj_v13.4/migrations/094_add_delivery_outbox.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS delivery_outbox_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT NOT NULL,
+    aggregate_type TEXT DEFAULT 'delivery_order',
+    aggregate_id INTEGER NOT NULL,
+    payload_json TEXT NOT NULL,
+    status TEXT DEFAULT 'pending',
+    retries INTEGER DEFAULT 0,
+    last_error TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    processed_at DATETIME,
+    operation_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_delivery_outbox_pending
+    ON delivery_outbox_events(status, id);
+CREATE INDEX IF NOT EXISTS idx_delivery_outbox_aggregate
+    ON delivery_outbox_events(aggregate_type, aggregate_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_delivery_outbox_operation
+    ON delivery_outbox_events(event_type, aggregate_id, operation_id)
+    WHERE operation_id IS NOT NULL;

--- a/pos_spj_v13.4/migrations/095_add_delivery_history_audit.sql
+++ b/pos_spj_v13.4/migrations/095_add_delivery_history_audit.sql
@@ -1,0 +1,10 @@
+-- Fase 9: delivery_order_history es la fuente auditable; historial_cambios queda deprecated.
+-- SQLite no soporta ADD COLUMN IF NOT EXISTS en todas las versiones usadas por el POS.
+-- La migración ejecutable equivalente es migrations/standalone/095_delivery_history_audit.py,
+-- que delega en DeliverySchemaMigrator para agregar columnas de forma idempotente.
+
+CREATE INDEX IF NOT EXISTS idx_delivery_history_order_created
+    ON delivery_order_history(order_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_delivery_history_event_id
+    ON delivery_order_history(event_id);

--- a/pos_spj_v13.4/migrations/engine.py
+++ b/pos_spj_v13.4/migrations/engine.py
@@ -90,6 +90,9 @@ MIGRATIONS = [
     _Migration("090",  "migrations.standalone.090_whatsapp_delivery_workflow_columns"),
     _Migration("091",  "migrations.standalone.091_scheduled_demand_events"),
     _Migration("092",  "migrations.standalone.092_loyalty_ledger_canonicalization"),
+    _Migration("093",  "migrations.standalone.093_delivery_schema_migrator"),
+    _Migration("094",  "migrations.standalone.094_delivery_outbox"),
+    _Migration("095",  "migrations.standalone.095_delivery_history_audit"),
 ]
 
 def _ensure_tracking_table(conn):

--- a/pos_spj_v13.4/migrations/standalone/093_delivery_schema_migrator.py
+++ b/pos_spj_v13.4/migrations/standalone/093_delivery_schema_migrator.py
@@ -1,0 +1,21 @@
+"""Migration 093 — centralize Delivery schema in DeliverySchemaMigrator.
+
+The migration is Python instead of raw SQL because SQLite does not support
+``ALTER TABLE ... ADD COLUMN IF NOT EXISTS``; idempotent column backfills are
+implemented by the shared migrator.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+version = 93
+description = "delivery schema migrator"
+
+
+def up(conn: sqlite3.Connection) -> None:
+    from core.delivery.infrastructure.delivery_schema_migrator import DeliverySchemaMigrator
+
+    DeliverySchemaMigrator(conn).ensure_schema()
+
+
+run = up

--- a/pos_spj_v13.4/migrations/standalone/094_delivery_outbox.py
+++ b/pos_spj_v13.4/migrations/standalone/094_delivery_outbox.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from core.delivery.infrastructure.delivery_schema_migrator import DeliverySchemaMigrator
+
+
+def run(conn) -> None:
+    DeliverySchemaMigrator(conn).ensure_schema()

--- a/pos_spj_v13.4/migrations/standalone/095_delivery_history_audit.py
+++ b/pos_spj_v13.4/migrations/standalone/095_delivery_history_audit.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from core.delivery.infrastructure.delivery_schema_migrator import DeliverySchemaMigrator
+
+
+def run(conn) -> None:
+    DeliverySchemaMigrator(conn).ensure_schema()

--- a/pos_spj_v13.4/modulos/delivery.py
+++ b/pos_spj_v13.4/modulos/delivery.py
@@ -46,6 +46,7 @@ from PyQt5.QtCore import Qt, QTimer, pyqtSignal, QRunnable, QThreadPool, QObject
 from PyQt5.QtGui import QFont, QColor
 from core.db.connection import get_connection
 from core.services.delivery_service import DeliveryService
+from core.delivery.domain.state_machine import DeliveryStateMachine
 from core.services.order_badge_service import OrderBadgeService
 from core.utils.delivery_ui_filters import (
     infer_workflow_for_ui as _infer_workflow_for_ui_fn,
@@ -108,56 +109,43 @@ ESTADO_COLOR = {
 # ── Action policy: single source of truth for which buttons appear per state ──
 
 class DeliveryActionPolicy:
-    """Maps delivery states → list of (icon, tooltip, accion, style).
+    """UI action metadata adapter backed by the domain state machine.
 
-    Used by both TarjetaPedido (kanban) and the detail/list action bar.
-    Never hardcode state logic in widgets — always delegate here.
+    Widgets can still receive legacy tuple actions, but the workflow decision
+    comes from ``DeliveryStateMachine`` rather than hardcoded UI state rules.
     """
-    _ACTIONS = {
-        "pendiente": [
-            ("▶",  "Preparar",            "preparar",     "success"),
-            ("📲", "Notificar por WA",    "notificar_wa", "secondary"),
-            ("✖",  "Cancelar pedido",     "cancelado",    "danger"),
-        ],
-        "preparacion": [
-            ("🛵", "En Ruta",             "en_ruta",      "primary"),
-            ("⚖️", "Ajustar peso",        "ajustar_peso", "warning"),
-            ("👤", "Asignar repartidor",  "asignar",      "primary"),
-            ("🖨️", "Imprimir ticket",     "imprimir",     "secondary"),
-            ("📲", "Notificar por WA",    "notificar_wa", "secondary"),
-            ("💳", "Link de pago",        "link_pago",    "secondary"),
-            ("✖",  "Cancelar pedido",     "cancelado",    "danger"),
-        ],
-        "en_ruta": [
-            ("✅", "Confirmar entrega",   "entregado",    "success"),
-            ("📲", "Notificar por WA",    "notificar_wa", "secondary"),
-        ],
-        "entregado": [
-            ("🖨️", "Imprimir ticket",     "imprimir",     "secondary"),
-        ],
-        "cancelado": [
-            ("♻️", "Reactivar pedido",    "reactivar",    "warning"),
-        ],
+
+    _METADATA = {
+        "preparacion": ("▶", "Preparar", "success"),
+        "cancelado": ("✖", "Cancelar pedido", "danger"),
+        "ajustar_peso": ("⚖️", "Ajustar peso", "warning"),
+        "en_ruta": ("🛵", "En Ruta", "primary"),
+        "asignar": ("👤", "Asignar repartidor", "primary"),
+        "entregado": ("✅", "Marcar entregado", "success"),
+        "notificar_wa": ("📲", "Notificar por WA", "secondary"),
+        "imprimir": ("🖨️", "Imprimir ticket", "secondary"),
+        "reactivar": ("♻️", "Reactivar pedido", "warning"),
+        "activar_programado": ("▶", "Activar ahora", "success"),
+        "reprogramar": ("🗓️", "Reprogramar", "warning"),
     }
 
     @classmethod
     def get_actions(cls, estado: str, *, workflow_type: str = "", adjustment_pending: bool = False) -> list:
-        actions = list(cls._ACTIONS.get(estado, []))
-        wf = (workflow_type or "").strip().lower()
-        if wf == "counter":
-            actions = [a for a in actions if a[2] not in ("en_ruta", "asignar")]
-            if estado == "preparacion":
-                actions.insert(0, ("✅", "Marcar entregado", "entregado", "success"))
-        if wf == "scheduled" and estado in ("programado", "scheduled"):
-            return [
-                ("▶", "Activar ahora", "activar_programado", "success"),
-                ("🗓️", "Reprogramar", "reprogramar", "warning"),
-                ("📈", "Ver forecast", "ver_forecast", "secondary"),
-                ("✖", "Cancelar pedido", "cancelado", "danger"),
-            ]
-        if adjustment_pending:
-            actions = [a for a in actions if a[2] not in ("en_ruta", "entregado")]
-        return actions
+        order_context = {
+            "estado": estado,
+            "workflow_type": workflow_type,
+            "adjustment_pending": adjustment_pending,
+        }
+        action_keys = DeliveryStateMachine().get_valid_actions(order_context)
+        return [
+            (
+                cls._METADATA.get(key, ("", key, "secondary"))[0],
+                cls._METADATA.get(key, ("", key, "secondary"))[1],
+                key,
+                cls._METADATA.get(key, ("", key, "secondary"))[2],
+            )
+            for key in action_keys
+        ]
 
 
 def _matches_operational_tab(pedido: dict, tab_key: str | None) -> bool:

--- a/pos_spj_v13.4/notifications/whatsapp_channel.py
+++ b/pos_spj_v13.4/notifications/whatsapp_channel.py
@@ -47,12 +47,20 @@ class WhatsAppNotificationChannel(NotificationChannel):
         phone = (payload.cliente_tel or "").strip()
         if not phone:
             return False
-        folio  = payload.folio or str(payload.order_id or "")
-        body   = payload.body
         try:
-            wa.notify_status(phone=phone, folio=folio, status=payload.event_type)
+            if hasattr(wa, "notify_from_event"):
+                ok = wa.notify_from_event({
+                    "order_id": payload.order_id,
+                    "canal": "whatsapp",
+                    "template": payload.event_type,
+                    "params": payload.metadata or {"message": payload.body},
+                    "cliente_tel": phone,
+                    "folio": payload.folio or str(payload.order_id or ""),
+                })
+            else:
+                ok = wa.notify_status(phone=phone, folio=payload.folio or str(payload.order_id or ""), status=payload.event_type)
             logger.debug("WhatsAppChannel: sent event=%s phone=%s", payload.event_type, phone[:6])
-            return True
+            return bool(ok)
         except Exception as exc:
             logger.warning("WhatsAppChannel send failed: %s", exc)
             return False

--- a/pos_spj_v13.4/repositories/delivery_repository.py
+++ b/pos_spj_v13.4/repositories/delivery_repository.py
@@ -15,130 +15,10 @@ class DeliveryRepository:
         self.ensure_schema()
 
     def ensure_schema(self) -> None:
-        self.db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS delivery_orders (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                venta_id INTEGER,
-                folio TEXT,
-                whatsapp_order_id TEXT,
-                cliente_id INTEGER,
-                cliente_nombre TEXT,
-                cliente_tel TEXT,
-                direccion TEXT NOT NULL,
-                lat REAL,
-                lng REAL,
-                estado TEXT DEFAULT 'pendiente',
-                notas TEXT,
-                total REAL DEFAULT 0,
-                responsable_entrega TEXT,
-                usuario TEXT,
-                fecha DATETIME DEFAULT (datetime('now')),
-                fecha_actualizacion DATETIME,
-                historial_cambios TEXT,
-                driver_id INTEGER,
-                sucursal_id INTEGER DEFAULT 1,
-                workflow_type TEXT,
-                delivery_type TEXT,
-                scheduled_at DATETIME,
-                source_channel TEXT DEFAULT 'whatsapp'
-            )
-            """
-        )
-        self.db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS delivery_items (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                delivery_id INTEGER NOT NULL,
-                producto_id INTEGER,
-                nombre TEXT NOT NULL,
-                cantidad REAL NOT NULL DEFAULT 0,
-                precio_unitario REAL NOT NULL DEFAULT 0,
-                subtotal REAL NOT NULL DEFAULT 0,
-                unidad TEXT DEFAULT 'kg',
-                requested_qty REAL,
-                prepared_qty REAL,
-                final_qty REAL,
-                prepared_by TEXT,
-                prepared_at DATETIME,
-                adjustment_reason TEXT,
-                tolerance_exceeded INTEGER DEFAULT 0
-            )
-            """
-        )
-        self.db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS delivery_order_history (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                order_id INTEGER NOT NULL,
-                estado_anterior TEXT,
-                estado_nuevo TEXT,
-                usuario TEXT,
-                fecha DATETIME DEFAULT (datetime('now')),
-                observacion TEXT
-            )
-            """
-        )
-        for col in (
-            "folio TEXT",
-            "whatsapp_order_id TEXT",
-            "lat REAL",
-            "lng REAL",
-            "responsable_entrega TEXT",
-            "usuario TEXT",
-            "fecha DATETIME DEFAULT CURRENT_TIMESTAMP",
-            "fecha_actualizacion DATETIME",
-            "historial_cambios TEXT",
-            "driver_id INTEGER",
-            "sucursal_id INTEGER DEFAULT 1",
-            "workflow_type TEXT",
-            "delivery_type TEXT",
-            "scheduled_at DATETIME",
-            "source_channel TEXT DEFAULT 'whatsapp'",
-        ):
-            try:
-                self.db.execute(f"ALTER TABLE delivery_orders ADD COLUMN {col}")
-            except Exception:
-                pass
-        for col in (
-            "producto_id INTEGER",
-            "unidad TEXT DEFAULT 'kg'",
-            "requested_qty REAL",
-            "prepared_qty REAL",
-            "final_qty REAL",
-            "prepared_by TEXT",
-            "prepared_at DATETIME",
-            "adjustment_reason TEXT",
-            "tolerance_exceeded INTEGER DEFAULT 0",
-        ):
-            try:
-                self.db.execute(f"ALTER TABLE delivery_items ADD COLUMN {col}")
-            except Exception:
-                pass
-        # Ensure drivers table exists so LEFT JOIN always has a valid target
-        self.db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS drivers (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                nombre TEXT NOT NULL,
-                telefono TEXT,
-                vehiculo TEXT,
-                activo INTEGER DEFAULT 1,
-                en_ruta INTEGER DEFAULT 0,
-                sucursal_id INTEGER DEFAULT 1,
-                usuario_id INTEGER
-            )
-            """
-        )
-        self.db.execute("CREATE INDEX IF NOT EXISTS idx_delivery_estado ON delivery_orders(estado, fecha)")
-        self.db.execute("CREATE INDEX IF NOT EXISTS idx_delivery_wa ON delivery_orders(whatsapp_order_id)")
-        self.db.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_delivery_venta ON delivery_orders(venta_id) WHERE venta_id IS NOT NULL")
-        self.db.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_delivery_wa_order ON delivery_orders(whatsapp_order_id) WHERE whatsapp_order_id IS NOT NULL")
-        self.db.execute("CREATE INDEX IF NOT EXISTS idx_delivery_items_delivery_id ON delivery_items(delivery_id)")
-        try:
-            self.db.commit()
-        except Exception:
-            pass
+        """Deprecated compatibility shim; schema ownership lives in DeliverySchemaMigrator."""
+        from core.delivery.infrastructure.delivery_schema_migrator import DeliverySchemaMigrator
+
+        DeliverySchemaMigrator(self.db).ensure_schema()
 
     @staticmethod
     def _normalize_status(status: str) -> str:
@@ -173,8 +53,9 @@ class DeliveryRepository:
             result.append(item)
         return result
 
-    def create_order(self, data: Dict[str, Any]) -> int:
-        hist = [{"estado": "pendiente", "usuario": data.get("usuario", "sistema")}]
+    def create_order(self, data: Dict[str, Any], *, commit: bool = True) -> int:
+        usuario = data.get("usuario", "sistema")
+        hist = [self._legacy_history_entry("pendiente", usuario, reason="creación")]
         cur = self.db.execute(
             """
             INSERT INTO delivery_orders(
@@ -195,7 +76,7 @@ class DeliveryRepository:
                 data.get("lng"),
                 data.get("notas", ""),
                 float(data.get("total", 0) or 0),
-                data.get("usuario", "sistema"),
+                usuario,
                 json.dumps(hist, ensure_ascii=False),
                 int(data.get("sucursal_id", 1)),
                 data.get("workflow_type"),
@@ -206,8 +87,17 @@ class DeliveryRepository:
         )
         oid = int(cur.lastrowid)
         self._replace_items(oid, data.get("items") or [])
-        self._insert_history(oid, None, "pendiente", data.get("usuario", "sistema"), "creación")
-        self.db.commit()
+        self._insert_history(
+            oid,
+            None,
+            "pendiente",
+            usuario,
+            "creación",
+            reason="order_created",
+            metadata={"source_channel": data.get("source_channel", "whatsapp"), "venta_id": data.get("venta_id")},
+        )
+        if commit:
+            self.db.commit()
         return oid
 
     def upsert_order_from_whatsapp(self, payload: Dict[str, Any], usuario: str = "whatsapp") -> int:
@@ -301,7 +191,19 @@ class DeliveryRepository:
         except Exception as exc:
             logger.warning("_replace_items delivery_id=%s falló: %s", order_id, exc)
 
-    def update_status(self, order_id: int, new_status: str, usuario: str, observacion: str = "", responsable: str = "") -> None:
+    def update_status(
+        self,
+        order_id: int,
+        new_status: str,
+        usuario: str,
+        observacion: str = "",
+        responsable: str = "",
+        *,
+        commit: bool = True,
+        reason: str | None = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        event_id: int | None = None,
+    ) -> None:
         row = self.db.execute(
             "SELECT estado, historial_cambios, venta_id FROM delivery_orders WHERE id=?", (order_id,)
         ).fetchone()
@@ -309,13 +211,7 @@ class DeliveryRepository:
             raise ValueError("Pedido no encontrado")
         prev = self._normalize_status(row[0])
         new_status = self._normalize_status(new_status)
-        hist = []
-        if row[1]:
-            try:
-                hist = json.loads(row[1])
-            except Exception:
-                hist = []
-        hist.append({"estado": new_status, "usuario": usuario})
+        hist = self._append_legacy_history(row[1], new_status, usuario, reason=reason or observacion or "status_changed")
         self.db.execute(
             """
             UPDATE delivery_orders
@@ -325,31 +221,283 @@ class DeliveryRepository:
             """,
             (new_status, responsable or None, usuario, json.dumps(hist, ensure_ascii=False), order_id),
         )
-        venta_id = row[2]
-        if venta_id:
-            venta_estado = {
-                "pendiente": "pendiente_wa",
-                "preparacion": "en_preparacion",
-                "en_ruta": "en_ruta",
-                "entregado": "entregada",
-                "cancelado": "cancelada",
-            }.get(new_status)
-            if venta_estado:
-                try:
-                    self.db.execute("UPDATE ventas SET estado=? WHERE id=?", (venta_estado, venta_id))
-                except Exception as exc:
-                    logger.debug("No se pudo sincronizar estado venta=%s: %s", venta_id, exc)
-        self._insert_history(order_id, prev, new_status, usuario, observacion)
-        self.db.commit()
+        # ventas is a secondary projection; SaleDeliveryProjectionService owns sale updates.
+        history_metadata = {"responsable": responsable or "", "venta_id": row[2]}
+        if metadata:
+            history_metadata.update(metadata)
+        self._insert_history(
+            order_id,
+            prev,
+            new_status,
+            usuario,
+            observacion,
+            reason=reason or "status_changed",
+            metadata=history_metadata,
+            event_id=event_id,
+        )
+        if commit:
+            self.db.commit()
 
-    def _insert_history(self, order_id: int, old: Optional[str], new: str, usuario: str, obs: str) -> None:
+    def _legacy_history_entry(self, status: str, usuario: str, *, reason: str = "") -> Dict[str, Any]:
+        return {
+            "estado": self._normalize_status(status),
+            "usuario": usuario,
+            "reason": reason,
+            "created_at": self.db.execute("SELECT datetime('now')").fetchone()[0],
+        }
+
+    def _append_legacy_history(self, raw_history: str | None, status: str, usuario: str, *, reason: str = "") -> List[Dict[str, Any]]:
+        hist: List[Dict[str, Any]] = []
+        if raw_history:
+            try:
+                parsed = json.loads(raw_history)
+                hist = parsed if isinstance(parsed, list) else []
+            except Exception as exc:
+                logger.warning("historial_cambios inválido para delivery: %s", exc)
+        hist.append(self._legacy_history_entry(status, usuario, reason=reason))
+        return hist
+
+    def _insert_history(
+        self,
+        order_id: int,
+        old: Optional[str],
+        new: str,
+        usuario: str,
+        obs: str,
+        *,
+        reason: str | None = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        event_id: int | None = None,
+    ) -> None:
+        columns = self._columns("delivery_order_history")
+        values: Dict[str, Any] = {
+            "order_id": order_id,
+            "estado_anterior": old,
+            "estado_nuevo": new,
+            "usuario": usuario,
+            "observacion": obs,
+        }
+        if "fecha" in columns:
+            values["fecha"] = self.db.execute("SELECT datetime('now')").fetchone()[0]
+        if "reason" in columns:
+            values["reason"] = reason or obs or "status_changed"
+        if "metadata_json" in columns:
+            values["metadata_json"] = json.dumps(metadata or {}, ensure_ascii=False, sort_keys=True)
+        if "event_id" in columns:
+            values["event_id"] = event_id
+        if "created_at" in columns:
+            values["created_at"] = self.db.execute("SELECT datetime('now')").fetchone()[0]
+
+        insert_columns = [col for col in values if col in columns]
+        placeholders = ",".join("?" for _ in insert_columns)
+        self.db.execute(
+            f"INSERT INTO delivery_order_history({', '.join(insert_columns)}) VALUES({placeholders})",
+            tuple(values[col] for col in insert_columns),
+        )
+
+    def iter_pending_whatsapp_sales(self, limit: int = 200) -> List[Dict[str, Any]]:
+        if not self._table_exists("ventas") or not self._table_exists("delivery_orders"):
+            return []
+        cols_ventas = self._columns("ventas")
+        cols_det = self._columns("detalles_venta") if self._table_exists("detalles_venta") else set()
+        if "id" not in cols_ventas:
+            return []
+
+        where = ["1=1"]
+        if "canal" in cols_ventas:
+            where.append("lower(canal)='whatsapp'")
+        if "estado" in cols_ventas:
+            where.append("lower(estado) IN ('pendiente','pendiente_wa','en_preparacion','preparacion','en_ruta','programado')")
+        rows = self.db.execute(
+            f"SELECT * FROM ventas WHERE {' AND '.join(where)} ORDER BY id DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        sales: List[Dict[str, Any]] = []
+        for row in rows:
+            sale = dict(row)
+            venta_id = sale.get("id")
+            items: List[Dict[str, Any]] = []
+            if venta_id and cols_det and "venta_id" in cols_det:
+                det_rows = self.db.execute(
+                    "SELECT producto_id, COALESCE(producto_nombre,'') AS producto_nombre, "
+                    "COALESCE(cantidad,0) AS cantidad, COALESCE(precio_unitario,0) AS precio_unitario, "
+                    "COALESCE(subtotal,0) AS subtotal "
+                    "FROM detalles_venta WHERE venta_id=?",
+                    (venta_id,),
+                ).fetchall()
+                items = [dict(r) for r in det_rows]
+            sale["items"] = items
+            sales.append(sale)
+        return sales
+
+    def _table_exists(self, table: str) -> bool:
+        return bool(self.db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1", (table,)
+        ).fetchone())
+
+    def _columns(self, table: str) -> set[str]:
+        return {r[1] for r in self.db.execute(f"PRAGMA table_info({table})").fetchall()}
+
+    def has_pending_adjustment(self, order_id: int) -> bool:
+        row = self.db.execute(
+            """SELECT 1 FROM delivery_items
+               WHERE delivery_id=? AND adjustment_status=? LIMIT 1""",
+            (order_id, "pending_customer"),
+        ).fetchone()
+        return row is not None
+
+    def mark_adjustment_blocked(self, order_id: int, target_status: str, *, commit: bool = True) -> None:
+        self.db.execute(
+            "UPDATE delivery_orders SET adjustment_pending=1, adjustment_blocked_state=? WHERE id=?",
+            (target_status, order_id),
+        )
+        if commit:
+            self.db.commit()
+
+    def activate_scheduled_order(
+        self,
+        order_id: int,
+        workflow_type: str,
+        *,
+        usuario: str = "sistema",
+        commit: bool = True,
+    ) -> None:
+        row = self.db.execute(
+            "SELECT estado, historial_cambios, venta_id FROM delivery_orders WHERE id=?",
+            (order_id,),
+        ).fetchone()
+        if not row:
+            raise ValueError("Pedido no encontrado")
+        prev = self._normalize_status(row[0])
+        hist = self._append_legacy_history(row[1], "pendiente", usuario, reason="scheduled_order_activated")
         self.db.execute(
             """
-            INSERT INTO delivery_order_history(order_id, estado_anterior, estado_nuevo, usuario, observacion)
-            VALUES(?,?,?,?,?)
+            UPDATE delivery_orders
+            SET workflow_type=?, estado='pendiente', fecha_actualizacion=datetime('now'),
+                usuario=?, historial_cambios=?
+            WHERE id=?
             """,
-            (order_id, old, new, usuario, obs),
+            (workflow_type, usuario, json.dumps(hist, ensure_ascii=False), order_id),
         )
+        self._insert_history(
+            order_id,
+            prev,
+            "pendiente",
+            usuario,
+            "activación de pedido programado",
+            reason="scheduled_order_activated",
+            metadata={"workflow_type": workflow_type, "venta_id": row[2]},
+        )
+        if commit:
+            self.db.commit()
+
+    def get_item_for_weight_adjustment(self, order_id: int, item_id: int) -> Optional[Dict[str, Any]]:
+        row = self.db.execute(
+            "SELECT id, precio_unitario, cantidad, nombre FROM delivery_items WHERE id=? AND delivery_id=?",
+            (item_id, order_id),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def mark_item_adjustment_pending(
+        self,
+        *,
+        order_id: int,
+        item_id: int,
+        prepared_qty: float,
+        pending_subtotal: float,
+        token: str,
+        tolerance_units: float,
+        prepared_by: str,
+        adjustment_reason: str,
+        commit: bool = True,
+    ) -> None:
+        self.db.execute(
+            """UPDATE delivery_items
+               SET pending_prepared_qty=?, pending_subtotal=?,
+                   adjustment_status=?, adjustment_requested_at=datetime('now'),
+                   adjustment_response='', adjustment_token=?, tolerance_units=?,
+                   prepared_by=?, adjustment_reason=?, tolerance_exceeded=1
+               WHERE id=? AND delivery_id=?""",
+            (
+                prepared_qty,
+                pending_subtotal,
+                "pending_customer",
+                token,
+                tolerance_units,
+                prepared_by,
+                adjustment_reason,
+                item_id,
+                order_id,
+            ),
+        )
+        self.db.execute(
+            "UPDATE delivery_orders SET adjustment_pending=1, adjustment_blocked_state='en_ruta' WHERE id=?",
+            (order_id,),
+        )
+        if commit:
+            self.db.commit()
+
+    def apply_item_weight_adjustment(
+        self,
+        *,
+        order_id: int,
+        item_id: int,
+        prepared_qty: float,
+        subtotal: float,
+        prepared_by: str,
+        adjustment_reason: str,
+    ) -> None:
+        self.db.execute(
+            """UPDATE delivery_items
+               SET cantidad=?, prepared_qty=?, final_qty=?, subtotal=?,
+                   prepared_by=?, prepared_at=datetime('now'),
+                   adjustment_reason=?, tolerance_exceeded=0,
+                   adjustment_status=?, pending_prepared_qty=NULL, pending_subtotal=NULL,
+                   adjustment_responded_at=datetime('now'), adjustment_response='auto_accepted'
+               WHERE id=? AND delivery_id=?""",
+            (
+                prepared_qty,
+                prepared_qty,
+                prepared_qty,
+                subtotal,
+                prepared_by,
+                adjustment_reason,
+                "accepted",
+                item_id,
+                order_id,
+            ),
+        )
+
+
+    def get_order_total(self, order_id: int) -> float:
+        row = self.db.execute("SELECT COALESCE(total, 0) FROM delivery_orders WHERE id=?", (order_id,)).fetchone()
+        return round(float(row[0]) if row else 0.0, 2)
+
+    def list_item_subtotals_for_order(self, order_id: int) -> List[float]:
+        rows = self.db.execute(
+            "SELECT COALESCE(subtotal, 0) AS subtotal FROM delivery_items WHERE delivery_id=?",
+            (order_id,),
+        ).fetchall()
+        return [float(row[0]) for row in rows]
+
+    def update_order_total(
+        self,
+        order_id: int,
+        total: float,
+        *,
+        mark_weight_adjusted: bool = True,
+        commit: bool = True,
+    ) -> None:
+        cols = self._columns("delivery_orders")
+        if mark_weight_adjusted and "weight_adjusted" in cols:
+            self.db.execute(
+                "UPDATE delivery_orders SET total=?, weight_adjusted=1 WHERE id=?",
+                (float(total), order_id),
+            )
+        else:
+            self.db.execute("UPDATE delivery_orders SET total=? WHERE id=?", (float(total), order_id))
+        if commit:
+            self.db.commit()
 
     def get_order(self, order_id: int) -> Optional[Dict[str, Any]]:
         row = self.db.execute("SELECT * FROM delivery_orders WHERE id=?", (order_id,)).fetchone()

--- a/pos_spj_v13.4/tests/test_delivery_application_use_cases.py
+++ b/pos_spj_v13.4/tests/test_delivery_application_use_cases.py
@@ -1,0 +1,294 @@
+import os
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.delivery.application.activate_scheduled_order import ActivateScheduledOrderUseCase
+from core.delivery.application.adjust_delivery_weight import AdjustDeliveryWeightUseCase
+from core.delivery.application.cancel_delivery_order import CancelDeliveryOrderUseCase
+from core.delivery.application.change_delivery_status import ChangeDeliveryStatusUseCase
+from core.delivery.application.create_delivery_order import CreateDeliveryOrderUseCase
+from core.delivery.application.sync_whatsapp_orders import SyncWhatsAppOrdersUseCase
+from core.delivery.projections.sale_delivery_projection import SaleDeliveryProjectionService
+from core.services.delivery_service import DeliveryService
+from core.services.order_total_service import OrderTotalService
+from repositories.delivery_repository import DeliveryRepository
+
+
+class DummyGeo:
+    def __init__(self):
+        self.calls = []
+
+    def geocode(self, address):
+        self.calls.append(address)
+        return {"lat": 19.43, "lng": -99.13}
+
+    def autocomplete(self, _query):
+        return []
+
+
+class DummyWA:
+    def __init__(self, pulled=None):
+        self.pulled = pulled or []
+        self.notifications = []
+        self.synced = []
+
+    def notify_status(self, **kwargs):
+        self.notifications.append(kwargs)
+        return True
+
+    def sync_status(self, whatsapp_order_id, status):
+        self.synced.append((whatsapp_order_id, status))
+        return True
+
+    def pull_orders(self):
+        return list(self.pulled)
+
+
+def _db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    repo = DeliveryRepository(db)
+    db.execute("CREATE TABLE ventas(id INTEGER PRIMARY KEY, estado TEXT, total REAL, workflow_type TEXT, canal TEXT, direccion TEXT)")
+    db.execute(
+        """
+        CREATE TABLE detalles_venta(
+            id INTEGER PRIMARY KEY,
+            venta_id INTEGER,
+            producto_id INTEGER,
+            producto_nombre TEXT,
+            cantidad REAL,
+            precio_unitario REAL,
+            subtotal REAL
+        )
+        """
+    )
+    return db, repo
+
+
+def _events():
+    published = []
+
+    def publish(event, payload):
+        published.append((event, payload))
+
+    return published, publish
+
+
+def _seed_order(db, repo, *, estado="pendiente", venta_id=1, workflow_type="delivery", delivery_type="domicilio"):
+    db.execute(
+        "INSERT INTO ventas(id, estado, total, workflow_type, canal, direccion) VALUES (?, 'pendiente', 200, NULL, 'whatsapp', 'Calle 1')",
+        (venta_id,),
+    )
+    db.execute(
+        """
+        INSERT INTO delivery_orders(id, venta_id, folio, whatsapp_order_id, cliente_tel, direccion, estado, total, workflow_type, delivery_type)
+        VALUES (1, ?, 'DEL-1', 'wa-1', '5512345678', 'Calle 1', ?, 200, ?, ?)
+        """,
+        (venta_id, estado, workflow_type, delivery_type),
+    )
+    db.execute(
+        """
+        INSERT INTO delivery_items(id, delivery_id, nombre, cantidad, precio_unitario, subtotal, unidad, prepared_qty, final_qty)
+        VALUES (1, 1, 'Pollo', 2.0, 100, 200, 'kg', 2.0, 2.0)
+        """
+    )
+    db.commit()
+
+
+def test_create_delivery_order_use_case_validates_geocodes_persists_and_publishes_without_db_payload():
+    db, repo = _db()
+    geo = DummyGeo()
+    wa = DummyWA()
+    published, publish = _events()
+
+    order_id = CreateDeliveryOrderUseCase(
+        db=db,
+        repository=repo,
+        geocoding_service=geo,
+        whatsapp_service=wa,
+        publisher=publish,
+    ).execute(
+        {
+            "folio": "DEL-X",
+            "cliente_tel": "5512345678",
+            "direccion": "Calle 123",
+            "items": [{"producto_id": 10, "nombre": "Pollo", "cantidad": 2, "precio_unitario": 50}],
+        },
+        usuario="tester",
+    )
+
+    row = repo.get_order(order_id)
+    assert row["lat"] == 19.43
+    assert geo.calls == ["Calle 123"]
+    assert wa.notifications[0]["status"] == "pedido_recibido"
+    assert {event for event, _payload in published} >= {"DELIVERY_ORDER_CREATED", "DELIVERY_ORDER_RESERVED"}
+    assert "pedido_delivery_creado" not in {event for event, _payload in published}
+    assert all("db" not in payload for _event, payload in published)
+
+
+def test_create_delivery_order_use_case_requires_address():
+    db, repo = _db()
+    with pytest.raises(ValueError, match="dirección"):
+        CreateDeliveryOrderUseCase(db=db, repository=repo).execute({"direccion": "  "})
+
+
+def test_change_status_use_case_projects_sale_and_emits_inventory_commit_without_db_payload():
+    db, repo = _db()
+    _seed_order(db, repo, estado="en_ruta")
+    published, publish = _events()
+    wa = DummyWA()
+
+    ChangeDeliveryStatusUseCase(
+        db=db,
+        repository=repo,
+        sale_projection=SaleDeliveryProjectionService(db),
+        whatsapp_service=wa,
+        publisher=publish,
+        get_order_items=lambda _order_id: [{"producto_id": 10, "final_qty": 2.0}],
+    ).execute(1, "entregado", usuario="tester", responsable="r1")
+
+    assert db.execute("SELECT estado FROM ventas WHERE id=1").fetchone()["estado"] == "entregada"
+    assert any(event == "DELIVERY_ORDER_DELIVERED" for event, _payload in published)
+    assert all(event != "pedido_entregado" for event, _payload in published)
+    commit_payload = [payload for event, payload in published if event == "INVENTORY_COMMIT_REQUIRED"][0]
+    assert commit_payload["operation_id"] == "delivery:1"
+    assert "db" not in commit_payload
+    assert wa.synced == [("wa-1", "entregado")]
+
+
+def test_change_status_use_case_blocks_pending_adjustments_before_route():
+    db, repo = _db()
+    _seed_order(db, repo, estado="preparacion")
+    db.execute("UPDATE delivery_items SET adjustment_status='pending_customer' WHERE id=1")
+    db.commit()
+
+    with pytest.raises(ValueError, match="ajuste"):
+        ChangeDeliveryStatusUseCase(db=db, repository=repo).execute(1, "en_ruta", usuario="tester")
+
+    row = db.execute("SELECT adjustment_pending, adjustment_blocked_state FROM delivery_orders WHERE id=1").fetchone()
+    assert int(row["adjustment_pending"]) == 1
+    assert row["adjustment_blocked_state"] == "en_ruta"
+
+
+def test_adjust_weight_use_case_applies_tolerance_and_projects_total_callback_without_db_payload():
+    db, repo = _db()
+    _seed_order(db, repo, estado="preparacion")
+    published, publish = _events()
+    projected = []
+
+    out = AdjustDeliveryWeightUseCase(
+        db=db,
+        repository=repo,
+        publisher=publish,
+        recalculate_order_total=OrderTotalService(db).recalculate_order_total,
+        sync_sale_total=lambda order_id, total: projected.append((order_id, total)),
+    ).execute(1, 1, 2.1, "op")
+
+    assert out["applied"] is True
+    assert out["new_total"] == 210.0
+    assert projected == [(1, 210.0)]
+    assert all("db" not in payload for _event, payload in published)
+
+
+def test_adjust_weight_use_case_marks_customer_pending_outside_tolerance():
+    db, repo = _db()
+    _seed_order(db, repo, estado="preparacion")
+    notifications = []
+
+    out = AdjustDeliveryWeightUseCase(
+        db=db,
+        repository=repo,
+        notify_adjustment_pending=lambda *args: notifications.append(args) or True,
+        recalculate_order_total=OrderTotalService(db).recalculate_order_total,
+    ).execute(1, 1, 2.25, "op")
+
+    item = db.execute("SELECT adjustment_status, pending_prepared_qty FROM delivery_items WHERE id=1").fetchone()
+    assert out["applied"] is False
+    assert item["adjustment_status"] == "pending_customer"
+    assert item["pending_prepared_qty"] == 2.25
+    assert notifications
+
+
+def test_activate_scheduled_order_use_case_moves_to_operational_workflow_and_projects_sale():
+    db, repo = _db()
+    _seed_order(db, repo, estado="programado", workflow_type="scheduled", delivery_type="pickup")
+    published, publish = _events()
+
+    result = ActivateScheduledOrderUseCase(
+        db=db,
+        repository=repo,
+        sale_projection=SaleDeliveryProjectionService(db),
+        publisher=publish,
+    ).execute(1, usuario="tester")
+
+    order = repo.get_order(1)
+    sale = db.execute("SELECT estado, workflow_type FROM ventas WHERE id=1").fetchone()
+    assert result == {"order_id": 1, "workflow_type": "counter", "status": "pending"}
+    assert order["estado"] == "pendiente"
+    assert sale["workflow_type"] == "counter"
+    assert all("db" not in payload for _event, payload in published)
+
+
+def test_cancel_delivery_order_use_case_wraps_status_change():
+    db, repo = _db()
+    _seed_order(db, repo, estado="preparacion")
+    change_status = ChangeDeliveryStatusUseCase(
+        db=db,
+        repository=repo,
+        sale_projection=SaleDeliveryProjectionService(db),
+    )
+
+    result = CancelDeliveryOrderUseCase(change_status).execute(1, usuario="tester", motivo="cliente")
+
+    assert result["status"] == "cancelado"
+    assert repo.get_order(1)["estado"] == "cancelado"
+    assert db.execute("SELECT estado FROM ventas WHERE id=1").fetchone()["estado"] == "cancelada"
+
+
+def test_sync_whatsapp_orders_use_case_upserts_pulled_orders_and_falls_back_to_local_sales():
+    db, repo = _db()
+    wa = DummyWA([
+        {"whatsapp_order_id": "wa-2", "folio": "WA-2", "cliente_tel": "55", "direccion": "Calle WA", "total": 99}
+    ])
+    published, publish = _events()
+
+    SyncWhatsAppOrdersUseCase(db=db, repository=repo, whatsapp_service=wa, publisher=publish).pull_orders_from_whatsapp()
+
+    assert db.execute("SELECT COUNT(*) FROM delivery_orders WHERE whatsapp_order_id='wa-2'").fetchone()[0] == 1
+    assert any(event == "DELIVERY_ORDER_CREATED" for event, _payload in published)
+    assert all(event != "pedido_whatsapp_recibido" for event, _payload in published)
+
+    db.execute("INSERT INTO ventas(id, estado, total, canal, direccion) VALUES (2, 'pendiente_wa', 50, 'whatsapp', 'Calle local')")
+    db.commit()
+    imported = SyncWhatsAppOrdersUseCase(db=db, repository=repo, whatsapp_service=DummyWA()).sync_pending_sales_to_delivery_orders()
+
+    assert imported == 1
+    assert db.execute("SELECT COUNT(*) FROM delivery_orders WHERE venta_id=2").fetchone()[0] == 1
+
+
+def test_delivery_service_is_application_facade_for_core_methods():
+    db, repo = _db()
+    geo = DummyGeo()
+    wa = DummyWA()
+    svc = DeliveryService(db=db, repository=repo, whatsapp_service=wa, geocoding_service=geo)
+    svc._publish = lambda *_args, **_kwargs: None
+
+    order_id = svc.create_order({"direccion": "Calle 123", "cliente_tel": "55"}, usuario="tester")
+    db.execute("UPDATE delivery_orders SET estado='preparacion' WHERE id=?", (order_id,))
+    db.execute(
+        """
+        INSERT INTO delivery_items(delivery_id, nombre, cantidad, precio_unitario, subtotal)
+        VALUES (?, 'Pollo', 1, 100, 100)
+        """,
+        (order_id,),
+    )
+    db.commit()
+
+    assert svc.adjust_item_weight(order_id, 1, 1.1, "op")["applied"] is True
+    svc.update_status(order_id, "en_ruta", usuario="tester")
+    svc.update_status(order_id, "entregado", usuario="tester", responsable="r1")
+    assert svc.list_orders()[0]["estado"] == "entregado"

--- a/pos_spj_v13.4/tests/test_delivery_domain_entities.py
+++ b/pos_spj_v13.4/tests/test_delivery_domain_entities.py
@@ -1,0 +1,37 @@
+import pytest
+
+from core.delivery.domain.entities import DeliveryItem, DeliveryOrder
+from core.delivery.domain.states import AdjustmentStatus, DeliveryStatus, DeliveryType, DeliveryWorkflowType
+from core.delivery.domain.value_objects import GeoPoint, Money, Quantity
+
+
+def test_order_from_mapping_normalizes_legacy_values_and_items():
+    order = DeliveryOrder.from_mapping({
+        "estado": "en_preparacion",
+        "workflow_type": "mostrador",
+        "delivery_type": "pickup",
+        "items": [{"nombre": "Pollo", "cantidad": 2, "precio_unitario": 50, "adjustment_status": "pending_customer"}],
+    })
+    assert order.estado == DeliveryStatus.PREPARACION
+    assert order.workflow_type == DeliveryWorkflowType.COUNTER
+    assert order.delivery_type == DeliveryType.PICKUP
+    assert order.items[0].subtotal == 100.0
+    assert order.has_pending_adjustment is True
+
+
+def test_item_from_mapping_supports_legacy_keys():
+    item = DeliveryItem.from_mapping({"product_id": 7, "name": "Ribeye", "qty": 1.2, "unit_price": 350})
+    assert item.producto_id == 7
+    assert item.nombre == "Ribeye"
+    assert item.subtotal == 420.0
+    assert item.adjustment_status == AdjustmentStatus.NONE
+
+
+def test_value_objects_validate_domain_values():
+    assert Money("10.005").as_float() == 10.01
+    assert Quantity("2.500", "KG").unit == "kg"
+    GeoPoint(19.4, -99.1)
+    with pytest.raises(ValueError, match="negativa"):
+        Quantity(-1)
+    with pytest.raises(ValueError, match="Latitud"):
+        GeoPoint(100, 0)

--- a/pos_spj_v13.4/tests/test_delivery_domain_events.py
+++ b/pos_spj_v13.4/tests/test_delivery_domain_events.py
@@ -1,0 +1,24 @@
+from core.delivery.domain.events import CRITICAL_OUTBOX_EVENTS, DeliveryEvents, required_payload_fields
+
+
+def test_event_catalog_documents_required_payloads():
+    assert required_payload_fields(DeliveryEvents.ORDER_CREATED) == (
+        "order_id",
+        "folio",
+        "direccion",
+        "total",
+        "sucursal_id",
+        "usuario",
+    )
+    assert required_payload_fields("INVENTORY_COMMIT_REQUIRED") == (
+        "order_id",
+        "operation_id",
+        "items",
+        "sucursal_id",
+    )
+
+
+def test_critical_events_are_identified_for_future_outbox():
+    assert DeliveryEvents.INVENTORY_COMMIT_REQUIRED in CRITICAL_OUTBOX_EVENTS
+    assert DeliveryEvents.CUSTOMER_NOTIFICATION_REQUESTED in CRITICAL_OUTBOX_EVENTS
+    assert DeliveryEvents.ORDER_PREPARING not in CRITICAL_OUTBOX_EVENTS

--- a/pos_spj_v13.4/tests/test_delivery_history_audit.py
+++ b/pos_spj_v13.4/tests/test_delivery_history_audit.py
@@ -1,0 +1,103 @@
+import json
+import sqlite3
+
+from core.delivery.application.activate_scheduled_order import ActivateScheduledOrderUseCase
+from core.delivery.application.cancel_delivery_order import CancelDeliveryOrderUseCase
+from core.delivery.application.change_delivery_status import ChangeDeliveryStatusUseCase
+from repositories.delivery_repository import DeliveryRepository
+
+
+def _db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    repo = DeliveryRepository(conn)
+    conn.execute("CREATE TABLE ventas(id INTEGER PRIMARY KEY, estado TEXT, total REAL, workflow_type TEXT)")
+    return conn, repo
+
+
+def test_create_order_writes_auditable_history_and_deprecated_json_compat():
+    db, repo = _db()
+
+    order_id = repo.create_order(
+        {
+            "folio": "DEL-H1",
+            "direccion": "Calle Historial 1",
+            "cliente_tel": "5512345678",
+            "usuario": "tester",
+            "source_channel": "whatsapp",
+            "venta_id": 10,
+        }
+    )
+
+    history = db.execute(
+        """
+        SELECT estado_anterior, estado_nuevo, usuario, reason, metadata_json, created_at
+        FROM delivery_order_history WHERE order_id=?
+        """,
+        (order_id,),
+    ).fetchone()
+    assert history["estado_anterior"] is None
+    assert history["estado_nuevo"] == "pendiente"
+    assert history["usuario"] == "tester"
+    assert history["reason"] == "order_created"
+    assert json.loads(history["metadata_json"]) == {"source_channel": "whatsapp", "venta_id": 10}
+    assert history["created_at"] is not None
+
+    raw_json = db.execute("SELECT historial_cambios FROM delivery_orders WHERE id=?", (order_id,)).fetchone()[0]
+    legacy_history = json.loads(raw_json)
+    assert legacy_history[0]["estado"] == "pendiente"
+    assert legacy_history[0]["reason"] == "creación"
+    assert legacy_history[0]["created_at"] is not None
+
+
+def test_change_status_history_has_reason_metadata_and_keeps_legacy_json():
+    db, repo = _db()
+    order_id = repo.create_order({"direccion": "Calle 2", "usuario": "creator"})
+
+    ChangeDeliveryStatusUseCase(db=db, repository=repo).execute(
+        order_id,
+        "preparacion",
+        usuario="chef",
+        observacion="pedido tomado por cocina",
+    )
+
+    rows = db.execute(
+        """
+        SELECT estado_anterior, estado_nuevo, usuario, observacion, reason, metadata_json
+        FROM delivery_order_history WHERE order_id=? ORDER BY id
+        """,
+        (order_id,),
+    ).fetchall()
+    assert len(rows) == 2
+    last = rows[-1]
+    assert dict(last) == {
+        "estado_anterior": "pendiente",
+        "estado_nuevo": "preparacion",
+        "usuario": "chef",
+        "observacion": "pedido tomado por cocina",
+        "reason": "delivery_status_preparacion",
+        "metadata_json": '{"responsable": "", "source": "ChangeDeliveryStatusUseCase", "target_status": "preparacion", "venta_id": null}',
+    }
+
+    legacy = json.loads(db.execute("SELECT historial_cambios FROM delivery_orders WHERE id=?", (order_id,)).fetchone()[0])
+    assert legacy[-1]["estado"] == "preparacion"
+    assert legacy[-1]["reason"] == "delivery_status_preparacion"
+
+
+def test_activate_scheduled_and_cancel_write_status_history_rows():
+    db, repo = _db()
+    order_id = repo.create_order({"direccion": "Calle 3", "usuario": "creator", "delivery_type": "pickup"})
+    repo.update_status(order_id, "programado", usuario="planner", reason="manual_schedule")
+
+    ActivateScheduledOrderUseCase(db=db, repository=repo).execute(order_id, usuario="planner")
+    CancelDeliveryOrderUseCase(
+        ChangeDeliveryStatusUseCase(db=db, repository=repo)
+    ).execute(order_id, usuario="planner", motivo="cliente no llegó")
+
+    rows = db.execute(
+        "SELECT estado_anterior, estado_nuevo, reason, observacion FROM delivery_order_history WHERE order_id=? ORDER BY id",
+        (order_id,),
+    ).fetchall()
+    transitions = [(r["estado_anterior"], r["estado_nuevo"], r["reason"], r["observacion"]) for r in rows]
+    assert ("programado", "pendiente", "scheduled_order_activated", "activación de pedido programado") in transitions
+    assert ("pendiente", "cancelado", "delivery_status_cancelado", "cliente no llegó") in transitions

--- a/pos_spj_v13.4/tests/test_delivery_inventory_projection.py
+++ b/pos_spj_v13.4/tests/test_delivery_inventory_projection.py
@@ -1,0 +1,133 @@
+import os
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.delivery.application.process_delivery_outbox import ProcessDeliveryOutboxUseCase
+from core.delivery.infrastructure.delivery_outbox_repository import DeliveryOutboxRepository
+from core.delivery.infrastructure.inventory_reservation_adapter import ReservationServiceInventoryAdapter
+from core.delivery.projections.delivery_inventory_projection import DeliveryInventoryProjectionService
+from repositories.delivery_repository import DeliveryRepository
+
+
+def _db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    DeliveryRepository(db)
+    db.execute("CREATE TABLE productos(id INTEGER PRIMARY KEY, nombre TEXT, existencia REAL DEFAULT 0, precio_compra REAL DEFAULT 0)")
+    db.execute(
+        """
+        CREATE TABLE inventario_actual(
+            producto_id INTEGER,
+            sucursal_id INTEGER,
+            cantidad REAL,
+            costo_promedio REAL DEFAULT 0,
+            ultima_actualizacion TEXT,
+            PRIMARY KEY(producto_id, sucursal_id)
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE branch_inventory(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            product_id INTEGER,
+            branch_id INTEGER,
+            quantity REAL,
+            batch_id INTEGER,
+            updated_at TEXT
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE movimientos_inventario(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            uuid TEXT,
+            producto_id INTEGER,
+            sucursal_id INTEGER,
+            tipo_movimiento TEXT,
+            referencia_tipo TEXT,
+            referencia_id TEXT,
+            cantidad REAL,
+            costo_unitario REAL,
+            operation_id TEXT,
+            usuario TEXT,
+            nota TEXT
+        )
+        """
+    )
+    db.execute("INSERT INTO productos(id, nombre, existencia, precio_compra) VALUES (10, 'Pollo', 10, 20)")
+    db.execute("INSERT INTO inventario_actual(producto_id, sucursal_id, cantidad, costo_promedio) VALUES (10, 1, 10, 20)")
+    db.commit()
+    return db
+
+
+def test_inventory_projection_reserves_releases_and_is_idempotent():
+    db = _db()
+    projection = DeliveryInventoryProjectionService(ReservationServiceInventoryAdapter(db))
+    payload = {
+        "order_id": 1,
+        "operation_id": "delivery:1",
+        "items": [{"producto_id": 10, "cantidad": 2}],
+        "branch_id": 1,
+    }
+
+    first = projection.handle_order_reserved(payload)
+    second = projection.handle_order_reserved(payload)
+
+    assert first["reserved"] == 1
+    assert second["reserved"] == 0
+    assert db.execute("SELECT COUNT(*) FROM inventory_reservations WHERE operation_id='delivery:1'").fetchone()[0] == 1
+
+    released = projection.handle_inventory_release_required({"order_id": 1, "operation_id": "delivery:1", "reason": "cancelado"})
+    assert released["released"] == 1
+    assert db.execute("SELECT released FROM inventory_reservations WHERE operation_id='delivery:1'").fetchone()[0] == 1
+
+
+def test_inventory_projection_commit_uses_final_qty_and_item_operation_id_idempotency():
+    db = _db()
+    projection = DeliveryInventoryProjectionService(ReservationServiceInventoryAdapter(db))
+    projection.handle_order_reserved({
+        "order_id": 2,
+        "operation_id": "delivery:2",
+        "items": [{"id": 7, "producto_id": 10, "cantidad": 3}],
+        "branch_id": 1,
+    })
+
+    payload = {
+        "order_id": 2,
+        "operation_id": "delivery:2",
+        "items": [{"id": 7, "producto_id": 10, "cantidad": 3, "prepared_qty": 2.5, "final_qty": 2.25}],
+        "branch_id": 1,
+    }
+    first = projection.handle_inventory_commit_required(payload)
+    second = projection.handle_inventory_commit_required(payload)
+
+    stock = db.execute("SELECT cantidad FROM inventario_actual WHERE producto_id=10 AND sucursal_id=1").fetchone()[0]
+    movement = db.execute("SELECT cantidad, operation_id FROM movimientos_inventario WHERE producto_id=10").fetchone()
+    assert first["committed"] == 1
+    assert second["committed"] == 0
+    assert stock == 7.75
+    assert movement["cantidad"] == -2.25
+    assert movement["operation_id"] == "delivery:2:item:7:commit"
+
+
+def test_outbox_processor_can_route_inventory_handlers():
+    db = _db()
+    outbox = DeliveryOutboxRepository(db)
+    projection = DeliveryInventoryProjectionService(ReservationServiceInventoryAdapter(db))
+    outbox.enqueue(
+        event_type="DELIVERY_ORDER_RESERVED",
+        aggregate_id=3,
+        payload={"order_id": 3, "operation_id": "delivery:3", "items": [{"producto_id": 10, "cantidad": 1}], "branch_id": 1},
+        operation_id="delivery:3",
+        commit=True,
+    )
+
+    result = ProcessDeliveryOutboxUseCase(outbox_repository=outbox, handlers=projection.handlers()).execute()
+
+    assert result == {"processed": 1, "failed": 0}
+    assert db.execute("SELECT reserved_qty FROM inventory_reservations WHERE operation_id='delivery:3'").fetchone()[0] == 1
+    assert db.execute("SELECT status FROM delivery_outbox_events").fetchone()[0] == "done"

--- a/pos_spj_v13.4/tests/test_delivery_legacy_event_bridge.py
+++ b/pos_spj_v13.4/tests/test_delivery_legacy_event_bridge.py
@@ -1,0 +1,70 @@
+from core.delivery.application.legacy_event_bridge import (
+    LEGACY_DELIVERY_EVENT_DEPRECATION,
+    LegacyDeliveryEventBridge,
+    register_legacy_delivery_event_bridge,
+)
+from core.delivery.domain.events import DeliveryEvents
+from core.events.event_bus import EventBus
+
+
+def test_bridge_translates_canonical_delivery_events_without_db_payload():
+    emitted = []
+    bridge = LegacyDeliveryEventBridge(lambda event, payload: emitted.append((event, payload)))
+
+    translated = bridge.handle(
+        DeliveryEvents.ORDER_DELIVERED.value,
+        {"order_id": 7, "responsable": "r1", "db": object()},
+    )
+
+    assert [(event.event_type, event.payload) for event in translated] == [
+        ("pedido_entregado", {"order_id": 7, "responsable": "r1"})
+    ]
+    assert emitted == [("pedido_entregado", {"order_id": 7, "responsable": "r1"})]
+    assert "db" not in emitted[0][1]
+
+
+def test_bridge_maps_created_route_and_inventory_release_events():
+    emitted = []
+    bridge = LegacyDeliveryEventBridge(lambda event, payload: emitted.append((event, payload)))
+
+    bridge.handle(DeliveryEvents.ORDER_CREATED.value, {"order_id": 1, "source_channel": "whatsapp"})
+    bridge.handle(DeliveryEvents.OUT_FOR_DELIVERY.value, {"order_id": 1, "driver_id": 9})
+    bridge.handle(DeliveryEvents.INVENTORY_RELEASE_REQUIRED.value, {"order_id": 1, "operation_id": "delivery:1"})
+
+    assert emitted == [
+        ("pedido_delivery_creado", {"order_id": 1}),
+        ("pedido_whatsapp_recibido", {"order_id": 1, "canal": "whatsapp"}),
+        ("pedido_en_ruta", {"order_id": 1}),
+        ("stock_liberar_solicitado", {"order_id": 1}),
+    ]
+
+
+def test_register_bridge_on_event_bus_publishes_legacy_events():
+    bus = EventBus()
+    bus.clear_handlers()
+    received = []
+    for event_name in ("pedido_delivery_creado", "pedido_whatsapp_recibido", "pedido_en_ruta"):
+        bus.subscribe(event_name, lambda payload, _event_name=event_name: received.append((_event_name, payload)))
+
+    register_legacy_delivery_event_bridge(bus)
+    bus.publish(DeliveryEvents.ORDER_CREATED.value, {"order_id": 5})
+    bus.publish(DeliveryEvents.OUT_FOR_DELIVERY.value, {"order_id": 5})
+
+    assert [event for event, _payload in received] == [
+        "pedido_delivery_creado",
+        "pedido_whatsapp_recibido",
+        "pedido_en_ruta",
+    ]
+    assert all("db" not in payload for _event, payload in received)
+    bus.clear_handlers()
+
+
+def test_legacy_deprecation_catalog_documents_events_to_remove_later():
+    assert {
+        "pedido_delivery_creado",
+        "pedido_whatsapp_recibido",
+        "pedido_en_ruta",
+        "pedido_entregado",
+        "stock_liberar_solicitado",
+        "notificacion_whatsapp_enviada",
+    } <= set(LEGACY_DELIVERY_EVENT_DEPRECATION)

--- a/pos_spj_v13.4/tests/test_delivery_outbox.py
+++ b/pos_spj_v13.4/tests/test_delivery_outbox.py
@@ -1,0 +1,160 @@
+import os
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.delivery.application.change_delivery_status import ChangeDeliveryStatusUseCase
+from core.delivery.application.create_delivery_order import CreateDeliveryOrderUseCase
+from core.delivery.application.process_delivery_outbox import ProcessDeliveryOutboxUseCase
+from core.delivery.infrastructure.delivery_outbox_repository import DeliveryOutboxRepository
+from repositories.delivery_repository import DeliveryRepository
+
+
+class DummyWA:
+    def __init__(self):
+        self.notifications = []
+        self.synced = []
+
+    def notify_status(self, **kwargs):
+        self.notifications.append(kwargs)
+        return True
+
+    def sync_status(self, whatsapp_order_id, status):
+        self.synced.append((whatsapp_order_id, status))
+        return True
+
+
+class DummyGeo:
+    def geocode(self, _address):
+        return None
+
+
+def _db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    repo = DeliveryRepository(db)
+    db.execute("CREATE TABLE ventas(id INTEGER PRIMARY KEY, estado TEXT, total REAL)")
+    return db, repo
+
+
+def _seed_delivery_in_route(db):
+    db.execute("INSERT INTO ventas(id, estado, total) VALUES (1, 'en_ruta', 200)")
+    db.execute(
+        """
+        INSERT INTO delivery_orders(id, venta_id, folio, whatsapp_order_id, cliente_tel, direccion, estado, total, workflow_type)
+        VALUES (1, 1, 'DEL-1', 'wa-1', '5512345678', 'Calle 1', 'en_ruta', 200, 'delivery')
+        """
+    )
+    db.execute(
+        """
+        INSERT INTO delivery_items(id, delivery_id, nombre, producto_id, cantidad, precio_unitario, subtotal, final_qty)
+        VALUES (1, 1, 'Pollo', 10, 2, 100, 200, 2)
+        """
+    )
+    db.commit()
+
+
+def test_outbox_repository_is_idempotent_by_operation_id_and_strips_db_payload():
+    db, _repo = _db()
+    outbox = DeliveryOutboxRepository(db)
+
+    first = outbox.enqueue(
+        event_type="INVENTORY_COMMIT_REQUIRED",
+        aggregate_id=1,
+        payload={"order_id": 1, "operation_id": "delivery:1", "db": db},
+        operation_id="delivery:1",
+        commit=True,
+    )
+    second = outbox.enqueue(
+        event_type="INVENTORY_COMMIT_REQUIRED",
+        aggregate_id=1,
+        payload={"order_id": 1, "operation_id": "delivery:1", "db": db},
+        operation_id="delivery:1",
+        commit=True,
+    )
+
+    assert first == second
+    assert db.execute("SELECT COUNT(*) FROM delivery_outbox_events").fetchone()[0] == 1
+    payload = outbox.payload_for(first)
+    assert payload == {"order_id": 1, "operation_id": "delivery:1"}
+
+
+def test_create_order_use_case_enqueues_outbox_events_in_committed_transaction_without_db_payload():
+    db, repo = _db()
+    outbox = DeliveryOutboxRepository(db)
+    published = []
+
+    order_id = CreateDeliveryOrderUseCase(
+        db=db,
+        repository=repo,
+        geocoding_service=DummyGeo(),
+        whatsapp_service=DummyWA(),
+        publisher=lambda event, payload: published.append((event, payload)),
+        outbox_repository=outbox,
+    ).execute(
+        {
+            "direccion": "Calle 1",
+            "cliente_tel": "55",
+            "items": [{"producto_id": 10, "nombre": "Pollo", "cantidad": 2, "precio_unitario": 100}],
+        },
+        usuario="tester",
+    )
+
+    rows = db.execute("SELECT event_type, payload_json FROM delivery_outbox_events WHERE aggregate_id=?", (order_id,)).fetchall()
+    event_types = {row["event_type"] for row in rows}
+    assert "DELIVERY_ORDER_RESERVED" in event_types
+    assert "CUSTOMER_NOTIFICATION_REQUESTED" in event_types
+    assert all('"db"' not in row["payload_json"] for row in rows)
+    assert repo.get_order(order_id)["direccion"] == "Calle 1"
+
+
+def test_delivered_status_enqueues_critical_outbox_events_and_projects_sale():
+    db, repo = _db()
+    _seed_delivery_in_route(db)
+    outbox = DeliveryOutboxRepository(db)
+
+    ChangeDeliveryStatusUseCase(
+        db=db,
+        repository=repo,
+        outbox_repository=outbox,
+        whatsapp_service=DummyWA(),
+        get_order_items=lambda _order_id: [{"producto_id": 10, "final_qty": 2}],
+        sale_projection=__import__(
+            "core.delivery.projections.sale_delivery_projection",
+            fromlist=["SaleDeliveryProjectionService"],
+        ).SaleDeliveryProjectionService(db),
+    ).execute(1, "entregado", usuario="tester", responsable="r1")
+
+    event_types = {
+        row[0]
+        for row in db.execute("SELECT event_type FROM delivery_outbox_events WHERE aggregate_id=1").fetchall()
+    }
+    assert {"DELIVERY_ORDER_DELIVERED", "INVENTORY_COMMIT_REQUIRED", "CUSTOMER_NOTIFICATION_REQUESTED"} <= event_types
+    assert db.execute("SELECT estado FROM ventas WHERE id=1").fetchone()[0] == "entregada"
+
+
+def test_process_delivery_outbox_marks_done_and_records_retry_errors():
+    db, _repo = _db()
+    outbox = DeliveryOutboxRepository(db)
+    ok_id = outbox.enqueue(event_type="OK", aggregate_id=1, payload={"order_id": 1}, commit=True)
+    fail_id = outbox.enqueue(event_type="FAIL", aggregate_id=1, payload={"order_id": 1}, commit=True)
+    handled = []
+
+    result = ProcessDeliveryOutboxUseCase(
+        outbox_repository=outbox,
+        handlers={
+            "OK": lambda payload: handled.append(payload["order_id"]),
+            "FAIL": lambda _payload: (_ for _ in ()).throw(RuntimeError("boom")),
+        },
+    ).execute(limit=10)
+
+    ok = db.execute("SELECT status, processed_at FROM delivery_outbox_events WHERE id=?", (ok_id,)).fetchone()
+    fail = db.execute("SELECT status, retries, last_error FROM delivery_outbox_events WHERE id=?", (fail_id,)).fetchone()
+    assert result == {"processed": 1, "failed": 1}
+    assert handled == [1]
+    assert ok["status"] == "done"
+    assert ok["processed_at"] is not None
+    assert fail["status"] == "pending"
+    assert fail["retries"] == 1
+    assert "boom" in fail["last_error"]

--- a/pos_spj_v13.4/tests/test_delivery_phase12_required.py
+++ b/pos_spj_v13.4/tests/test_delivery_phase12_required.py
@@ -1,0 +1,366 @@
+import os
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "..", "whatsapp_service"))
+
+from core.delivery.application.change_delivery_status import ChangeDeliveryStatusUseCase
+from core.delivery.application.create_delivery_order import CreateDeliveryOrderUseCase
+from core.delivery.application.process_delivery_outbox import ProcessDeliveryOutboxUseCase
+from core.delivery.infrastructure.delivery_outbox_repository import DeliveryOutboxRepository
+from core.delivery.infrastructure.inventory_reservation_adapter import ReservationServiceInventoryAdapter
+from core.delivery.projections.delivery_inventory_projection import DeliveryInventoryProjectionService
+from core.delivery.projections.sale_delivery_projection import SaleDeliveryProjectionService
+from core.services.delivery_service import DeliveryService
+from core.services.order_total_service import OrderTotalService
+from erp.adjustment_approval import AdjustmentApprovalService
+from repositories.delivery_repository import DeliveryRepository
+
+
+class DummyGeo:
+    def __init__(self):
+        self.calls = []
+
+    def geocode(self, address):
+        self.calls.append(address)
+        return {"lat": 20.1, "lng": -103.2}
+
+    def autocomplete(self, _query):
+        return []
+
+
+class DummyWA:
+    def __init__(self, pulled=None):
+        self.pulled = pulled or []
+        self.notifications = []
+        self.synced = []
+
+    def notify_status(self, **kwargs):
+        self.notifications.append(kwargs)
+        return True
+
+    def sync_status(self, whatsapp_order_id, status):
+        self.synced.append((whatsapp_order_id, status))
+        return True
+
+    def pull_orders(self):
+        return list(self.pulled)
+
+
+def _db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    repo = DeliveryRepository(db)
+    db.execute("CREATE TABLE ventas(id INTEGER PRIMARY KEY, estado TEXT, total REAL, workflow_type TEXT, canal TEXT, direccion TEXT)")
+    db.execute(
+        """
+        CREATE TABLE detalles_venta(
+            id INTEGER PRIMARY KEY,
+            venta_id INTEGER,
+            producto_id INTEGER,
+            producto_nombre TEXT,
+            cantidad REAL,
+            precio_unitario REAL,
+            subtotal REAL
+        )
+        """
+    )
+    return db, repo
+
+
+def _seed_order(
+    db,
+    *,
+    order_id=1,
+    venta_id=1,
+    estado="pendiente",
+    workflow_type="delivery",
+    delivery_type="home_delivery",
+    total=200,
+    phone="5512345678",
+):
+    db.execute(
+        "INSERT OR IGNORE INTO ventas(id, estado, total, workflow_type, canal, direccion) VALUES (?, ?, ?, ?, 'whatsapp', 'Calle 1')",
+        (venta_id, estado, total, workflow_type),
+    )
+    db.execute(
+        """
+        INSERT INTO delivery_orders(id, venta_id, folio, whatsapp_order_id, cliente_tel, direccion, estado, total, workflow_type, delivery_type)
+        VALUES (?, ?, ?, ?, ?, 'Calle 1', ?, ?, ?, ?)
+        """,
+        (order_id, venta_id, f"DEL-{order_id}", f"wa-{order_id}", phone, estado, total, workflow_type, delivery_type),
+    )
+    db.execute(
+        """
+        INSERT INTO delivery_items(id, delivery_id, nombre, producto_id, cantidad, precio_unitario, subtotal, unidad, prepared_qty, final_qty)
+        VALUES (?, ?, 'Pollo', 10, 2.0, 100, 200, 'kg', 2.0, 2.0)
+        """,
+        (order_id, order_id),
+    )
+    db.commit()
+
+
+def _inventory_db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    DeliveryRepository(db)
+    db.execute("CREATE TABLE productos(id INTEGER PRIMARY KEY, nombre TEXT, existencia REAL DEFAULT 0, precio_compra REAL DEFAULT 0)")
+    db.execute(
+        """
+        CREATE TABLE inventario_actual(
+            producto_id INTEGER,
+            sucursal_id INTEGER,
+            cantidad REAL,
+            costo_promedio REAL DEFAULT 0,
+            ultima_actualizacion TEXT,
+            PRIMARY KEY(producto_id, sucursal_id)
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE branch_inventory(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            product_id INTEGER,
+            branch_id INTEGER,
+            quantity REAL,
+            batch_id INTEGER,
+            updated_at TEXT
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE TABLE movimientos_inventario(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            uuid TEXT,
+            producto_id INTEGER,
+            sucursal_id INTEGER,
+            tipo_movimiento TEXT,
+            referencia_tipo TEXT,
+            referencia_id TEXT,
+            cantidad REAL,
+            costo_unitario REAL,
+            operation_id TEXT,
+            usuario TEXT,
+            nota TEXT
+        )
+        """
+    )
+    db.execute("INSERT INTO productos(id, nombre, existencia, precio_compra) VALUES (10, 'Pollo', 20, 20)")
+    db.execute("INSERT INTO inventario_actual(producto_id, sucursal_id, cantidad, costo_promedio) VALUES (10, 1, 20, 20)")
+    db.commit()
+    return db
+
+
+def test_create_order_required_contract_and_whatsapp_dedupe():
+    db, repo = _db()
+    geo = DummyGeo()
+    outbox = DeliveryOutboxRepository(db)
+
+    with pytest.raises(ValueError, match="dirección"):
+        CreateDeliveryOrderUseCase(db=db, repository=repo).execute({"direccion": " "})
+
+    order_id = CreateDeliveryOrderUseCase(
+        db=db,
+        repository=repo,
+        geocoding_service=geo,
+        whatsapp_service=DummyWA(),
+        outbox_repository=outbox,
+    ).execute(
+        {
+            "whatsapp_order_id": "wa-create-1",
+            "venta_id": 100,
+            "direccion": "Calle Crear",
+            "cliente_tel": "55",
+            "items": [{"producto_id": 10, "nombre": "Pollo", "cantidad": 2, "precio_unitario": 100}],
+        },
+        usuario="tester",
+    )
+
+    assert geo.calls == ["Calle Crear"]
+    assert repo.get_order(order_id)["lat"] == 20.1
+    assert db.execute("SELECT COUNT(*) FROM delivery_items WHERE delivery_id=?", (order_id,)).fetchone()[0] == 1
+    event_types = {row[0] for row in db.execute("SELECT event_type FROM delivery_outbox_events WHERE aggregate_id=?", (order_id,)).fetchall()}
+    assert {"DELIVERY_ORDER_RESERVED", "CUSTOMER_NOTIFICATION_REQUESTED"} <= event_types
+
+    repo.upsert_order_from_whatsapp({"whatsapp_order_id": "wa-dup", "venta_id": 101, "direccion": "Dir A"})
+    repo.upsert_order_from_whatsapp({"whatsapp_order_id": "wa-dup", "venta_id": 101, "direccion": "Dir B"})
+    repo.upsert_order_from_whatsapp({"venta_id": 102, "direccion": "Dir C"})
+    repo.upsert_order_from_whatsapp({"venta_id": 102, "direccion": "Dir D"})
+    assert db.execute("SELECT COUNT(*) FROM delivery_orders WHERE whatsapp_order_id='wa-dup'").fetchone()[0] == 1
+    assert db.execute("SELECT COUNT(*) FROM delivery_orders WHERE venta_id=102").fetchone()[0] == 1
+
+
+def test_change_status_required_transition_matrix():
+    db, repo = _db()
+    uc = lambda: ChangeDeliveryStatusUseCase(db=db, repository=repo, sale_projection=SaleDeliveryProjectionService(db), whatsapp_service=DummyWA())
+
+    _seed_order(db, order_id=1, estado="pendiente", workflow_type="delivery")
+    uc().execute(1, "preparacion", usuario="tester")
+    assert repo.get_order(1)["estado"] == "preparacion"
+    uc().execute(1, "en_ruta", usuario="tester")
+    assert repo.get_order(1)["estado"] == "en_ruta"
+
+    _seed_order(db, order_id=2, venta_id=2, estado="preparacion", workflow_type="counter", delivery_type="pickup")
+    uc().execute(2, "entregado", usuario="tester", responsable="mostrador")
+    assert repo.get_order(2)["estado"] == "entregado"
+
+    _seed_order(db, order_id=3, venta_id=3, estado="preparacion", workflow_type="counter", delivery_type="pickup")
+    with pytest.raises(ValueError, match="mostrador"):
+        uc().execute(3, "en_ruta", usuario="tester")
+
+    _seed_order(db, order_id=4, venta_id=4, estado="programado", workflow_type="scheduled")
+    with pytest.raises(ValueError, match="programado"):
+        uc().execute(4, "preparacion", usuario="tester")
+
+    _seed_order(db, order_id=5, venta_id=5, estado="en_ruta", workflow_type="delivery")
+    with pytest.raises(ValueError, match="responsable"):
+        uc().execute(5, "entregado", usuario="tester")
+
+    _seed_order(db, order_id=6, venta_id=6, estado="preparacion", workflow_type="delivery")
+    db.execute("UPDATE delivery_items SET adjustment_status='pending_customer' WHERE delivery_id=6")
+    db.commit()
+    with pytest.raises(ValueError, match="ajuste"):
+        uc().execute(6, "en_ruta", usuario="tester")
+    with pytest.raises(ValueError, match="ajuste"):
+        uc().execute(6, "entregado", usuario="tester", responsable="r1")
+
+
+def test_inventory_required_reserve_release_commit_and_idempotency():
+    db = _inventory_db()
+    projection = DeliveryInventoryProjectionService(ReservationServiceInventoryAdapter(db))
+
+    reserved = projection.handle_order_reserved({
+        "order_id": 10,
+        "operation_id": "delivery:10",
+        "items": [{"id": 1, "producto_id": 10, "cantidad": 2}],
+        "branch_id": 1,
+    })
+    assert reserved["reserved"] == 1
+
+    released = projection.handle_inventory_release_required({"order_id": 10, "operation_id": "delivery:10", "reason": "cancelado"})
+    assert released["released"] == 1
+
+    projection.handle_order_reserved({
+        "order_id": 11,
+        "operation_id": "delivery:11",
+        "items": [{"id": 7, "producto_id": 10, "cantidad": 3}],
+        "branch_id": 1,
+    })
+    payload = {
+        "order_id": 11,
+        "operation_id": "delivery:11",
+        "items": [{"id": 7, "producto_id": 10, "cantidad": 3, "prepared_qty": 2.5, "final_qty": 2.25}],
+        "branch_id": 1,
+    }
+    first = projection.handle_inventory_commit_required(payload)
+    second = projection.handle_inventory_commit_required(payload)
+    assert first["committed"] == 1
+    assert second["committed"] == 0
+    assert db.execute("SELECT COUNT(*) FROM movimientos_inventario WHERE operation_id='delivery:11:item:7:commit'").fetchone()[0] == 1
+
+
+def test_weight_adjustment_required_accept_reject_and_route_blocking():
+    db, repo = _db()
+    _seed_order(db, order_id=1, estado="preparacion")
+    svc = DeliveryService(db=db, repository=repo, whatsapp_service=DummyWA(), geocoding_service=DummyGeo())
+    svc._publish = lambda *_args, **_kwargs: None
+
+    auto = svc.adjust_item_weight(1, 1, 2.1, "op")
+    assert auto["applied"] is True
+    assert repo.get_order(1)["total"] == 210.0
+
+    _seed_order(db, order_id=2, venta_id=2, estado="preparacion", phone="5599999999")
+    pending = svc.adjust_item_weight(2, 2, 2.3, "op")
+    assert pending["applied"] is False
+    assert db.execute("SELECT pending_prepared_qty FROM delivery_items WHERE id=2").fetchone()[0] == 2.3
+    with pytest.raises(ValueError, match="ajuste"):
+        svc.update_status(2, "en_ruta", usuario="tester")
+    accepted = AdjustmentApprovalService(db).respond_latest_for_phone("5599999999", accepted=True)
+    assert accepted["total"] == 230.0
+    assert db.execute("SELECT cantidad, adjustment_status FROM delivery_items WHERE id=2").fetchone()[0] == 2.3
+
+    _seed_order(db, order_id=3, venta_id=3, estado="preparacion", phone="5588888888")
+    svc.adjust_item_weight(3, 3, 2.3, "op")
+    rejected = AdjustmentApprovalService(db).respond_latest_for_phone("5588888888", accepted=False)
+    item = db.execute("SELECT cantidad, subtotal, adjustment_status FROM delivery_items WHERE id=3").fetchone()
+    assert rejected["total"] == 200.0
+    assert item["cantidad"] == 2.0
+    assert item["subtotal"] == 200.0
+    assert item["adjustment_status"] == "rejected"
+
+
+def test_totals_required_recalculate_from_items_single_sale_projection_and_total_updated_event():
+    db, repo = _db()
+    _seed_order(db, order_id=1, estado="preparacion")
+    db.execute("INSERT INTO delivery_items(id, delivery_id, nombre, cantidad, precio_unitario, subtotal) VALUES (20, 1, 'Salsa', 1, 15, 15)")
+    db.commit()
+
+    total = OrderTotalService(db).recalculate_order_total(1)
+    assert total == 215.0
+    assert db.execute("SELECT total FROM ventas WHERE id=1").fetchone()[0] == 200.0
+
+    update_ventas_total_count = {"n": 0}
+    def _trace(sql):
+        normalized = " ".join(sql.upper().split())
+        if normalized.startswith("UPDATE VENTAS SET TOTAL"):
+            update_ventas_total_count["n"] += 1
+    db.set_trace_callback(_trace)
+
+    svc = DeliveryService(db=db, repository=repo, whatsapp_service=DummyWA(), geocoding_service=DummyGeo())
+    svc._publish = lambda *_args, **_kwargs: None
+    svc.adjust_item_weight(1, 1, 2.05, "op")
+    db.set_trace_callback(None)
+
+    assert update_ventas_total_count["n"] == 1
+    row = db.execute("SELECT payload_json FROM delivery_outbox_events WHERE event_type='DELIVERY_TOTAL_UPDATED' AND aggregate_id=1").fetchone()
+    assert row is not None
+    assert '"new_total"' in row["payload_json"]
+
+
+def test_outbox_required_transaction_processing_retry_and_no_duplicate_processing():
+    db, _repo = _db()
+    outbox = DeliveryOutboxRepository(db)
+    first = outbox.enqueue(event_type="OK", aggregate_id=1, payload={"order_id": 1, "db": db}, operation_id="op:1", commit=True)
+    duplicate = outbox.enqueue(event_type="OK", aggregate_id=1, payload={"order_id": 1}, operation_id="op:1", commit=True)
+    fail_id = outbox.enqueue(event_type="FAIL", aggregate_id=1, payload={"order_id": 1}, operation_id="op:fail", commit=True)
+    handled = []
+
+    assert first == duplicate
+    assert outbox.payload_for(first) == {"order_id": 1}
+
+    result = ProcessDeliveryOutboxUseCase(
+        outbox_repository=outbox,
+        handlers={
+            "OK": lambda payload: handled.append(payload["order_id"]),
+            "FAIL": lambda _payload: (_ for _ in ()).throw(RuntimeError("boom")),
+        },
+    ).execute(limit=10)
+    second = ProcessDeliveryOutboxUseCase(
+        outbox_repository=outbox,
+        handlers={
+            "OK": lambda payload: handled.append(payload["order_id"]),
+            "FAIL": lambda _payload: (_ for _ in ()).throw(RuntimeError("boom")),
+        },
+    ).execute(limit=10)
+
+    ok = db.execute("SELECT status FROM delivery_outbox_events WHERE id=?", (first,)).fetchone()[0]
+    fail = db.execute("SELECT status, retries, last_error FROM delivery_outbox_events WHERE id=?", (fail_id,)).fetchone()
+    assert result == {"processed": 1, "failed": 1}
+    assert second == {"processed": 0, "failed": 1}
+    assert handled == [1]
+    assert ok == "done"
+    assert fail["status"] == "pending"
+    assert fail["retries"] == 2
+    assert "boom" in fail["last_error"]
+
+
+def test_delivery_service_legacy_compatibility_required_api_surface():
+    db, repo = _db()
+    svc = DeliveryService(db=db, repository=repo, whatsapp_service=DummyWA(), geocoding_service=DummyGeo())
+    for name in ("create_order", "update_status", "adjust_item_weight", "list_orders"):
+        assert callable(getattr(svc, name))

--- a/pos_spj_v13.4/tests/test_delivery_sale_projection.py
+++ b/pos_spj_v13.4/tests/test_delivery_sale_projection.py
@@ -1,0 +1,153 @@
+import os
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "..", "whatsapp_service"))
+
+from core.delivery.projections.sale_delivery_projection import SaleDeliveryProjectionService
+from core.services.delivery_service import DeliveryService
+from core.services.order_total_service import OrderTotalService
+from repositories.delivery_repository import DeliveryRepository
+
+
+class DummyGeo:
+    def geocode(self, _address):
+        return None
+
+    def autocomplete(self, _query):
+        return []
+
+
+class DummyWA:
+    def notify_status(self, **_kwargs):
+        return True
+
+    def sync_status(self, *_args, **_kwargs):
+        return True
+
+    def pull_orders(self):
+        return []
+
+
+def _db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    DeliveryRepository(db)
+    db.execute("CREATE TABLE ventas(id INTEGER PRIMARY KEY, estado TEXT, total REAL, workflow_type TEXT)")
+    db.execute("INSERT INTO ventas(id, estado, total, workflow_type) VALUES (1, 'pendiente', 100, NULL)")
+    db.execute(
+        """
+        INSERT INTO delivery_orders(id, venta_id, folio, direccion, estado, total, delivery_type)
+        VALUES (1, 1, 'DEL-1', 'Calle 1', 'pendiente', 100, 'domicilio')
+        """
+    )
+    db.execute(
+        """
+        INSERT INTO delivery_items(delivery_id, nombre, cantidad, precio_unitario, subtotal)
+        VALUES (1, 'Pollo', 2, 60, 120)
+        """
+    )
+    db.commit()
+    return db
+
+
+def test_projection_maps_delivery_status_to_sale_status():
+    db = _db()
+    projection = SaleDeliveryProjectionService(db)
+
+    assert projection.project_status(1, "preparacion") is True
+
+    row = db.execute("SELECT estado FROM ventas WHERE id=1").fetchone()
+    assert row["estado"] == "en_preparacion"
+
+
+def test_repository_update_status_does_not_update_ventas_directly():
+    db = _db()
+    repo = DeliveryRepository(db)
+
+    repo.update_status(1, "en_ruta", usuario="tester")
+
+    venta = db.execute("SELECT estado FROM ventas WHERE id=1").fetchone()
+    delivery = db.execute("SELECT estado FROM delivery_orders WHERE id=1").fetchone()
+    assert delivery["estado"] == "en_ruta"
+    assert venta["estado"] == "pendiente"
+
+
+def test_delivery_service_update_status_projects_to_ventas_once():
+    db = _db()
+    svc = DeliveryService(db=db, whatsapp_service=DummyWA(), geocoding_service=DummyGeo())
+    svc._publish = lambda *_args, **_kwargs: None
+
+    svc.update_status(1, "preparacion", usuario="tester")
+
+    venta = db.execute("SELECT estado FROM ventas WHERE id=1").fetchone()
+    assert venta["estado"] == "en_preparacion"
+
+
+def test_order_total_service_only_updates_delivery_total():
+    db = _db()
+
+    total = OrderTotalService(db).recalculate_order_total(1)
+
+    delivery = db.execute("SELECT total FROM delivery_orders WHERE id=1").fetchone()
+    venta = db.execute("SELECT total FROM ventas WHERE id=1").fetchone()
+    assert total == 120.0
+    assert delivery["total"] == 120.0
+    assert venta["total"] == 100.0
+
+
+def test_delivery_service_sync_venta_total_uses_projection():
+    db = _db()
+    svc = DeliveryService(db=db, whatsapp_service=DummyWA(), geocoding_service=DummyGeo())
+
+    svc._sync_venta_total(1, 130.0)
+
+    venta = db.execute("SELECT total FROM ventas WHERE id=1").fetchone()
+    assert venta["total"] == 130.0
+
+
+def test_scheduled_activation_projects_workflow_and_sale_status():
+    db = _db()
+    db.execute("UPDATE delivery_orders SET estado='programado', delivery_type='pickup' WHERE id=1")
+    db.commit()
+    svc = DeliveryService(db=db, whatsapp_service=DummyWA(), geocoding_service=DummyGeo())
+    svc._publish = lambda *_args, **_kwargs: None
+
+    out = svc.activate_scheduled_order(1, usuario="tester")
+
+    venta = db.execute("SELECT estado, workflow_type FROM ventas WHERE id=1").fetchone()
+    assert out["workflow_type"] == "counter"
+    assert venta["estado"] == "pendiente"
+    assert venta["workflow_type"] == "counter"
+
+
+def test_projection_is_safe_when_ventas_columns_are_absent():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute("CREATE TABLE ventas(id INTEGER PRIMARY KEY)")
+
+    projection = SaleDeliveryProjectionService(db)
+
+    assert projection.project_status(1, "entregado") is False
+    assert projection.project_total(1, 99.0) is False
+
+
+def test_adjustment_approval_projects_accepted_total_to_sale():
+    from erp.adjustment_approval import AdjustmentApprovalService
+
+    db = _db()
+    db.execute(
+        """
+        UPDATE delivery_items
+        SET adjustment_status='pending_customer', pending_prepared_qty=2.5, pending_subtotal=150
+        WHERE delivery_id=1
+        """
+    )
+    db.execute("UPDATE delivery_orders SET cliente_tel='5512345678', adjustment_pending=1 WHERE id=1")
+    db.commit()
+
+    out = AdjustmentApprovalService(db).respond_latest_for_phone("5512345678", accepted=True)
+
+    venta = db.execute("SELECT total FROM ventas WHERE id=1").fetchone()
+    assert out["total"] == 150.0
+    assert venta["total"] == 150.0

--- a/pos_spj_v13.4/tests/test_delivery_schema_migrator.py
+++ b/pos_spj_v13.4/tests/test_delivery_schema_migrator.py
@@ -1,0 +1,89 @@
+import sqlite3
+
+from core.delivery.infrastructure.delivery_schema_migrator import DeliverySchemaMigrator
+from core.services.delivery_service import DeliveryService
+from repositories.delivery_repository import DeliveryRepository
+
+
+class DummyWA:
+    def notify_status(self, **_kwargs):
+        return True
+
+    def sync_status(self, *_args, **_kwargs):
+        return True
+
+    def pull_orders(self):
+        return []
+
+
+class DummyGeo:
+    def geocode(self, _address):
+        return None
+
+    def autocomplete(self, _query):
+        return []
+
+
+def _columns(conn, table):
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _indexes(conn, table):
+    return {row[1] for row in conn.execute(f"PRAGMA index_list({table})").fetchall()}
+
+
+def test_migrator_creates_delivery_schema_and_indexes_idempotently():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    migrator = DeliverySchemaMigrator(conn)
+
+    migrator.ensure_schema()
+    migrator.ensure_schema()
+
+    assert "workflow_type" in _columns(conn, "delivery_orders")
+    assert "adjustment_pending" in _columns(conn, "delivery_orders")
+    assert "pending_prepared_qty" in _columns(conn, "delivery_items")
+    assert "metadata_json" in _columns(conn, "delivery_order_history")
+    assert "usuario_id" in _columns(conn, "drivers")
+    assert "idx_delivery_items_adjustment_status" in _indexes(conn, "delivery_items")
+    assert "idx_delivery_workflow_status" in _indexes(conn, "delivery_orders")
+    assert "idx_delivery_history_order_created" in _indexes(conn, "delivery_order_history")
+
+
+def test_migrator_backfills_existing_minimal_tables_without_dropping_data():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE delivery_orders (id INTEGER PRIMARY KEY, direccion TEXT NOT NULL, estado TEXT)")
+    conn.execute("CREATE TABLE delivery_items (id INTEGER PRIMARY KEY, delivery_id INTEGER NOT NULL, nombre TEXT NOT NULL)")
+    conn.execute("CREATE TABLE delivery_order_history (id INTEGER PRIMARY KEY, order_id INTEGER NOT NULL)")
+    conn.execute("INSERT INTO delivery_orders(id, direccion, estado) VALUES (1, 'Calle 1', 'pendiente')")
+    conn.commit()
+
+    DeliverySchemaMigrator(conn).ensure_schema()
+
+    row = conn.execute("SELECT direccion, estado FROM delivery_orders WHERE id=1").fetchone()
+    assert dict(row) == {"direccion": "Calle 1", "estado": "pendiente"}
+    assert "fecha" in _columns(conn, "delivery_orders")
+    assert "source_channel" in _columns(conn, "delivery_orders")
+    assert "tolerance_units" in _columns(conn, "delivery_items")
+    assert "created_at" in _columns(conn, "delivery_order_history")
+
+
+def test_repository_ensure_schema_delegates_to_migrator_contract():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    DeliveryRepository(conn)
+
+    assert "adjustment_blocked_state" in _columns(conn, "delivery_orders")
+    assert "adjustment_token" in _columns(conn, "delivery_items")
+
+
+def test_delivery_service_adjustment_schema_shim_uses_migrator():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    DeliveryService(db=conn, whatsapp_service=DummyWA(), geocoding_service=DummyGeo())
+
+    assert "pending_subtotal" in _columns(conn, "delivery_items")
+    assert "idx_delivery_items_adjustment_token" in _indexes(conn, "delivery_items")

--- a/pos_spj_v13.4/tests/test_delivery_service_compat_phase10.py
+++ b/pos_spj_v13.4/tests/test_delivery_service_compat_phase10.py
@@ -1,0 +1,132 @@
+import sqlite3
+
+from core.delivery.domain.events import DeliveryEvents
+from core.services.delivery_service import DeliveryService, LEGACY_COMPATIBILITY_METHODS
+from repositories.delivery_repository import DeliveryRepository
+
+
+class DummyGeo:
+    def geocode(self, _address):
+        return None
+
+    def autocomplete(self, _query):
+        return []
+
+
+class DummyWA:
+    def __init__(self):
+        self.notifications = []
+        self.synced = []
+
+    def notify_status(self, **kwargs):
+        self.notifications.append(kwargs)
+        return True
+
+    def sync_status(self, whatsapp_order_id, status):
+        self.synced.append((whatsapp_order_id, status))
+        return True
+
+    def pull_orders(self):
+        return []
+
+
+def _db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    repo = DeliveryRepository(db)
+    db.execute("CREATE TABLE ventas(id INTEGER PRIMARY KEY, estado TEXT, total REAL)")
+    return db, repo
+
+
+def _service():
+    db, repo = _db()
+    svc = DeliveryService(db=db, repository=repo, whatsapp_service=DummyWA(), geocoding_service=DummyGeo())
+    svc._publish = lambda *_args, **_kwargs: None
+    return db, svc
+
+
+def test_delivery_service_exposes_legacy_compatibility_surface():
+    _db_conn, svc = _service()
+
+    for name in (
+        "create_order",
+        "create_delivery_order",
+        "update_status",
+        "update_order_status",
+        "adjust_item_weight",
+        "adjust_weight",
+        "cancel_order",
+        "cancel_delivery_order",
+        "list_orders",
+        "get_order",
+        "get_order_items",
+        "pull_orders_from_whatsapp",
+        "sync_pending_sales_to_delivery_orders",
+    ):
+        assert callable(getattr(svc, name))
+
+    assert {
+        "_ensure_adjustment_columns",
+        "_sync_venta_total",
+        "_notify_adjustment_pending",
+        "_validate_workflow_transition",
+        "_release_stock",
+        "sync_pending_sales_to_delivery_orders",
+    } <= LEGACY_COMPATIBILITY_METHODS
+
+
+def test_legacy_aliases_delegate_to_facade_flows_and_record_history():
+    db, svc = _service()
+
+    order_id = svc.create_delivery_order({"direccion": "Calle 10", "cliente_tel": "55"}, usuario="tester")
+    assert svc.get_order(order_id)["estado"] == "pendiente"
+
+    svc.update_order_status(order_id, "preparacion", usuario="tester", observacion="compat alias")
+    db.execute(
+        "INSERT INTO delivery_items(delivery_id, nombre, cantidad, precio_unitario, subtotal) VALUES (?, 'Pollo', 1, 100, 100)",
+        (order_id,),
+    )
+    db.commit()
+    assert svc.adjust_weight(order_id, 1, 1.1, "op")["applied"] is True
+
+    row = db.execute(
+        "SELECT reason, observacion FROM delivery_order_history WHERE order_id=? AND estado_nuevo='preparacion' ORDER BY id DESC LIMIT 1",
+        (order_id,),
+    ).fetchone()
+    assert row["reason"] == "delivery_status_preparacion"
+    assert row["observacion"] == "compat alias"
+
+
+def test_legacy_notification_and_release_shims_prefer_outbox_without_db_payload():
+    db, svc = _service()
+    order_id = svc.create_order({"direccion": "Calle 20", "cliente_tel": "5512345678"}, usuario="tester")
+    order = svc.get_order(order_id)
+    svc.whatsapp_service.notifications.clear()
+
+    svc._safe_wa_notify(order, "preparacion")
+    svc._release_stock(order_id)
+
+    assert svc.whatsapp_service.notifications == []
+    rows = db.execute(
+        "SELECT event_type, payload_json FROM delivery_outbox_events WHERE aggregate_id=? ORDER BY id",
+        (order_id,),
+    ).fetchall()
+    event_types = {row["event_type"] for row in rows}
+    assert DeliveryEvents.CUSTOMER_NOTIFICATION_REQUESTED.value in event_types
+    assert DeliveryEvents.INVENTORY_RELEASE_REQUIRED.value in event_types
+    assert all('"db"' not in row["payload_json"] for row in rows)
+
+
+def test_cancel_delivery_order_alias_preserves_motivo_in_audit_history():
+    db, svc = _service()
+    order_id = svc.create_order({"direccion": "Calle 30", "cliente_tel": "55"}, usuario="tester")
+
+    result = svc.cancel_delivery_order(order_id, usuario="tester", motivo="cliente pidió cancelar")
+
+    assert result["status"] == "cancelado"
+    row = db.execute(
+        "SELECT reason, observacion FROM delivery_order_history WHERE order_id=? ORDER BY id DESC LIMIT 1",
+        (order_id,),
+    ).fetchone()
+    assert row["reason"] == "delivery_status_cancelado"
+    assert row["observacion"] == "cliente pidió cancelar"

--- a/pos_spj_v13.4/tests/test_delivery_state_machine.py
+++ b/pos_spj_v13.4/tests/test_delivery_state_machine.py
@@ -1,0 +1,93 @@
+import pytest
+
+from core.delivery.domain.entities import DeliveryItem, DeliveryOrder
+from core.delivery.domain.state_machine import DeliveryStateMachine
+from core.delivery.domain.states import DeliveryStatus, DeliveryWorkflowType
+
+
+sm = DeliveryStateMachine()
+
+
+def test_normalize_legacy_statuses():
+    assert sm.normalize_status("asignado") == DeliveryStatus.PREPARACION
+    assert sm.normalize_status("pendiente_wa") == DeliveryStatus.PENDIENTE
+    assert sm.normalize_status("entregada") == DeliveryStatus.ENTREGADO
+
+
+def test_unknown_status_is_rejected_in_domain():
+    with pytest.raises(ValueError, match="desconocido"):
+        sm.normalize_status("inventado")
+
+
+def test_infer_workflow_from_delivery_type_and_programado():
+    assert sm.infer_workflow({"estado": "programado"}) == DeliveryWorkflowType.SCHEDULED
+    assert sm.infer_workflow({"estado": "pendiente", "delivery_type": "pickup"}) == DeliveryWorkflowType.COUNTER
+    assert sm.infer_workflow({"estado": "pendiente", "delivery_type": "domicilio"}) == DeliveryWorkflowType.DELIVERY
+
+
+def test_pendiente_to_preparacion_allowed():
+    sm.assert_can_transition({"estado": "pendiente", "workflow_type": "delivery"}, "preparacion")
+
+
+def test_delivery_preparacion_to_en_ruta_allowed():
+    sm.assert_can_transition({"estado": "preparacion", "workflow_type": "delivery"}, "en_ruta")
+
+
+def test_delivery_preparacion_to_entregado_forbidden_even_with_responsable():
+    with pytest.raises(ValueError, match="en_ruta"):
+        sm.assert_can_transition(
+            {"estado": "preparacion", "workflow_type": "delivery", "responsable_entrega": "r1"},
+            "entregado",
+        )
+
+
+def test_counter_preparacion_to_entregado_allowed_with_responsable():
+    sm.assert_can_transition(
+        {"estado": "preparacion", "workflow_type": "counter", "responsable_entrega": "caja"},
+        "entregado",
+    )
+
+
+def test_counter_to_en_ruta_forbidden():
+    with pytest.raises(ValueError, match="mostrador"):
+        sm.assert_can_transition({"estado": "preparacion", "workflow_type": "counter"}, "en_ruta")
+
+
+def test_scheduled_cannot_prepare_without_activation():
+    with pytest.raises(ValueError, match="programado"):
+        sm.assert_can_transition({"estado": "programado", "workflow_type": "scheduled"}, "preparacion")
+
+
+def test_delivered_requires_responsable():
+    with pytest.raises(ValueError, match="responsable"):
+        sm.assert_can_transition({"estado": "en_ruta", "workflow_type": "delivery"}, "entregado")
+
+
+def test_pending_adjustment_blocks_route_and_delivery_from_order_items():
+    order = DeliveryOrder(
+        estado=DeliveryStatus.PREPARACION,
+        workflow_type=DeliveryWorkflowType.DELIVERY,
+        items=[DeliveryItem(adjustment_status="pending_customer")],
+    )
+    with pytest.raises(ValueError, match="ajuste"):
+        sm.assert_can_transition(order, "en_ruta")
+
+
+def test_cancelled_reactivation_can_be_disabled():
+    locked_sm = DeliveryStateMachine(allow_cancelled_reactivation=False)
+    with pytest.raises(ValueError, match="cancelado"):
+        locked_sm.assert_can_transition({"estado": "cancelado"}, "pendiente")
+
+
+def test_delivered_cannot_go_back():
+    with pytest.raises(ValueError, match="reverso"):
+        sm.assert_can_transition({"estado": "entregado", "workflow_type": "delivery"}, "pendiente")
+
+
+def test_valid_actions_are_domain_keys_not_ui_labels():
+    assert sm.get_valid_actions({"estado": "programado"}) == ["activar_programado", "reprogramar", "cancelado"]
+    assert sm.get_valid_actions({"estado": "preparacion", "workflow_type": "counter"}) == [
+        "ajustar_peso",
+        "entregado",
+        "cancelado",
+    ]

--- a/pos_spj_v13.4/tests/test_delivery_ui_phase13.py
+++ b/pos_spj_v13.4/tests/test_delivery_ui_phase13.py
@@ -1,0 +1,98 @@
+import sqlite3
+
+from core.delivery.infrastructure.delivery_schema_migrator import DeliverySchemaMigrator
+from core.services import delivery_service as delivery_service_module
+from core.services.delivery_service import DeliveryService
+from integrations.delivery_pwa import pwa_server
+
+
+class _DummyRepo:
+    pass
+
+
+def test_delivery_service_ui_actions_are_backed_by_state_machine(monkeypatch):
+    calls = []
+
+    class FakeStateMachine:
+        def get_valid_actions(self, order_context):
+            calls.append(order_context)
+            return ["en_ruta", "cancelado"]
+
+    monkeypatch.setattr(delivery_service_module, "DeliveryStateMachine", FakeStateMachine)
+
+    svc = DeliveryService(db=None, repository=_DummyRepo(), whatsapp_service=None, geocoding_service=None)
+    actions = svc.get_valid_actions(
+        status="preparacion",
+        workflow_type="delivery",
+        adjustment_pending=True,
+        scheduled_at="2026-06-03 10:00:00",
+        delivery_type="home_delivery",
+    )
+
+    assert calls == [{
+        "estado": "preparacion",
+        "workflow_type": "delivery",
+        "delivery_type": "home_delivery",
+        "scheduled_at": "2026-06-03 10:00:00",
+        "adjustment_pending": True,
+    }]
+    assert [action["key"] for action in actions] == ["en_ruta", "cancelado"]
+    assert actions[0]["label"] == "Enviar a ruta"
+
+
+def test_pwa_get_pedidos_returns_backend_actions(monkeypatch):
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    DeliverySchemaMigrator(db).ensure_schema()
+    db.execute("CREATE TABLE clientes(id INTEGER PRIMARY KEY, nombre TEXT, telefono TEXT)")
+    db.execute("INSERT INTO clientes(id, nombre, telefono) VALUES (1, 'Cliente PWA', '555')")
+    db.execute(
+        """
+        INSERT INTO delivery_orders(
+            id, cliente_id, estado, direccion, total, fecha,
+            workflow_type, delivery_type, adjustment_pending, driver_id
+        ) VALUES (1, 1, 'preparacion', 'Calle PWA', 150, '2026-06-02 10:00:00',
+                  'delivery', 'home_delivery', 0, 7)
+        """
+    )
+    db.commit()
+    monkeypatch.setattr(pwa_server, "get_connection", lambda: db)
+
+    handler = object.__new__(pwa_server.DeliveryAPIHandler)
+    pedidos = handler._get_pedidos("7")
+
+    assert len(pedidos) == 1
+    assert pedidos[0]["id"] == 1
+    assert "actions" in pedidos[0]
+    assert "en_ruta" in {action["key"] for action in pedidos[0]["actions"]}
+
+
+def test_pwa_update_status_uses_delivery_service_boundary(monkeypatch):
+    calls = []
+
+    class FakeService:
+        def __init__(self, conn):
+            self.conn = conn
+
+        def update_status(self, order_id, status, usuario, responsable="", observacion=""):
+            calls.append({
+                "order_id": order_id,
+                "status": status,
+                "usuario": usuario,
+                "responsable": responsable,
+                "observacion": observacion,
+            })
+
+    monkeypatch.setattr(pwa_server, "get_connection", lambda: object())
+    monkeypatch.setattr(pwa_server, "DeliveryService", FakeService)
+
+    handler = object.__new__(pwa_server.DeliveryAPIHandler)
+    assert handler._actualizar_estado({"id": "9", "estado": "entregado", "responsable": "driver-7"}) is True
+
+    assert calls == [{
+        "order_id": 9,
+        "status": "entregado",
+        "usuario": "pwa_delivery",
+        "responsable": "driver-7",
+        "observacion": "",
+    }]

--- a/pos_spj_v13.4/tests/test_delivery_weight_policy.py
+++ b/pos_spj_v13.4/tests/test_delivery_weight_policy.py
@@ -1,0 +1,40 @@
+import pytest
+
+from core.delivery.domain.policies import DeliveryTotalPolicy, DeliveryWorkflowPolicy, WeightAdjustmentPolicy
+from core.delivery.domain.states import AdjustmentStatus
+
+
+def test_weight_adjustment_within_tolerance_auto_accepts():
+    decision = WeightAdjustmentPolicy(tolerance_units=0.2).evaluate(2.0, 2.15, 100)
+    assert decision.apply_immediately is True
+    assert decision.status == AdjustmentStatus.AUTO_ACCEPTED
+    assert decision.new_subtotal == 215.0
+    assert decision.diff_pct == 7.5
+
+
+def test_weight_adjustment_outside_tolerance_requires_customer():
+    decision = WeightAdjustmentPolicy(tolerance_units=0.2).evaluate(2.0, 2.25, 100)
+    assert decision.apply_immediately is False
+    assert decision.status == AdjustmentStatus.PENDING_CUSTOMER
+    assert decision.tolerance_exceeded is True
+
+
+def test_weight_adjustment_zero_requested_does_not_block_on_tolerance():
+    decision = WeightAdjustmentPolicy(tolerance_units=0.2).evaluate(0, 0.5, 100)
+    assert decision.tolerance_exceeded is False
+    assert decision.diff_pct == 0.0
+    assert decision.new_subtotal == 50.0
+
+
+def test_weight_adjustment_rejects_negative_values():
+    with pytest.raises(ValueError, match="preparada"):
+        WeightAdjustmentPolicy().evaluate(1, -1, 10)
+
+
+def test_total_policy_rounds_money():
+    assert DeliveryTotalPolicy.calculate_total([10.005, 1.005]) == 11.01
+
+
+def test_workflow_policy_requires_driver_only_for_delivery():
+    assert DeliveryWorkflowPolicy.requires_driver("delivery") is True
+    assert DeliveryWorkflowPolicy.requires_driver("pickup") is False

--- a/pos_spj_v13.4/tests/test_delivery_whatsapp_notifier.py
+++ b/pos_spj_v13.4/tests/test_delivery_whatsapp_notifier.py
@@ -1,0 +1,188 @@
+import os
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.delivery.application.adjust_delivery_weight import AdjustDeliveryWeightUseCase
+from core.delivery.application.change_delivery_status import ChangeDeliveryStatusUseCase
+from core.delivery.application.create_delivery_order import CreateDeliveryOrderUseCase
+from core.delivery.infrastructure.delivery_outbox_repository import DeliveryOutboxRepository
+from core.delivery.infrastructure.whatsapp_delivery_notifier import WhatsAppDeliveryNotifier
+from core.events.handlers.delivery_handler import DeliveryNotificationDispatchHandler
+from notifications.base import NotificationPayload
+from notifications.whatsapp_channel import WhatsAppNotificationChannel
+from repositories.delivery_repository import DeliveryRepository
+
+
+class DummyClient:
+    def __init__(self):
+        self.sent = []
+
+    def enviar_mensaje(self, phone, message):
+        self.sent.append((phone, message))
+        return True
+
+
+class DummyGeo:
+    def geocode(self, _address):
+        return None
+
+
+class DummyWA:
+    def __init__(self):
+        self.status = []
+
+    def notify_status(self, **kwargs):
+        self.status.append(kwargs)
+        return True
+
+    def sync_status(self, *_args, **_kwargs):
+        return True
+
+
+def _db():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    repo = DeliveryRepository(db)
+    db.execute("CREATE TABLE ventas(id INTEGER PRIMARY KEY, estado TEXT, total REAL)")
+    return db, repo
+
+
+def _seed_preparing_order(db):
+    db.execute("INSERT INTO ventas(id, estado, total) VALUES (1, 'en_preparacion', 200)")
+    db.execute(
+        """
+        INSERT INTO delivery_orders(id, venta_id, folio, whatsapp_order_id, cliente_tel, direccion, estado, total, workflow_type)
+        VALUES (1, 1, 'DEL-1', 'wa-1', '5512345678', 'Calle 1', 'preparacion', 200, 'delivery')
+        """
+    )
+    db.execute(
+        """
+        INSERT INTO delivery_items(id, delivery_id, nombre, producto_id, cantidad, precio_unitario, subtotal, final_qty)
+        VALUES (1, 1, 'Pollo', 10, 2, 100, 200, 2)
+        """
+    )
+    db.commit()
+
+
+def test_whatsapp_notifier_templates_status_adjustment_and_event_payloads():
+    client = DummyClient()
+    notifier = WhatsAppDeliveryNotifier(client)
+
+    assert notifier.notify_status(phone="5512345678", folio="DEL-1", status="en_ruta") is True
+    assert "va en ruta" in client.sent[-1][1]
+
+    assert notifier.notify_adjustment_required(
+        phone="5512345678",
+        folio="DEL-1",
+        item_name="Pollo",
+        requested_qty=2,
+        prepared_qty=2.3,
+        unit="kg",
+        new_subtotal=230,
+    ) is True
+    assert "ACEPTAR AJUSTE" in client.sent[-1][1]
+
+    assert notifier.notify_from_event({
+        "template": "entregado",
+        "cliente_tel": "5512345678",
+        "params": {"folio": "DEL-1"},
+    }) is True
+    assert "entregado" in client.sent[-1][1]
+
+
+def test_notification_dispatch_handler_routes_whatsapp_to_delivery_notifier():
+    calls = []
+
+    class MockNotifier:
+        def notify_from_event(self, payload):
+            calls.append(payload)
+            return True
+
+    handler = DeliveryNotificationDispatchHandler(whatsapp_notifier=MockNotifier())
+    handler.handle({"canal": "whatsapp", "template": "en_ruta", "cliente_tel": "55", "params": {"folio": "DEL-1"}})
+
+    assert calls[0]["template"] == "en_ruta"
+
+
+def test_whatsapp_channel_prefers_notify_from_event_payloads():
+    calls = []
+
+    class MockWA:
+        def notify_from_event(self, payload):
+            calls.append(payload)
+            return True
+
+    channel = WhatsAppNotificationChannel(wa_service=MockWA())
+    ok = channel.send(NotificationPayload(
+        event_type="adjustment_required",
+        title="Ajuste",
+        body="body",
+        channel="whatsapp",
+        order_id=1,
+        folio="DEL-1",
+        cliente_tel="5512345678",
+        metadata={"requested_qty": 2, "prepared_qty": 2.4},
+    ))
+
+    assert ok is True
+    assert calls[0]["template"] == "adjustment_required"
+    assert calls[0]["params"]["prepared_qty"] == 2.4
+
+
+def test_create_and_status_use_cases_only_enqueue_customer_notification_when_outbox_exists():
+    db, repo = _db()
+    outbox = DeliveryOutboxRepository(db)
+    wa = DummyWA()
+
+    order_id = CreateDeliveryOrderUseCase(
+        db=db,
+        repository=repo,
+        geocoding_service=DummyGeo(),
+        whatsapp_service=wa,
+        outbox_repository=outbox,
+    ).execute({"direccion": "Calle 1", "cliente_tel": "5512345678"})
+
+    assert wa.status == []
+    assert db.execute("SELECT COUNT(*) FROM delivery_outbox_events WHERE event_type='CUSTOMER_NOTIFICATION_REQUESTED'").fetchone()[0] == 1
+
+    db.execute("UPDATE delivery_orders SET estado='en_ruta' WHERE id=?", (order_id,))
+    db.commit()
+    ChangeDeliveryStatusUseCase(
+        db=db,
+        repository=repo,
+        whatsapp_service=wa,
+        outbox_repository=outbox,
+    ).execute(order_id, "entregado", usuario="tester", responsable="r1")
+
+    assert len(wa.status) == 0
+    templates = [
+        row[0]
+        for row in db.execute("SELECT json_extract(payload_json, '$.template') FROM delivery_outbox_events WHERE event_type='CUSTOMER_NOTIFICATION_REQUESTED'")
+    ]
+    assert "pedido_recibido" in templates
+    assert "entregado" in templates
+
+
+def test_adjustment_pending_enqueues_notification_instead_of_direct_whatsapp_when_outbox_exists():
+    db, repo = _db()
+    _seed_preparing_order(db)
+    outbox = DeliveryOutboxRepository(db)
+    direct_notifications = []
+
+    out = AdjustDeliveryWeightUseCase(
+        db=db,
+        repository=repo,
+        outbox_repository=outbox,
+        notify_adjustment_pending=lambda *args: direct_notifications.append(args) or True,
+        recalculate_order_total=lambda _order_id: 200,
+    ).execute(1, 1, 2.25, "op")
+
+    assert out["applied"] is False
+    assert direct_notifications == []
+    templates = [
+        row[0]
+        for row in db.execute("SELECT json_extract(payload_json, '$.template') FROM delivery_outbox_events WHERE event_type='CUSTOMER_NOTIFICATION_REQUESTED'")
+    ]
+    assert templates == ["adjustment_required"]

--- a/pos_spj_v13.4/tests/test_order_totals_phase8.py
+++ b/pos_spj_v13.4/tests/test_order_totals_phase8.py
@@ -171,3 +171,58 @@ def test_adjustment_approval_service_recalculates_exactly_once():
         assert calls["n"] == 1
     finally:
         OrderTotalService.recalculate_order_total = original
+
+
+def test_order_total_service_is_delivery_only_until_sale_projection_runs():
+    db = _db(); _seed_order(db, "preparacion")
+    db.execute(
+        "INSERT INTO delivery_items(id, delivery_id, nombre, cantidad, precio_unitario, subtotal, unidad) "
+        "VALUES (2,1,'Salsa',1,15,15,'pz')"
+    )
+    db.commit()
+
+    total = OrderTotalService(db).recalculate_order_total(1)
+    assert total == 215.0
+    assert float(db.execute("SELECT total FROM delivery_orders WHERE id=1").fetchone()[0]) == 215.0
+    assert float(db.execute("SELECT total FROM ventas WHERE id=1").fetchone()[0]) == 200.0
+
+    from core.delivery.projections.sale_delivery_projection import SaleDeliveryProjectionService
+    assert SaleDeliveryProjectionService(db).project_total(1, total) is True
+    assert float(db.execute("SELECT total FROM ventas WHERE id=1").fetchone()[0]) == 215.0
+
+
+def test_within_tolerance_registers_total_updated_outbox_event():
+    db = _db(); svc = _svc(db); _seed_order(db, "preparacion")
+
+    out = svc.adjust_item_weight(order_id=1, item_id=1, prepared_qty=2.1, prepared_by="op")
+
+    assert out["applied"] is True
+    row = db.execute(
+        "SELECT payload_json FROM delivery_outbox_events "
+        "WHERE aggregate_id=1 AND event_type='DELIVERY_TOTAL_UPDATED'"
+    ).fetchone()
+    assert row is not None
+    assert '"old_total": 200.0' in row["payload_json"]
+    assert '"new_total": 210.0' in row["payload_json"]
+
+
+def test_customer_response_records_total_updated_before_adjustment_event():
+    db = _db(); svc = _svc(db); _seed_order(db, "preparacion")
+    db.execute("""
+        CREATE TABLE wa_event_log(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, event_type TEXT, data_json TEXT,
+            sucursal_id INTEGER, prioridad INTEGER, timestamp TEXT
+        )
+    """)
+    db.commit()
+    svc.adjust_item_weight(order_id=1, item_id=1, prepared_qty=2.25, prepared_by="op")
+
+    out = AdjustmentApprovalService(db).respond_latest_for_phone("5512345678", accepted=True)
+
+    assert out["total"] == 225.0
+    events = [
+        row["event_type"]
+        for row in db.execute("SELECT event_type FROM wa_event_log ORDER BY id").fetchall()
+    ]
+    assert "DELIVERY_TOTAL_UPDATED" in events
+    assert events[-1] == "DELIVERY_ADJUSTMENT_ACCEPTED"

--- a/whatsapp_service/erp/adjustment_approval.py
+++ b/whatsapp_service/erp/adjustment_approval.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import logging
 import sqlite3
 from typing import Dict
+from core.delivery.domain.events import DeliveryEvents
 from core.services.order_total_service import OrderTotalService
+from core.delivery.projections.sale_delivery_projection import SaleDeliveryProjectionService
 from phone_number import possible_match_key
 
 logger = logging.getLogger("wa.adjustment_approval")
@@ -102,8 +104,10 @@ class AdjustmentApprovalService:
             )
             action = "rejected"
 
-        # Recalcular total del pedido con fuente de verdad única.
+        # Recalcular total del pedido desde delivery_items; ventas se actualiza solo vía proyección controlada.
+        old_total = round(float(data.get("order_total") or 0), 2)
         new_total = OrderTotalService(self.db).recalculate_order_total(order_id)
+        SaleDeliveryProjectionService(self.db).project_total(venta_id, new_total)
         pending_left = self.db.execute(
             "SELECT 1 FROM delivery_items WHERE delivery_id=? AND adjustment_status='pending_customer' LIMIT 1",
             (order_id,),
@@ -121,14 +125,24 @@ class AdjustmentApprovalService:
                 """
                 INSERT INTO wa_event_log(event_type, data_json, sucursal_id, prioridad, timestamp)
                 SELECT ?,
+                       json_object('order_id', ?, 'old_total', ?, 'new_total', ?, 'folio', ?, 'cliente_tel', COALESCE(cliente_tel,'')),
+                       COALESCE(sucursal_id,1), 35, datetime('now')
+                FROM delivery_orders WHERE id=?
+                """,
+                (DeliveryEvents.TOTAL_UPDATED.value, order_id, old_total, new_total, folio, order_id),
+            )
+            self.db.execute(
+                """
+                INSERT INTO wa_event_log(event_type, data_json, sucursal_id, prioridad, timestamp)
+                SELECT ?,
                        json_object('order_id', ?, 'item_id', ?, 'folio', ?, 'response', ?, 'total', ?),
                        COALESCE(sucursal_id,1), 40, datetime('now')
                 FROM delivery_orders WHERE id=?
                 """,
                 (event_type, order_id, item_id, folio, action, new_total, order_id),
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("No se pudo registrar evento de ajuste delivery order=%s item=%s: %s", order_id, item_id, exc)
 
         self.db.commit()
         return {

--- a/whatsapp_service/router/delivery_router.py
+++ b/whatsapp_service/router/delivery_router.py
@@ -21,6 +21,8 @@ from typing import Optional
 from fastapi import APIRouter, Query, Header, HTTPException
 from pydantic import BaseModel
 
+from core.delivery.projections.sale_delivery_projection import SaleDeliveryProjectionService
+
 logger = logging.getLogger("wa.delivery")
 router = APIRouter(prefix="/api/delivery", tags=["delivery"])
 
@@ -222,7 +224,10 @@ async def sync_order_status(req: DeliveryStatusRequest,
         if "estado" not in cols:
             return {"ok": False, "error": "ventas.estado not found"}
 
-        conn.execute("UPDATE ventas SET estado=? WHERE id=?", (status_venta, venta_id))
+        projected = SaleDeliveryProjectionService(conn).project_status(venta_id, req.status)
+        if not projected:
+            return {"ok": False, "error": "delivery sale status projection failed"}
+        status_venta = _map_status_to_venta(req.status)
         try:
             conn.execute("""
                 INSERT INTO wa_event_log(event_type, data_json, sucursal_id, prioridad, timestamp)


### PR DESCRIPTION
### Motivation

- Consolidate delivery business rules into a proper bounded context so domain and application layers own workflow, totals and adjustments instead of UI/legacy shims.
- Ensure reliability for critical side effects by introducing a transactional outbox and identifying critical canonical events (avoid passing `db` in event payloads).
- Maintain runtime compatibility with existing consumers during migration via a temporary `LegacyDeliveryEventBridge` while documenting canonical/legacy mappings.

### Description

- Add a new `core/delivery` package with domain models (`states`, `entities`, `value_objects`), policies, state machine, canonical `DeliveryEvents`, and application use cases such as `CreateDeliveryOrderUseCase`, `ChangeDeliveryStatusUseCase`, `AdjustDeliveryWeightUseCase`, `ProcessDeliveryOutboxUseCase`, and others.
- Introduce transactional outbox support with `DeliverySchemaMigrator`, `DeliveryOutboxRepository`, `ProcessDeliveryOutboxUseCase`, and migration scripts (`migrations/093–095`), and make critical events idempotent via `operation_id` keys.
- Refactor `core/services/delivery_service.py` into a backward-compatible facade that delegates to application use cases and projections, adds UI action metadata, and prefers outbox notifications over direct `db`/WhatsApp calls.
- Add infrastructure adapters and projections: `WhatsAppDeliveryNotifier`, `ReservationServiceInventoryAdapter`, `DeliveryInventoryProjectionService`, `SaleDeliveryProjectionService`, and a one-way `LegacyDeliveryEventBridge` with wiring in `core/events/wiring.py`.
- Centralize delivery schema and index management in `DeliverySchemaMigrator` and update `repositories/delivery_repository.py` to delegate schema concerns; add `delivery_outbox_events` and history/audit enhancements.
- Update event bus constants and handlers to route canonical events, remove `db` from published payloads, and provide safe notification dispatching that prefers notifier adapters.
- Add documentation files `docs/EVENT_CATALOG.md`, `docs/architecture/DELIVERY_ARCHITECTURE.md`, and `docs/audits/DELIVERY_REFACTOR_AUDIT.md` describing conventions, events and migration plan.
- Add an extensive test suite under `pos_spj_v13.4/tests/` covering domain, use cases, outbox, inventory projection, legacy bridge, schema migrator and end-to-end behaviours.

### Testing

- Ran the new delivery unit/integration test suite including `tests/test_delivery_application_use_cases.py`, `tests/test_delivery_outbox.py`, `tests/test_delivery_inventory_projection.py`, `tests/test_delivery_state_machine.py`, and related tests under `pos_spj_v13.4/tests/`, and they passed locally.
- Exercised outbox idempotency and retry behaviour via `ProcessDeliveryOutboxUseCase` tests which verified `delivery_outbox_events` lifecycle and error retry recording.
- Verified migration and schema idempotency with `DeliverySchemaMigrator` tests that create/backfill minimal tables and assert indexes/columns are present and data is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bcfc36f0083288ed26cd8efa99d39)