### PR TITLE
Refactor Inventario: introduce QueryService and ApplicationService, migrate UI reads/writes

### DIFF
--- a/pos_spj_v13.4/backend/application/commands/inventory_commands.py
+++ b/pos_spj_v13.4/backend/application/commands/inventory_commands.py
@@ -1,0 +1,50 @@
+"""Inventory commands for the canonical application-service route."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from backend.application.commands.base_command import BaseCommand
+
+
+@dataclass(frozen=True)
+class RegisterInventoryEntryCommand(BaseCommand):
+    """Register an audited stock entry for one product and branch."""
+
+    product_id: int = 0
+    quantity: float = 0.0
+    unit_cost: float = 0.0
+    supplier_id: int | None = None
+    reference: str = ""
+    notes: str = ""
+
+    def validate_context(self) -> None:
+        super().validate_context()
+        if self.product_id <= 0:
+            raise ValueError("product_id is required")
+        if int(self.branch_id) <= 0:
+            raise ValueError("branch_id is required")
+        if self.quantity <= 0:
+            raise ValueError("quantity must be greater than zero")
+        if not self.user_name:
+            raise ValueError("user_name is required")
+
+
+@dataclass(frozen=True)
+class AdjustInventoryCommand(BaseCommand):
+    """Set audited physical-count stock for one product and branch."""
+
+    product_id: int = 0
+    new_quantity: float = 0.0
+    reason: str = "Ajuste manual"
+
+    def validate_context(self) -> None:
+        super().validate_context()
+        if self.product_id <= 0:
+            raise ValueError("product_id is required")
+        if int(self.branch_id) <= 0:
+            raise ValueError("branch_id is required")
+        if self.new_quantity < 0:
+            raise ValueError("new_quantity cannot be negative")
+        if not self.user_name:
+            raise ValueError("user_name is required")

--- a/pos_spj_v13.4/backend/application/queries/inventory_query_service.py
+++ b/pos_spj_v13.4/backend/application/queries/inventory_query_service.py
@@ -1,0 +1,140 @@
+"""Read-only QueryService for inventory desktop/API read models."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Sequence
+
+
+class InventoryQueryService:
+    """Inventory reads owned by the application layer, not PyQt widgets."""
+
+    def __init__(self, db) -> None:
+        self._db = db
+
+    def list_inventory_rows(self, *, branch_id: int) -> list[tuple[Any, ...]]:
+        try:
+            return list(self._db.execute(
+                "SELECT p.id, p.nombre, COALESCE(p.categoria,''), "
+                "COALESCE(bi.quantity, p.existencia, 0), "
+                "COALESCE(p.stock_minimo, 5), COALESCE(p.unidad,'pza') "
+                "FROM productos p "
+                "LEFT JOIN branch_inventory bi "
+                "    ON bi.product_id=p.id AND bi.branch_id=? "
+                "WHERE p.activo=1 ORDER BY p.nombre",
+                [branch_id],
+            ).fetchall())
+        except Exception:
+            return []
+
+    def get_last_movement_by_product(self, *, branch_id: int) -> dict[int, str]:
+        try:
+            rows = self._db.execute(
+                "SELECT product_id, MAX(created_at) "
+                "FROM inventory_movements WHERE branch_id=? "
+                "GROUP BY product_id",
+                [branch_id],
+            ).fetchall()
+            return {int(row[0]): str(row[1] or "")[:16] for row in rows}
+        except Exception:
+            return {}
+
+    def list_low_stock_alerts(self, *, limit: int = 8) -> list[tuple[Any, ...]]:
+        try:
+            return list(self._db.execute(
+                "SELECT nombre, existencia, COALESCE(stock_minimo,5), unidad "
+                "FROM productos WHERE existencia <= COALESCE(stock_minimo,5) AND activo=1 "
+                "ORDER BY existencia ASC LIMIT ?",
+                [int(limit)],
+            ).fetchall())
+        except Exception:
+            return []
+
+    def list_recent_feed(self, *, branch_id: int, limit: int = 12) -> list[dict[str, Any]]:
+        movements: list[dict[str, Any]] = []
+        try:
+            rows = self._db.execute(
+                "SELECT im.movement_type, im.quantity, im.usuario, im.created_at, p.nombre "
+                "FROM inventory_movements im "
+                "JOIN productos p ON p.id = im.product_id "
+                "WHERE im.branch_id = ? "
+                "ORDER BY im.created_at DESC LIMIT ?",
+                [branch_id, int(limit)],
+            ).fetchall()
+            for row in rows:
+                movements.append({
+                    "movement_type": row[0],
+                    "quantity": row[1],
+                    "usuario": row[2],
+                    "created_at": row[3],
+                    "nombre": row[4],
+                })
+        except Exception:
+            movements = self._list_legacy_adjustment_feed(branch_id=branch_id, limit=limit)
+        return movements
+
+    def _list_legacy_adjustment_feed(self, *, branch_id: int, limit: int) -> list[dict[str, Any]]:
+        try:
+            rows = self._db.execute(
+                "SELECT tipo, cantidad, usuario, created_at, "
+                "(SELECT nombre FROM productos WHERE id=a.producto_id) "
+                "FROM ajustes_inventario a "
+                "WHERE sucursal_id=? ORDER BY created_at DESC LIMIT ?",
+                [branch_id, int(limit)],
+            ).fetchall()
+            return [
+                {
+                    "movement_type": row[0],
+                    "quantity": row[1],
+                    "usuario": row[2],
+                    "created_at": row[3],
+                    "nombre": row[4],
+                }
+                for row in rows
+            ]
+        except Exception:
+            return []
+
+    def list_product_history(self, *, product_id: int, branch_id: int, limit: int = 100) -> list[tuple[Any, ...]]:
+        try:
+            return list(self._db.execute(
+                "SELECT created_at, movement_type, quantity, usuario, "
+                "COALESCE(reference_type,''), COALESCE(operation_id,'') "
+                "FROM inventory_movements "
+                "WHERE product_id=? AND branch_id=? "
+                "ORDER BY created_at DESC LIMIT ?",
+                [product_id, branch_id, int(limit)],
+            ).fetchall())
+        except Exception:
+            return []
+
+    def list_recent_movements(self, *, branch_id: int, limit: int = 200) -> list[tuple[Any, ...]]:
+        try:
+            return list(self._db.execute(
+                "SELECT im.created_at, p.nombre, im.movement_type, im.quantity, im.branch_id, "
+                "COALESCE(im.reference,''), COALESCE(im.usuario,''), COALESCE(im.origin,'') "
+                "FROM inventory_movements im JOIN productos p ON p.id=im.product_id "
+                "WHERE im.branch_id=? ORDER BY im.created_at DESC LIMIT ?",
+                [branch_id, int(limit)],
+            ).fetchall())
+        except Exception:
+            return []
+
+    def get_operational_kpis(self, *, branch_id: int, product_data: Sequence[dict[str, Any]]) -> dict[str, int]:
+        stock_low = sum(1 for product in product_data if product.get("health") == "BAJO MÍN.")
+        no_stock = sum(1 for product in product_data if product.get("health") == "SIN STOCK")
+        movements_today = 0
+        try:
+            row = self._db.execute(
+                "SELECT COUNT(*) FROM inventory_movements WHERE branch_id=? AND DATE(created_at)=DATE('now')",
+                [branch_id],
+            ).fetchone()
+            movements_today = int((row[0] if row else 0) or 0)
+        except Exception:
+            movements_today = 0
+        return {
+            "stock_bajo": stock_low,
+            "sin_stock_fisico": no_stock,
+            "virtual_disponible": 0,
+            "reservados": 0,
+            "mov_hoy": movements_today,
+        }

--- a/pos_spj_v13.4/backend/application/services/inventory_application_service.py
+++ b/pos_spj_v13.4/backend/application/services/inventory_application_service.py
@@ -1,0 +1,49 @@
+"""Application service for inventory mutations.
+
+This service is the canonical entrypoint for desktop UI and future APIs. It
+keeps the current business behavior by delegating to the protected legacy use
+case, while dependencies are injected explicitly instead of passing a full
+application composition object through the UI layer.
+"""
+
+from __future__ import annotations
+
+from backend.application.commands.inventory_commands import (
+    AdjustInventoryCommand,
+    RegisterInventoryEntryCommand,
+)
+from core.use_cases.inventario import GestionarInventarioUC, ResultadoInventario
+
+
+class InventoryApplicationService:
+    """Inventory mutation facade with explicit dependencies."""
+
+    def __init__(self, *, db, inventory_service, event_bus=None) -> None:
+        self._use_case = GestionarInventarioUC(
+            db=db,
+            inventory_service=inventory_service,
+            event_bus=event_bus,
+        )
+
+    def register_entry(self, command: RegisterInventoryEntryCommand) -> ResultadoInventario:
+        command.validate_context()
+        return self._use_case.registrar_entrada(
+            producto_id=command.product_id,
+            cantidad=command.quantity,
+            sucursal_id=command.branch_id,
+            usuario=command.user_name,
+            costo_unit=command.unit_cost,
+            proveedor_id=command.supplier_id,
+            referencia=command.reference,
+            notas=command.notes,
+        )
+
+    def adjust_stock(self, command: AdjustInventoryCommand) -> ResultadoInventario:
+        command.validate_context()
+        return self._use_case.registrar_ajuste(
+            producto_id=command.product_id,
+            cantidad_nueva=command.new_quantity,
+            sucursal_id=command.branch_id,
+            usuario=command.user_name,
+            motivo=command.reason,
+        )

--- a/pos_spj_v13.4/core/use_cases/inventario.py
+++ b/pos_spj_v13.4/core/use_cases/inventario.py
@@ -103,6 +103,7 @@ class GestionarInventarioUC:
                 "cantidad":    cantidad,
                 "stock_nuevo": stock_nuevo,
                 "usuario":     usuario,
+                "operation_id": op_id,
                 "op_id":       op_id,
             })
             return ResultadoInventario(ok=True, operacion_id=op_id, stock_nuevo=stock_nuevo)
@@ -151,6 +152,7 @@ class GestionarInventarioUC:
                 "delta":       delta,
                 "motivo":      motivo,
                 "usuario":     usuario,
+                "operation_id": op_id,
                 "op_id":       op_id,
             })
             return ResultadoInventario(
@@ -206,6 +208,7 @@ class GestionarInventarioUC:
                 "sucursal_origen":  sucursal_origen,
                 "sucursal_destino": sucursal_destino,
                 "usuario":          usuario,
+                "operation_id":     op_id,
                 "op_id":            op_id,
             })
             return ResultadoInventario(ok=True, operacion_id=op_id, stock_nuevo=stock_nuevo)

--- a/pos_spj_v13.4/modulos/inventario_local.py
+++ b/pos_spj_v13.4/modulos/inventario_local.py
@@ -14,12 +14,13 @@ Architecture:
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import datetime
 
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QFrame,
     QTableWidget, QTableWidgetItem, QHeaderView, QAbstractItemView,
-    QMessageBox, QDialog, QDialogButtonBox, QComboBox, QDoubleSpinBox,
+    QMessageBox, QDialog, QDialogButtonBox, QComboBox,
     QTextEdit, QLineEdit, QScrollArea, QSizePolicy, QFileDialog, QSplitter, QTabWidget,
 )
 from PyQt5.QtCore import Qt, pyqtSignal
@@ -31,10 +32,17 @@ from modulos.ui_components import (
 )
 from modulos.spj_refresh_mixin import RefreshMixin
 from modulos.kpi_card import KPICard
-from core.services.inventory_query_service import get_recent_movements, get_inventory_operational_kpis
+from backend.application.commands.inventory_commands import (
+    AdjustInventoryCommand,
+    RegisterInventoryEntryCommand,
+)
+from backend.application.queries.inventory_query_service import InventoryQueryService
+from backend.application.services.inventory_application_service import InventoryApplicationService
+from frontend.desktop.components.money_input import MoneyInput
+from frontend.desktop.components.quantity_input import QuantityInput
 from core.events.event_bus import (
     VENTA_COMPLETADA, PRODUCTO_ACTUALIZADO, PRODUCTO_CREADO,
-    AJUSTE_INVENTARIO, COMPRA_REGISTRADA,
+    AJUSTE_INVENTARIO, COMPRA_REGISTRADA, get_bus,
 )
 
 logger = logging.getLogger("spj.inventario")
@@ -267,29 +275,21 @@ class _InsightsPanel(QFrame):
         self._lbl_no_mov.hide()
         root.addWidget(self._lbl_no_mov)
 
-    def refresh(self, db, sucursal_id: int) -> None:
-        self._refresh_alerts(db, sucursal_id)
-        self._refresh_movements(db, sucursal_id)
+    def refresh(self, query_service: InventoryQueryService, sucursal_id: int) -> None:
+        self._refresh_alerts(query_service)
+        self._refresh_movements(query_service, sucursal_id)
 
-    def _refresh_alerts(self, db, sucursal_id: int) -> None:
+    def _refresh_alerts(self, query_service: InventoryQueryService) -> None:
         while self._alerts_lyt.count():
             item = self._alerts_lyt.takeAt(0)
             if item.widget():
                 item.widget().deleteLater()
 
         alertas = []
-        try:
-            rows = db.execute(
-                "SELECT nombre, existencia, COALESCE(stock_minimo,5), unidad "
-                "FROM productos WHERE existencia <= COALESCE(stock_minimo,5) AND activo=1 "
-                "ORDER BY existencia ASC LIMIT 8"
-            ).fetchall()
-            for r in rows:
-                stock = float(r[1] or 0)
-                health = _HEALTH_CRITICAL if stock <= 0 else _HEALTH_LOW
-                alertas.append((str(r[0]), stock, str(r[3] or ""), health))
-        except Exception:
-            pass
+        for r in query_service.list_low_stock_alerts(limit=8):
+            stock = float(r[1] or 0)
+            health = _HEALTH_CRITICAL if stock <= 0 else _HEALTH_LOW
+            alertas.append((str(r[0]), stock, str(r[3] or ""), health))
 
         if not alertas:
             self._lbl_no_alerts.show()
@@ -316,43 +316,13 @@ class _InsightsPanel(QFrame):
             rl.addWidget(lbl, 1)
             self._alerts_lyt.addWidget(row)
 
-    def _refresh_movements(self, db, sucursal_id: int) -> None:
+    def _refresh_movements(self, query_service: InventoryQueryService, sucursal_id: int) -> None:
         while self._mov_lyt.count() > 1:
             item = self._mov_lyt.takeAt(0)
             if item.widget():
                 item.widget().deleteLater()
 
-        movs = []
-        try:
-            rows = db.execute(
-                "SELECT im.movement_type, im.quantity, im.usuario, im.created_at, p.nombre "
-                "FROM inventory_movements im "
-                "JOIN productos p ON p.id = im.product_id "
-                "WHERE im.branch_id = ? "
-                "ORDER BY im.created_at DESC LIMIT 12",
-                [sucursal_id]
-            ).fetchall()
-            for r in rows:
-                movs.append({
-                    "movement_type": r[0], "quantity": r[1],
-                    "usuario": r[2], "created_at": r[3], "nombre": r[4],
-                })
-        except Exception:
-            try:
-                rows = db.execute(
-                    "SELECT tipo, cantidad, usuario, created_at, "
-                    "(SELECT nombre FROM productos WHERE id=a.producto_id) "
-                    "FROM ajustes_inventario a "
-                    "WHERE sucursal_id=? ORDER BY created_at DESC LIMIT 12",
-                    [sucursal_id]
-                ).fetchall()
-                for r in rows:
-                    movs.append({
-                        "movement_type": r[0], "quantity": r[1],
-                        "usuario": r[2], "created_at": r[3], "nombre": r[4],
-                    })
-            except Exception:
-                pass
+        movs = query_service.list_recent_feed(branch_id=sucursal_id, limit=12)
 
         if not movs:
             self._lbl_no_mov.show()
@@ -414,9 +384,7 @@ class _AuditAdjustDialog(QDialog):
         root.addWidget(lbl_cnt)
 
         cnt_row = QHBoxLayout()
-        self.spin_nuevo = QDoubleSpinBox(self)
-        self.spin_nuevo.setRange(0, 999_999)
-        self.spin_nuevo.setDecimals(3)
+        self.spin_nuevo = QuantityInput(self)
         self.spin_nuevo.setValue(stock_actual)
         self.spin_nuevo.setObjectName("inputField")
         self.spin_nuevo.setSuffix(f"  {unidad}")
@@ -538,18 +506,13 @@ class _StockEntryDialog(QDialog):
         root.addWidget(_divider(self))
 
         root.addWidget(QLabel(f"Cantidad a ingresar ({unidad}) *"))
-        self.spin_qty = QDoubleSpinBox(self)
-        self.spin_qty.setRange(0.001, 999_999)
-        self.spin_qty.setDecimals(3)
-        self.spin_qty.setValue(1.0)
+        self.spin_qty = QuantityInput(self)
+        self.spin_qty.setMinimum(0.001)
         self.spin_qty.setObjectName("inputField")
         root.addWidget(self.spin_qty)
 
         root.addWidget(QLabel("Costo unitario (opcional)"))
-        self.spin_costo = QDoubleSpinBox(self)
-        self.spin_costo.setRange(0, 999_999)
-        self.spin_costo.setDecimals(2)
-        self.spin_costo.setPrefix("$")
+        self.spin_costo = MoneyInput(self)
         self.spin_costo.setObjectName("inputField")
         root.addWidget(self.spin_costo)
 
@@ -583,7 +546,7 @@ class _StockEntryDialog(QDialog):
 class _MovHistoryDialog(QDialog):
     """Read-only audit trail for a single product."""
 
-    def __init__(self, prod_id: int, nombre: str, db, sucursal_id: int, parent=None):
+    def __init__(self, prod_id: int, nombre: str, query_service: InventoryQueryService, sucursal_id: int, parent=None):
         super().__init__(parent)
         self.setWindowTitle(f"Historial de Movimientos — {nombre}")
         self.setMinimumSize(600, 400)
@@ -616,17 +579,9 @@ class _MovHistoryDialog(QDialog):
         tabla.horizontalHeader().setSectionResizeMode(5, QHeaderView.ResizeToContents)
         tabla.setAlternatingRowColors(True)
 
-        try:
-            rows = db.execute(
-                "SELECT created_at, movement_type, quantity, usuario, "
-                "COALESCE(reference_type,''), COALESCE(operation_id,'') "
-                "FROM inventory_movements "
-                "WHERE product_id=? AND branch_id=? "
-                "ORDER BY created_at DESC LIMIT 100",
-                [prod_id, sucursal_id]
-            ).fetchall()
-        except Exception:
-            rows = []
+        rows = query_service.list_product_history(
+            product_id=prod_id, branch_id=sucursal_id, limit=100
+        )
 
         for i, r in enumerate(rows):
             tabla.insertRow(i)
@@ -670,6 +625,12 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
         self.container      = container
         self.sucursal_id    = 1
         self.usuario_actual = ""
+        self._inventory_query = InventoryQueryService(container.db)
+        self._inventory_app = InventoryApplicationService(
+            db=container.db,
+            inventory_service=container.inventory_service,
+            event_bus=get_bus(),
+        )
 
         self._prod_data: list[dict] = []  # cached for export
 
@@ -1014,36 +975,15 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
                 self._loading.hide()
 
     def _do_cargar(self) -> None:
-        db = self.container.db
         self._prod_data = []
 
-        try:
-            rows = db.execute(
-                "SELECT p.id, p.nombre, COALESCE(p.categoria,''), "
-                "COALESCE(bi.quantity, p.existencia, 0),"
-                "COALESCE(p.stock_minimo, 5), COALESCE(p.unidad,'pza') "
-                "FROM productos p "
-                "LEFT JOIN branch_inventory bi "
-                "    ON bi.product_id=p.id AND bi.branch_id=? "
-                "WHERE p.activo=1 ORDER BY p.nombre",
-                [self.sucursal_id]
-            ).fetchall()
-        except Exception as e:
-            logger.warning("cargar inventario: %s", e)
-            rows = []
+        rows = self._inventory_query.list_inventory_rows(branch_id=self.sucursal_id)
+        if not rows:
+            logger.warning("cargar inventario: sin filas para sucursal %s", self.sucursal_id)
 
-        # Fetch last movement timestamps
-        _last_mov: dict[int, str] = {}
-        try:
-            ts_rows = db.execute(
-                "SELECT product_id, MAX(created_at) "
-                "FROM inventory_movements WHERE branch_id=? "
-                "GROUP BY product_id",
-                [self.sucursal_id]
-            ).fetchall()
-            _last_mov = {int(r[0]): str(r[1] or "")[:16] for r in ts_rows}
-        except Exception:
-            pass
+        _last_mov = self._inventory_query.get_last_movement_by_product(
+            branch_id=self.sucursal_id
+        )
 
         self.tabla.setRowCount(0)
         self.tabla_disponibilidad.setRowCount(0)
@@ -1124,25 +1064,28 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
         if hasattr(self, "_empty_state"):
             self._empty_state.setVisible(count == 0)
 
-        self._refresh_kpis(db)
+        self._refresh_kpis(None)
         self._populate_categories()
 
         if hasattr(self, "_insights"):
             try:
-                self._insights.refresh(db, self.sucursal_id)
+                self._insights.refresh(self._inventory_query, self.sucursal_id)
             except Exception:
                 pass
 
     def _cargar_movimientos_tab(self) -> None:
         self.tabla_movimientos.setRowCount(0)
-        rows = get_recent_movements(self.container.db, self.sucursal_id, limit=200)
+        rows = self._inventory_query.list_recent_movements(branch_id=self.sucursal_id, limit=200)
         for i, r in enumerate(rows):
             self.tabla_movimientos.insertRow(i)
             for j, v in enumerate(r):
                 self.tabla_movimientos.setItem(i, j, QTableWidgetItem(str(v or "")))
 
     def _refresh_kpis(self, db) -> None:
-        data = get_inventory_operational_kpis(db, self.sucursal_id, self._prod_data)
+        del db
+        data = self._inventory_query.get_operational_kpis(
+            branch_id=self.sucursal_id, product_data=self._prod_data
+        )
         self._kpi_bajo.set_valor(str(data.get("stock_bajo", 0)))
         self._kpi_sin.set_valor(str(data.get("sin_stock_fisico", 0)))
         self._kpi_virtual.set_valor(str(data.get("virtual_disponible", 0)))
@@ -1242,14 +1185,16 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
 
         r = dlg.resultado
         try:
-            uc = GestionarInventarioUC.desde_container(self.container)
-            res = uc.registrar_entrada(
-                producto_id  = prod["id"],
-                cantidad     = r["cantidad"],
-                sucursal_id  = self.sucursal_id,
-                usuario      = self.usuario_actual or "sistema",
-                costo_unit   = r["costo_unit"],
-                notas        = r["referencia"],
+            res = self._inventory_app.register_entry(
+                RegisterInventoryEntryCommand(
+                    operation_id=f"INV-UI-{uuid.uuid4().hex[:12].upper()}",
+                    product_id=prod["id"],
+                    quantity=r["cantidad"],
+                    branch_id=str(self.sucursal_id),
+                    user_name=self.usuario_actual or "sistema",
+                    unit_cost=r["costo_unit"],
+                    notes=r["referencia"],
+                )
             )
             if not res.ok:
                 raise Exception(res.error)
@@ -1283,20 +1228,16 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
 
         r = dlg.resultado
         try:
-            uc = getattr(self.container, "uc_inventario", None)
-            if uc:
-                res = uc.registrar_ajuste(
-                    prod["id"], r["cantidad_nueva"],
-                    self.sucursal_id, self.usuario_actual or "sistema",
-                    r["motivo"],
+            res = self._inventory_app.adjust_stock(
+                AdjustInventoryCommand(
+                    operation_id=f"INV-UI-{uuid.uuid4().hex[:12].upper()}",
+                    product_id=prod["id"],
+                    new_quantity=r["cantidad_nueva"],
+                    branch_id=str(self.sucursal_id),
+                    user_name=self.usuario_actual or "sistema",
+                    reason=r["motivo"],
                 )
-            else:
-                uc2 = GestionarInventarioUC.desde_container(self.container)
-                res = uc2.registrar_ajuste(
-                    prod["id"], r["cantidad_nueva"],
-                    self.sucursal_id, self.usuario_actual or "sistema",
-                    r["motivo"],
-                )
+            )
             if not res.ok:
                 raise Exception(res.error)
             Toast.success(
@@ -1315,7 +1256,7 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
             return
         dlg = _MovHistoryDialog(
             prod["id"], prod["nombre"],
-            self.container.db, self.sucursal_id, self
+            self._inventory_query, self.sucursal_id, self
         )
         dlg.exec_()
 
@@ -1377,6 +1318,3 @@ class ModuloInventarioLocal(QWidget, RefreshMixin):
             except Exception as e:
                 QMessageBox.critical(self, "Error", str(e))
 
-
-# ── Import needed by _accion_entrada / _accion_ajuste ────────────────────────
-from core.use_cases.inventario import GestionarInventarioUC  # noqa: E402

--- a/pos_spj_v13.4/tests/unit/test_inventory_application_service.py
+++ b/pos_spj_v13.4/tests/unit/test_inventory_application_service.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from backend.application.commands.inventory_commands import (
+    AdjustInventoryCommand,
+    RegisterInventoryEntryCommand,
+)
+from backend.application.services.inventory_application_service import InventoryApplicationService
+
+
+class FakeInventoryService:
+    def __init__(self) -> None:
+        self.stock = 5.0
+        self.calls = []
+
+    def get_stock(self, product_id: int, branch_id: int) -> float:
+        return self.stock
+
+    def add_stock(self, **kwargs) -> None:
+        self.calls.append(("add", kwargs))
+        self.stock += float(kwargs["qty"])
+
+    def deduct_stock(self, **kwargs) -> None:
+        self.calls.append(("deduct", kwargs))
+        self.stock -= float(kwargs["qty"])
+
+
+class FakeDb:
+    def __init__(self) -> None:
+        self.committed = False
+
+    def execute(self, *args, **kwargs):
+        raise RuntimeError("audit tables are optional in this protection test")
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+class FakeEventBus:
+    def __init__(self) -> None:
+        self.events = []
+
+    def publish(self, event, payload, async_=False) -> None:
+        self.events.append((event, payload, async_))
+
+
+def test_register_entry_preserves_stock_update_and_operation_event_payload() -> None:
+    inv = FakeInventoryService()
+    bus = FakeEventBus()
+    service = InventoryApplicationService(db=FakeDb(), inventory_service=inv, event_bus=bus)
+
+    result = service.register_entry(
+        RegisterInventoryEntryCommand(
+            operation_id="UI-OP-1",
+            branch_id=1,
+            user_name="almacen",
+            product_id=7,
+            quantity=3.5,
+            unit_cost=12.0,
+            notes="recepción manual",
+        )
+    )
+
+    assert result.ok is True
+    assert result.stock_nuevo == 8.5
+    assert inv.calls[0][0] == "add"
+    assert inv.calls[0][1]["operation_id"] == result.operacion_id
+    assert bus.events[0][1]["operation_id"] == result.operacion_id
+
+
+def test_adjust_stock_preserves_delta_deduction_and_operation_event_payload() -> None:
+    inv = FakeInventoryService()
+    bus = FakeEventBus()
+    service = InventoryApplicationService(db=FakeDb(), inventory_service=inv, event_bus=bus)
+
+    result = service.adjust_stock(
+        AdjustInventoryCommand(
+            operation_id="UI-OP-2",
+            branch_id=1,
+            user_name="auditor",
+            product_id=7,
+            new_quantity=2.0,
+            reason="Conteo físico — prueba",
+        )
+    )
+
+    assert result.ok is True
+    assert result.stock_nuevo == 2.0
+    assert inv.calls[0][0] == "deduct"
+    assert inv.calls[0][1]["qty"] == 3.0
+    assert inv.calls[0][1]["operation_id"] == result.operacion_id
+    assert bus.events[0][1]["operation_id"] == result.operacion_id

--- a/pos_spj_v13.4/tests/unit/test_inventory_query_service.py
+++ b/pos_spj_v13.4/tests/unit/test_inventory_query_service.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sqlite3
+
+from backend.application.queries.inventory_query_service import InventoryQueryService
+
+
+def _db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE productos("
+        "id INTEGER PRIMARY KEY, nombre TEXT, categoria TEXT, existencia REAL, "
+        "stock_minimo REAL, unidad TEXT, activo INTEGER)"
+    )
+    conn.execute("CREATE TABLE branch_inventory(product_id INTEGER, branch_id INTEGER, quantity REAL)")
+    conn.execute(
+        "CREATE TABLE inventory_movements("
+        "product_id INTEGER, branch_id INTEGER, created_at TEXT, movement_type TEXT, "
+        "quantity REAL, usuario TEXT, reference_type TEXT, operation_id TEXT, reference TEXT, origin TEXT)"
+    )
+    conn.execute("INSERT INTO productos VALUES(1,'Pollo','Carnes',4,5,'kg',1)")
+    conn.execute("INSERT INTO branch_inventory VALUES(1,2,9)")
+    conn.execute(
+        "INSERT INTO inventory_movements VALUES(1,2,'2026-06-07 10:00','ENTRADA',3,'u','ENTRADA','OP1','ref','desktop')"
+    )
+    return conn
+
+
+def test_inventory_query_service_lists_inventory_rows_without_ui_sql() -> None:
+    service = InventoryQueryService(_db())
+
+    rows = service.list_inventory_rows(branch_id=2)
+
+    assert rows[0][0] == 1
+    assert rows[0][1] == "Pollo"
+    assert rows[0][3] == 9
+
+
+def test_inventory_query_service_returns_kpis_and_history() -> None:
+    service = InventoryQueryService(_db())
+
+    assert service.get_last_movement_by_product(branch_id=2) == {1: "2026-06-07 10:00"}
+    assert service.list_product_history(product_id=1, branch_id=2)[0][5] == "OP1"
+    assert service.get_operational_kpis(branch_id=2, product_data=[{"health": "BAJO MÍN."}])["stock_bajo"] == 1


### PR DESCRIPTION
### Motivation
- Align the Inventory module with the refactor rules: move SQL out of PyQt UI, route reads through QueryServices and mutating operations through explicit ApplicationServices, and keep backend logic unchanged while adding protective scaffolding. 
- Ensure every critical mutation includes an `operation_id` for traceability and event correlation across UI, UseCase and EventBus layers. 

### Description
- Added canonical command DTOs for inventory operations in `backend/application/commands/inventory_commands.py` to validate `operation_id`, branch and user context before execution. 
- Implemented `InventoryQueryService` in `backend/application/queries/inventory_query_service.py` to centralize all inventory read models for the UI (inventory rows, low-stock alerts, recent feed, product history, KPIs). 
- Implemented `InventoryApplicationService` in `backend/application/services/inventory_application_service.py` as the canonical, dependency-injected facade for `register_entry` and `adjust_stock`, delegating to the existing use case. 
- Migrated the PyQt inventory UI (`modulos/inventario_local.py`) to use `InventoryQueryService` for reads and `InventoryApplicationService` for mutations, replaced direct SQL in the UI, and switched numeric widgets to `QuantityInput`/`MoneyInput`. 
- Emitted `operation_id` in inventory event payloads from the UseCase layer (`core/use_cases/inventario.py`) so events include the canonical identifier for handlers. 
- Added unit protection tests: `tests/unit/test_inventory_query_service.py` and `tests/unit/test_inventory_application_service.py` that exercise reads, history, KPIs and mutation command flows. 

### Testing
- Ran targeted architecture guard tests: `test_no_commit_rollback_in_frontend.py`, `test_no_hardcoded_numeric_defaults_in_ui.py`, and `test_no_container_passed_to_services.py`, which passed for the modified paths. 
- Executed unit suite including new tests: `PYTHONPATH=pos_spj_v13.4 python -m pytest pos_spj_v13.4/tests/unit -q`, resulting in all unit tests passing (new tests passed). 
- Executed integration and inventory scenario tests: `pos_spj_v13.4/tests/integration` and `pos_spj_v13.4/tests/test_inventory.py` / `pos_spj_v13.4/tests/test_fase5_inventory_availability_service.py`, which passed for the affected areas. 
- Compiled new modules (`python -m compileall`) and ran the subset of architecture checks used during the change; a full run of `tests/architecture` still shows an unrelated pre-existing SQL allowlist mismatch in `modulos/ventas.py` (existing debt increased by 1 in that file), but the inventory-focused guard tests and the new unit/integration tests for inventory succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24ed2839108328a89329fc6d65883a)