### PR TITLE
Refactor product catalog backend flow

### DIFF
--- a/pos_spj_v13.4/backend/application/commands/__init__.py
+++ b/pos_spj_v13.4/backend/application/commands/__init__.py
@@ -4,6 +4,7 @@ from backend.application.commands.base_command import BaseCommand
 from backend.application.commands.cash_register_commands import GenerateZCutCommand
 from backend.application.commands.delivery_commands import CreateDeliveryOrderCommand
 from backend.application.commands.product_commands import CreateProductCommand
+from backend.application.commands.product_commands import UpdateProductCommand
 from backend.application.commands.production_commands import ExecuteMeatProductionCommand
 from backend.application.commands.purchase_planning_commands import GeneratePurchasePlanCommand
 from backend.application.commands.quote_commands import ConvertQuoteToSaleCommand
@@ -17,6 +18,7 @@ __all__ = [
     "GenerateZCutCommand",
     "CreateDeliveryOrderCommand",
     "CreateProductCommand",
+    "UpdateProductCommand",
     "ExecuteMeatProductionCommand",
     "GeneratePurchasePlanCommand",
     "ConvertQuoteToSaleCommand",

--- a/pos_spj_v13.4/backend/application/commands/product_commands.py
+++ b/pos_spj_v13.4/backend/application/commands/product_commands.py
@@ -9,4 +9,27 @@ from backend.application.commands.base_command import BaseCommand
 
 @dataclass(frozen=True)
 class CreateProductCommand(BaseCommand):
-    pass
+    """Command for the canonical product creation route."""
+
+    name: str = ""
+    sku: str | None = None
+    barcode: str = ""
+    category: str = ""
+    sale_price: float = 0.0
+    purchase_price: float = 0.0
+    minimum_sale_price: float = 0.0
+    unit: str = ""
+    sale_unit: str = ""
+    purchase_unit: str = ""
+    minimum_stock: float = 0.0
+    product_type: str = "simple"
+    image_path: str | None = None
+    active: bool = True
+    allow_duplicate_name: bool = False
+
+
+@dataclass(frozen=True)
+class UpdateProductCommand(CreateProductCommand):
+    """Command for the canonical product update route."""
+
+    product_id: int | str = 0

--- a/pos_spj_v13.4/backend/application/queries/product_query_service.py
+++ b/pos_spj_v13.4/backend/application/queries/product_query_service.py
@@ -1,12 +1,132 @@
-"""Read-only QueryService for the products UI/API read models."""
+"""Read-only QueryService for product UI/API read models."""
 
 from __future__ import annotations
 
+from typing import Any, Sequence
+
 from backend.application.queries.base_query_service import BaseQueryService, KpiMetric, QueryFilters, SearchResult, TableRow
+from backend.domain.services.product_type_policy import ProductTypePolicy
+
+
+class SQLiteProductQueryDataSource:
+    """Product read adapter used by desktop until a repository-backed API is wired."""
+
+    def __init__(self, connection: Any) -> None:
+        self._connection = connection
+        try:
+            import sqlite3
+            if getattr(self._connection, "row_factory", None) is None:
+                self._connection.row_factory = sqlite3.Row
+        except Exception:
+            pass
+
+    def search(self, scope: str, query: str, filters: QueryFilters | None = None) -> Sequence[SearchResult]:
+        if scope != "products":
+            return []
+        like = f"%{query}%"
+        rows = self._connection.execute(
+            """
+            SELECT id, nombre, codigo, categoria, unidad, precio, tipo_producto
+            FROM productos
+            WHERE COALESCE(activo,1)=1
+              AND (? = '' OR nombre LIKE ? OR COALESCE(codigo,'') LIKE ? OR COALESCE(codigo_barras,'') LIKE ?)
+            ORDER BY nombre ASC
+            LIMIT 50
+            """,
+            (query, like, like, like),
+        ).fetchall()
+        return [
+            SearchResult(
+                id=str(row["id"] if hasattr(row, "keys") else row[0]),
+                label=str(row["nombre"] if hasattr(row, "keys") else row[1]),
+                subtitle=str(row["codigo"] if hasattr(row, "keys") else row[2] or ""),
+                metadata={
+                    "category": row["categoria"] if hasattr(row, "keys") else row[3],
+                    "unit": row["unidad"] if hasattr(row, "keys") else row[4],
+                    "price": row["precio"] if hasattr(row, "keys") else row[5],
+                    "product_type": row["tipo_producto"] if hasattr(row, "keys") else row[6],
+                },
+            )
+            for row in rows
+        ]
+
+    def list_rows(self, scope: str, filters: QueryFilters | None = None) -> Sequence[TableRow]:
+        if scope != "products":
+            return []
+        filters = filters or {}
+        params: list[Any] = []
+        query = (
+            "SELECT id, codigo, COALESCE(codigo_barras,'') AS codigo_barras, nombre, categoria, "
+            "precio, COALESCE(existencia,0) AS existencia, COALESCE(activo,1) AS activo, tipo_producto "
+            "FROM productos WHERE 1=1"
+        )
+        state = filters.get("state", "active")
+        if state == "active":
+            query += " AND COALESCE(activo,1)=1"
+        elif state == "deleted":
+            query += " AND COALESCE(activo,1)=0"
+        category = str(filters.get("category") or "")
+        if category:
+            query += " AND categoria=?"
+            params.append(category)
+        text = str(filters.get("query") or "").strip()
+        if text:
+            query += " AND (nombre LIKE ? OR COALESCE(codigo,'') LIKE ? OR COALESCE(codigo_barras,'') LIKE ?)"
+            like = f"%{text}%"
+            params.extend([like, like, like])
+        query += " ORDER BY activo DESC, nombre ASC LIMIT 1000"
+        rows = self._connection.execute(query, params).fetchall()
+        return [TableRow(id=str(self._value(row, "id", 0)), values=self._row_dict(row)) for row in rows]
+
+    def metrics(self, scope: str, filters: QueryFilters | None = None) -> Sequence[KpiMetric]:
+        if scope != "products":
+            return []
+        active = self._count("COALESCE(activo,1)=1")
+        inactive = self._count("COALESCE(activo,1)=0")
+        return [
+            KpiMetric("activos", "Productos activos", active),
+            KpiMetric("inactivos", "Inactivos", inactive),
+        ]
+
+    def list_categories(self) -> list[str]:
+        rows = self._connection.execute(
+            "SELECT DISTINCT categoria FROM productos WHERE categoria IS NOT NULL AND categoria!='' ORDER BY categoria"
+        ).fetchall()
+        return [str(self._value(row, "categoria", 0)) for row in rows]
+
+    def get_product(self, product_id: int | str) -> dict[str, Any] | None:
+        row = self._connection.execute("SELECT * FROM productos WHERE id=?", (product_id,)).fetchone()
+        return self._row_dict(row) if row is not None else None
+
+    def find_duplicate_name(self, name: str, *, exclude_product_id: int | str | None = None) -> dict[str, Any] | None:
+        params: list[Any] = [name]
+        query = "SELECT id, codigo FROM productos WHERE LOWER(TRIM(nombre))=LOWER(TRIM(?)) AND COALESCE(activo,1)=1"
+        if exclude_product_id:
+            query += " AND id!=?"
+            params.append(exclude_product_id)
+        row = self._connection.execute(query, params).fetchone()
+        return self._row_dict(row) if row is not None else None
+
+    def _count(self, where: str) -> int:
+        return int(self._connection.execute(f"SELECT COUNT(*) FROM productos WHERE {where}").fetchone()[0])
+
+    @staticmethod
+    def _value(row: Any, key: str, index: int) -> Any:
+        return row[key] if hasattr(row, "keys") else row[index]
+
+    @staticmethod
+    def _row_dict(row: Any) -> dict[str, Any]:
+        if hasattr(row, "keys"):
+            return {key: row[key] for key in row.keys()}
+        return dict(row)
 
 
 class ProductQueryService(BaseQueryService):
     scope = "products"
+
+    @classmethod
+    def from_connection(cls, connection: Any) -> "ProductQueryService":
+        return cls(SQLiteProductQueryDataSource(connection))
 
     def search_products(self, query: str, filters: QueryFilters | None = None) -> list[SearchResult]:
         return list(self.search(query, filters))
@@ -16,3 +136,54 @@ class ProductQueryService(BaseQueryService):
 
     def get_kpis(self, filters: QueryFilters | None = None) -> list[KpiMetric]:
         return list(self.metrics(filters))
+
+    def list_categories(self) -> list[str]:
+        data_source = self._data_source
+        if hasattr(data_source, "list_categories"):
+            return list(data_source.list_categories())
+        return []
+
+    def get_product(self, product_id: int | str) -> dict[str, Any] | None:
+        data_source = self._data_source
+        if hasattr(data_source, "get_product"):
+            product = data_source.get_product(product_id)
+            if product:
+                self._apply_type_rules(product)
+            return product
+        return None
+
+    def find_duplicate_name(self, name: str, *, exclude_product_id: int | str | None = None) -> dict[str, Any] | None:
+        data_source = self._data_source
+        if hasattr(data_source, "find_duplicate_name"):
+            return data_source.find_duplicate_name(name, exclude_product_id=exclude_product_id)
+        return None
+
+    @staticmethod
+    def type_labels_es() -> tuple[str, ...]:
+        return ProductTypePolicy.spanish_labels()
+
+    @staticmethod
+    def type_help_es(product_type: str | None) -> str:
+        return ProductTypePolicy.rules_for(product_type).help_es
+
+    @staticmethod
+    def type_rules(product_type: str | None) -> dict[str, Any]:
+        rules = ProductTypePolicy.rules_for(product_type)
+        return {
+            "code": rules.code,
+            "label_es": rules.label_es,
+            "is_sellable": rules.is_sellable,
+            "is_inventory_tracked": rules.is_inventory_tracked,
+            "allows_recipe": rules.allows_recipe,
+            "allows_virtual_stock": rules.allows_virtual_stock,
+            "deducts_components_on_sale": rules.deducts_components_on_sale,
+            "is_composite": rules.is_composite,
+            "is_byproduct": rules.is_byproduct,
+            "recipe_kind": rules.recipe_kind,
+            "help_es": rules.help_es,
+        }
+
+    @staticmethod
+    def _apply_type_rules(product: dict[str, Any]) -> None:
+        rules = ProductTypePolicy.rules_for(product.get("tipo_producto"))
+        product["type_rules"] = rules

--- a/pos_spj_v13.4/backend/application/services/__init__.py
+++ b/pos_spj_v13.4/backend/application/services/__init__.py
@@ -1,5 +1,20 @@
 """Application services for canonical module routes."""
 
+from backend.application.services.product_catalog_service import (
+    ProductBarcodeService,
+    ProductCatalogService,
+    ProductImageService,
+    ProductPricingService,
+    ProductRecipeConfigService,
+)
 from backend.application.services.waste_application_service import WasteApplicationService, WasteFinanceHandler
 
-__all__ = ["WasteApplicationService", "WasteFinanceHandler"]
+__all__ = [
+    "ProductBarcodeService",
+    "ProductCatalogService",
+    "ProductImageService",
+    "ProductPricingService",
+    "ProductRecipeConfigService",
+    "WasteApplicationService",
+    "WasteFinanceHandler",
+]

--- a/pos_spj_v13.4/backend/application/services/product_catalog_service.py
+++ b/pos_spj_v13.4/backend/application/services/product_catalog_service.py
@@ -1,0 +1,236 @@
+"""Canonical application service for product catalog mutations."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+from uuid import uuid4
+import logging
+
+from backend.application.commands.product_commands import CreateProductCommand, UpdateProductCommand
+from backend.application.dto.use_case_result import UseCaseResult
+from backend.domain.services.product_type_policy import ProductTypePolicy
+from backend.shared.events.event_bus import EventBus, InMemoryEventBus
+from backend.shared.events.event_contracts import create_domain_event
+from backend.shared.events.event_names import EventName
+
+logger = logging.getLogger(__name__)
+
+
+class ProductRepositoryProtocol(Protocol):
+    def get_by_id(self, product_id: int | str) -> dict[str, Any] | None: ...
+    def sku_exists(self, sku: str, *, exclude_product_id: int | str | None = None) -> dict[str, Any] | None: ...
+    def active_name_duplicate(self, name: str, *, exclude_product_id: int | str | None = None) -> dict[str, Any] | None: ...
+    def has_active_recipe(self, product_id: int | str) -> bool: ...
+    def create(self, product_data: dict[str, Any]) -> str: ...
+    def update(self, product_id: int | str, product_data: dict[str, Any]) -> str: ...
+    def save_changes(self) -> None: ...
+    def rollback_changes(self) -> None: ...
+
+
+class ProductPricingService:
+    """Normalizes base product price and cost numbers."""
+
+    @staticmethod
+    def normalize_price(value: float | int | None) -> float:
+        return round(max(float(value or 0.0), 0.0), 2)
+
+    @classmethod
+    def normalize_money_fields(cls, command: CreateProductCommand) -> dict[str, float]:
+        return {
+            "sale_price": cls.normalize_price(command.sale_price),
+            "purchase_price": cls.normalize_price(command.purchase_price),
+            "minimum_sale_price": cls.normalize_price(command.minimum_sale_price),
+        }
+
+
+class ProductImageService:
+    """Keeps catalog image path handling behind the application boundary."""
+
+    @staticmethod
+    def normalize_path(path: str | None) -> str | None:
+        value = (path or "").strip()
+        return value or None
+
+
+class ProductBarcodeService:
+    """Keeps barcode/SKU normalization behind the application boundary."""
+
+    @staticmethod
+    def normalize_barcode(value: str | None) -> str:
+        return (value or "").strip()
+
+    @staticmethod
+    def normalize_sku(value: str | None) -> str:
+        clean = (value or "").strip()
+        return clean or f"P-{uuid4().hex[:8].upper()}"
+
+
+class ProductRecipeConfigService:
+    """Reports recipe status without changing recipe data."""
+
+    def __init__(self, repository: ProductRepositoryProtocol) -> None:
+        self._repository = repository
+
+    def recipe_pending_for(self, *, product_id: int | str, product_type: str) -> bool:
+        rules = ProductTypePolicy.rules_for(product_type)
+        return rules.allows_recipe and not self._repository.has_active_recipe(product_id)
+
+
+class ProductCatalogService:
+    """Coordinates the single canonical product catalog mutation route."""
+
+    def __init__(
+        self,
+        *,
+        repository: ProductRepositoryProtocol,
+        event_bus: EventBus | None = None,
+        pricing_service: ProductPricingService | None = None,
+        image_service: ProductImageService | None = None,
+        barcode_service: ProductBarcodeService | None = None,
+    ) -> None:
+        self._repository = repository
+        self._event_bus = event_bus or InMemoryEventBus()
+        self._pricing = pricing_service or ProductPricingService()
+        self._image = image_service or ProductImageService()
+        self._barcode = barcode_service or ProductBarcodeService()
+        self._recipes = ProductRecipeConfigService(repository)
+
+    def create(self, command: CreateProductCommand) -> UseCaseResult:
+        command.validate_context()
+        product_data_or_error = self._build_product_data(command)
+        if isinstance(product_data_or_error, UseCaseResult):
+            return product_data_or_error
+        product_data = product_data_or_error
+
+        duplicate_result = self._validate_duplicates(command, product_data, exclude_product_id=None)
+        if duplicate_result is not None:
+            return duplicate_result
+
+        try:
+            product_id = self._repository.create(product_data)
+            self._repository.save_changes()
+        except Exception:
+            self._rollback(command.operation_id)
+            return UseCaseResult(False, command.operation_id, message="PRODUCT_CREATE_FAILED")
+
+        return self._success(command, product_id, EventName.PRODUCT_CREATED, product_data)
+
+    def update(self, command: UpdateProductCommand) -> UseCaseResult:
+        command.validate_context()
+        if not command.product_id:
+            return UseCaseResult(False, command.operation_id, message="PRODUCT_ID_REQUIRED")
+        if self._repository.get_by_id(command.product_id) is None:
+            return UseCaseResult(False, command.operation_id, message="PRODUCT_NOT_FOUND")
+
+        product_data_or_error = self._build_product_data(command)
+        if isinstance(product_data_or_error, UseCaseResult):
+            return product_data_or_error
+        product_data = product_data_or_error
+
+        duplicate_result = self._validate_duplicates(command, product_data, exclude_product_id=command.product_id)
+        if duplicate_result is not None:
+            return duplicate_result
+
+        try:
+            product_id = self._repository.update(command.product_id, product_data)
+            self._repository.save_changes()
+        except Exception:
+            self._rollback(command.operation_id)
+            return UseCaseResult(False, command.operation_id, message="PRODUCT_UPDATE_FAILED")
+
+        return self._success(command, product_id, EventName.PRODUCT_UPDATED, product_data)
+
+    def _build_product_data(self, command: CreateProductCommand) -> dict[str, Any] | UseCaseResult:
+        name = command.name.strip()
+        if not name:
+            return UseCaseResult(False, command.operation_id, message="PRODUCT_NAME_REQUIRED")
+        try:
+            rules = ProductTypePolicy.rules_for(command.product_type)
+        except ValueError:
+            return UseCaseResult(False, command.operation_id, message="PRODUCT_TYPE_UNSUPPORTED")
+
+        prices = self._pricing.normalize_money_fields(command)
+        minimum_stock = max(float(command.minimum_stock or 0.0), 0.0)
+        unit = (command.unit or command.sale_unit or command.purchase_unit or "").strip() or "pza"
+        return {
+            "name": name,
+            "sku": self._barcode.normalize_sku(command.sku),
+            "barcode": self._barcode.normalize_barcode(command.barcode),
+            "category": command.category.strip(),
+            "unit": unit,
+            "sale_unit": (command.sale_unit or unit).strip(),
+            "purchase_unit": (command.purchase_unit or unit).strip(),
+            "minimum_stock": minimum_stock,
+            "product_type": rules.code,
+            "is_composite": 1 if rules.is_composite else 0,
+            "is_byproduct": 1 if rules.is_byproduct else 0,
+            "active": bool(command.active),
+            "image_path": self._image.normalize_path(command.image_path),
+            **prices,
+        }
+
+    def _validate_duplicates(
+        self,
+        command: CreateProductCommand,
+        product_data: dict[str, Any],
+        *,
+        exclude_product_id: int | str | None,
+    ) -> UseCaseResult | None:
+        sku_duplicate = self._repository.sku_exists(product_data["sku"], exclude_product_id=exclude_product_id)
+        if sku_duplicate is not None:
+            return UseCaseResult(False, command.operation_id, message="PRODUCT_SKU_DUPLICATE", data=sku_duplicate)
+        name_duplicate = self._repository.active_name_duplicate(product_data["name"], exclude_product_id=exclude_product_id)
+        if name_duplicate is not None and not command.allow_duplicate_name:
+            return UseCaseResult(False, command.operation_id, message="PRODUCT_NAME_DUPLICATE_ACTIVE", data=name_duplicate)
+        return None
+
+    def _success(
+        self,
+        command: CreateProductCommand,
+        product_id: int | str,
+        event_name: EventName,
+        product_data: dict[str, Any],
+    ) -> UseCaseResult:
+        recipe_pending = self._recipes.recipe_pending_for(product_id=product_id, product_type=product_data["product_type"])
+        event = create_domain_event(
+            event_name=event_name,
+            operation_id=command.operation_id,
+            entity_id=str(product_id),
+            branch_id=str(command.branch_id),
+            user_id=command.user_id,
+            user_name=command.user_name,
+            source_module="products",
+            payload={
+                "product_id": str(product_id),
+                "name": product_data["name"],
+                "sku": product_data["sku"],
+                "product_type": product_data["product_type"],
+                "sale_price": product_data["sale_price"],
+                "purchase_price": product_data["purchase_price"],
+                "minimum_stock": product_data["minimum_stock"],
+                "recipe_pending": recipe_pending,
+            },
+        )
+        published_events: tuple[Any, ...] = ()
+        side_effect_errors: list[str] = []
+        try:
+            self._event_bus.publish(event)
+            published_events = (event,)
+        except Exception:
+            side_effect_errors.append("PRODUCT_EVENT_PUBLISH_FAILED")
+            logger.exception("[PRODUCTS] event publish failed operation_id=%s product_id=%s", command.operation_id, product_id)
+        message = "PRODUCT_CREATED" if event_name is EventName.PRODUCT_CREATED else "PRODUCT_UPDATED"
+        return UseCaseResult(
+            True,
+            command.operation_id,
+            entity_id=str(product_id),
+            message=message,
+            data={"product_id": str(product_id), "recipe_pending": recipe_pending, "side_effect_errors": tuple(side_effect_errors)},
+            events=published_events,
+        )
+
+    def _rollback(self, operation_id: str) -> None:
+        try:
+            self._repository.rollback_changes()
+        except Exception:
+            logger.exception("[PRODUCTS] rollback failed operation_id=%s", operation_id)

--- a/pos_spj_v13.4/backend/application/use_cases/__init__.py
+++ b/pos_spj_v13.4/backend/application/use_cases/__init__.py
@@ -9,6 +9,7 @@ from backend.application.use_cases.dispatch_transfer_use_case import DispatchTra
 from backend.application.use_cases.receive_transfer_use_case import ReceiveTransferUseCase
 from backend.application.use_cases.create_delivery_order_use_case import CreateDeliveryOrderUseCase
 from backend.application.use_cases.create_product_use_case import CreateProductUseCase
+from backend.application.use_cases.update_product_use_case import UpdateProductUseCase
 from backend.application.use_cases.generate_z_cut_use_case import GenerateZCutUseCase
 from backend.application.use_cases.convert_quote_to_sale_use_case import ConvertQuoteToSaleUseCase
 from backend.application.use_cases.generate_purchase_plan_use_case import GeneratePurchasePlanUseCase
@@ -23,6 +24,7 @@ __all__ = [
     "ReceiveTransferUseCase",
     "CreateDeliveryOrderUseCase",
     "CreateProductUseCase",
+    "UpdateProductUseCase",
     "GenerateZCutUseCase",
     "ConvertQuoteToSaleUseCase",
     "GeneratePurchasePlanUseCase",

--- a/pos_spj_v13.4/backend/application/use_cases/update_product_use_case.py
+++ b/pos_spj_v13.4/backend/application/use_cases/update_product_use_case.py
@@ -1,28 +1,28 @@
-"""Canonical use case for product creation."""
+"""Canonical use case for product updates."""
 
 from __future__ import annotations
 
-from backend.application.commands.product_commands import CreateProductCommand
+from backend.application.commands.product_commands import UpdateProductCommand
 from backend.application.dto.use_case_result import UseCaseResult
 from backend.application.services.product_catalog_service import ProductCatalogService
 from backend.application.use_cases.base_use_case import BaseUseCase, UseCaseHandler
 
 
-class CreateProductUseCase(BaseUseCase[CreateProductCommand]):
-    name = "CreateProductUseCase"
+class UpdateProductUseCase(BaseUseCase[UpdateProductCommand]):
+    name = "UpdateProductUseCase"
 
     def __init__(
         self,
         app_service: ProductCatalogService | None = None,
-        handler: UseCaseHandler[CreateProductCommand] | None = None,
+        handler: UseCaseHandler[UpdateProductCommand] | None = None,
     ) -> None:
         self._app_service = app_service
         self._handler = handler
 
-    def execute(self, command: CreateProductCommand) -> UseCaseResult:
+    def execute(self, command: UpdateProductCommand) -> UseCaseResult:
         command.validate_context()
         if self._app_service is not None:
-            return self._app_service.create(command)
+            return self._app_service.update(command)
         if self._handler is not None:
             return self._handler(command)
         return UseCaseResult.not_implemented(command.operation_id, use_case_name=self.name)

--- a/pos_spj_v13.4/backend/domain/__init__.py
+++ b/pos_spj_v13.4/backend/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Backend domain layer."""

--- a/pos_spj_v13.4/backend/domain/services/__init__.py
+++ b/pos_spj_v13.4/backend/domain/services/__init__.py
@@ -1,0 +1,5 @@
+"""Domain services and policies."""
+
+from backend.domain.services.product_type_policy import ProductTypePolicy, ProductTypeRules
+
+__all__ = ["ProductTypePolicy", "ProductTypeRules"]

--- a/pos_spj_v13.4/backend/domain/services/product_type_policy.py
+++ b/pos_spj_v13.4/backend/domain/services/product_type_policy.py
@@ -1,0 +1,128 @@
+"""Product type policy rules for the catalog domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProductTypeRules:
+    code: str
+    label_es: str
+    is_sellable: bool
+    is_inventory_tracked: bool
+    allows_recipe: bool
+    allows_virtual_stock: bool
+    deducts_components_on_sale: bool
+    is_composite: bool = False
+    is_byproduct: bool = False
+    recipe_kind: str | None = None
+    help_es: str = ""
+
+
+class ProductTypePolicy:
+    """Centralized rules for product type behavior.
+
+    The UI keeps Spanish labels, while the backend persists canonical English-ish
+    lowercase codes used by services and future API endpoints.
+    """
+
+    _RULES: dict[str, ProductTypeRules] = {
+        "simple": ProductTypeRules(
+            code="simple",
+            label_es="Simple",
+            is_sellable=True,
+            is_inventory_tracked=True,
+            allows_recipe=False,
+            allows_virtual_stock=False,
+            deducts_components_on_sale=False,
+            help_es="Producto que se compra y vende directamente.",
+        ),
+        "compuesto": ProductTypeRules(
+            code="compuesto",
+            label_es="Compuesto",
+            is_sellable=True,
+            is_inventory_tracked=False,
+            allows_recipe=True,
+            allows_virtual_stock=True,
+            deducts_components_on_sale=True,
+            is_composite=True,
+            recipe_kind="COMBINACION",
+            help_es="Producto vendido como paquete/combo. Puede descontar componentes al venderse.",
+        ),
+        "procesable": ProductTypeRules(
+            code="procesable",
+            label_es="Procesable",
+            is_sellable=False,
+            is_inventory_tracked=True,
+            allows_recipe=True,
+            allows_virtual_stock=False,
+            deducts_components_on_sale=False,
+            recipe_kind="SUBPRODUCTO",
+            help_es="Producto que puede transformarse en subproductos. Ejemplo: pollo entero.",
+        ),
+        "subproducto": ProductTypeRules(
+            code="subproducto",
+            label_es="Subproducto",
+            is_sellable=True,
+            is_inventory_tracked=True,
+            allows_recipe=True,
+            allows_virtual_stock=False,
+            deducts_components_on_sale=False,
+            is_byproduct=True,
+            recipe_kind="SUBPRODUCTO",
+            help_es="Producto generado por un despiece o usado como componente de otros productos.",
+        ),
+        "producido": ProductTypeRules(
+            code="producido",
+            label_es="Producido",
+            is_sellable=True,
+            is_inventory_tracked=True,
+            allows_recipe=True,
+            allows_virtual_stock=False,
+            deducts_components_on_sale=False,
+            recipe_kind="PRODUCCION",
+            help_es="Producto elaborado a partir de insumos o subproductos.",
+        ),
+        "insumo": ProductTypeRules(
+            code="insumo",
+            label_es="Insumo",
+            is_sellable=False,
+            is_inventory_tracked=True,
+            allows_recipe=False,
+            allows_virtual_stock=False,
+            deducts_components_on_sale=False,
+            help_es="Producto usado como ingrediente/material.",
+        ),
+        "servicio": ProductTypeRules(
+            code="servicio",
+            label_es="Servicio",
+            is_sellable=True,
+            is_inventory_tracked=False,
+            allows_recipe=False,
+            allows_virtual_stock=False,
+            deducts_components_on_sale=False,
+            help_es="No controla inventario físico.",
+        ),
+    }
+    _SPANISH_TO_CODE = {rules.label_es.lower(): code for code, rules in _RULES.items()}
+
+    @classmethod
+    def normalize(cls, product_type: str | None) -> str:
+        value = (product_type or "simple").strip().lower()
+        value = cls._SPANISH_TO_CODE.get(value, value)
+        if value not in cls._RULES:
+            raise ValueError(f"Unsupported product type: {product_type}")
+        return value
+
+    @classmethod
+    def rules_for(cls, product_type: str | None) -> ProductTypeRules:
+        return cls._RULES[cls.normalize(product_type)]
+
+    @classmethod
+    def spanish_labels(cls) -> tuple[str, ...]:
+        return tuple(rules.label_es for rules in cls._RULES.values())
+
+    @classmethod
+    def recipe_allowed(cls, product_type: str | None) -> bool:
+        return cls.rules_for(product_type).allows_recipe

--- a/pos_spj_v13.4/backend/infrastructure/db/repositories/product_repository.py
+++ b/pos_spj_v13.4/backend/infrastructure/db/repositories/product_repository.py
@@ -1,0 +1,124 @@
+"""SQLite-backed repository for the product catalog canonical route."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+class ProductRepository:
+    """Owns product persistence details for catalog use cases."""
+
+    def __init__(self, connection: Any) -> None:
+        self._connection = connection
+        try:
+            import sqlite3
+            if getattr(self._connection, "row_factory", None) is None:
+                self._connection.row_factory = sqlite3.Row
+        except Exception:
+            pass
+
+    def get_by_id(self, product_id: int | str) -> dict[str, Any] | None:
+        row = self._connection.execute("SELECT * FROM productos WHERE id=?", (product_id,)).fetchone()
+        return dict(row) if row is not None else None
+
+    def list_categories(self) -> list[str]:
+        rows = self._connection.execute(
+            "SELECT DISTINCT categoria FROM productos WHERE categoria IS NOT NULL AND categoria!='' ORDER BY categoria"
+        ).fetchall()
+        return [str(row[0]) for row in rows]
+
+    def sku_exists(self, sku: str, *, exclude_product_id: int | str | None = None) -> dict[str, Any] | None:
+        if exclude_product_id:
+            row = self._connection.execute(
+                "SELECT id, nombre FROM productos WHERE codigo=? AND id!=?",
+                (sku, exclude_product_id),
+            ).fetchone()
+        else:
+            row = self._connection.execute("SELECT id, nombre FROM productos WHERE codigo=?", (sku,)).fetchone()
+        return dict(row) if row is not None else None
+
+    def active_name_duplicate(self, name: str, *, exclude_product_id: int | str | None = None) -> dict[str, Any] | None:
+        params: list[Any] = [name]
+        query = "SELECT id, codigo FROM productos WHERE LOWER(TRIM(nombre))=LOWER(TRIM(?)) AND COALESCE(activo,1)=1"
+        if exclude_product_id:
+            query += " AND id!=?"
+            params.append(exclude_product_id)
+        row = self._connection.execute(query, params).fetchone()
+        return dict(row) if row is not None else None
+
+    def has_active_recipe(self, product_id: int | str) -> bool:
+        try:
+            row = self._connection.execute(
+                "SELECT id FROM product_recipes WHERE base_product_id=? AND is_active=1",
+                (product_id,),
+            ).fetchone()
+        except Exception:
+            return False
+        return row is not None
+
+    def create(self, product_data: dict[str, Any]) -> str:
+        cursor = self._connection.execute(
+            """
+            INSERT INTO productos (
+                nombre, codigo, codigo_barras, categoria, precio, precio_compra,
+                precio_minimo_venta, unidad, stock_minimo, tipo_producto, es_compuesto,
+                es_subproducto, imagen_path, existencia, oculto, activo
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?)
+            """,
+            (
+                product_data["name"],
+                product_data["sku"],
+                product_data["barcode"],
+                product_data["category"],
+                product_data["sale_price"],
+                product_data["purchase_price"],
+                product_data["minimum_sale_price"],
+                product_data["unit"],
+                product_data["minimum_stock"],
+                product_data["product_type"],
+                product_data["is_composite"],
+                product_data["is_byproduct"],
+                product_data["image_path"],
+                1 if product_data["active"] else 0,
+            ),
+        )
+        return str(cursor.lastrowid)
+
+    def update(self, product_id: int | str, product_data: dict[str, Any]) -> str:
+        updated_at = datetime.now(timezone.utc).isoformat()
+        self._connection.execute(
+            """
+            UPDATE productos SET
+                nombre=?, codigo=?, codigo_barras=?, categoria=?, precio=?, precio_compra=?,
+                precio_minimo_venta=?, unidad=?, stock_minimo=?, tipo_producto=?,
+                es_compuesto=?, es_subproducto=?, activo=?, imagen_path=?,
+                ultima_actualizacion=?
+            WHERE id=?
+            """,
+            (
+                product_data["name"],
+                product_data["sku"],
+                product_data["barcode"],
+                product_data["category"],
+                product_data["sale_price"],
+                product_data["purchase_price"],
+                product_data["minimum_sale_price"],
+                product_data["unit"],
+                product_data["minimum_stock"],
+                product_data["product_type"],
+                product_data["is_composite"],
+                product_data["is_byproduct"],
+                1 if product_data["active"] else 0,
+                product_data["image_path"],
+                updated_at,
+                product_id,
+            ),
+        )
+        return str(product_id)
+
+    def save_changes(self) -> None:
+        self._connection.commit()
+
+    def rollback_changes(self) -> None:
+        self._connection.rollback()

--- a/pos_spj_v13.4/modulos/dialogs/receta_dialog.py
+++ b/pos_spj_v13.4/modulos/dialogs/receta_dialog.py
@@ -22,12 +22,69 @@ from PyQt5.QtCore import Qt
 from modulos.ui_components import (
     create_primary_button, create_success_button, create_secondary_button,
 )
+from frontend.desktop.components.search_selector import SearchOption, SearchSelector
 from repositories.recetas import (
     RecetaError, RecetaCyclicError, RecetaSelfReferenceError,
     RecetaPercentageError, RecetaDuplicadaError,
 )
 
 logger = logging.getLogger("spj.ui.dialogs.receta")
+
+
+class _RecipeProductSelector(SearchSelector):
+    """SearchSelector adapter for recipe product selection."""
+
+    def __init__(self, productos: List[Dict], parent=None, *, placeholder: str) -> None:
+        self._productos = productos
+        self._selected_id = None
+        self._selected_label = ""
+        super().__init__(parent, provider=self._provide, placeholder=placeholder)
+        self.selected.connect(self._on_selected)
+
+    def _provide(self, query: str):
+        text = (query or "").strip().lower()
+        matches = []
+        for product in self._productos:
+            label = str(product.get("nombre") or "")
+            code = str(product.get("codigo") or "")
+            if text and text not in label.lower() and text not in code.lower():
+                continue
+            matches.append(SearchOption(
+                id=str(product.get("id")),
+                label=label,
+                subtitle=str(product.get("unidad") or "kg"),
+            ))
+            if len(matches) >= 50:
+                break
+        return matches
+
+    def _on_selected(self, option: SearchOption) -> None:
+        self._selected_id = int(option.id) if str(option.id).isdigit() else option.id
+        self._selected_label = option.label
+        self.set_selected_label(option.label)
+
+    def currentData(self):
+        return self._selected_id
+
+    def currentText(self):
+        return self._selected_label
+
+    def findData(self, value):
+        for index, product in enumerate(self._productos):
+            if product.get("id") == value:
+                return index
+        return -1
+
+    def setCurrentIndex(self, index: int) -> None:
+        if index < 0 or index >= len(self._productos):
+            return
+        product = self._productos[index]
+        self._selected_id = product.get("id")
+        self._selected_label = str(product.get("nombre") or "")
+        self.set_selected_label(self._selected_label)
+
+    def addItem(self, *_args, **_kwargs) -> None:
+        return
 
 
 class DialogoReceta(QDialog):
@@ -69,12 +126,9 @@ class DialogoReceta(QDialog):
         self._e_nombre = QLineEdit()
         self._e_nombre.setPlaceholderText("Nombre de la receta…")
 
-        self._combo_base = QComboBox()
-        self._combo_base.addItem("— Seleccionar producto base —", None)
-        for p in self._productos:
-            self._combo_base.addItem(
-                f"{p['nombre']} [{p.get('unidad', 'kg')}]", p["id"]
-            )
+        self._combo_base = _RecipeProductSelector(
+            self._productos, self, placeholder="Buscar producto base…"
+        )
 
         self._combo_tipo_receta = QComboBox()
         self._combo_tipo_receta.addItem("SUBPRODUCTO — Para productos procesables", "SUBPRODUCTO")
@@ -105,10 +159,9 @@ class DialogoReceta(QDialog):
 
         # Add-component row
         add_row = QHBoxLayout()
-        self._combo_comp = QComboBox()
-        self._combo_comp.addItem("— Componente —", None)
-        for p in self._productos:
-            self._combo_comp.addItem(p["nombre"], p["id"])
+        self._combo_comp = _RecipeProductSelector(
+            self._productos, self, placeholder="Buscar componente…"
+        )
 
         self._spin_rend = QDoubleSpinBox()
         self._spin_rend.setRange(0, 100); self._spin_rend.setDecimals(3); self._spin_rend.setSuffix(" %")

--- a/pos_spj_v13.4/modulos/productos.py
+++ b/pos_spj_v13.4/modulos/productos.py
@@ -11,6 +11,7 @@ from modulos.ui_components import (
 import os
 import shutil
 from datetime import datetime
+from uuid import uuid4
 from modulos.spj_refresh_mixin import RefreshMixin
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit,
@@ -31,6 +32,13 @@ from modulos.dialogs.receta_dialog import DialogoReceta
 from core.services.recipes.recipe_service import RecipeService
 from modulos.kpi_card import KPICard
 from core.services.product_catalog_query_service import get_product_configuration_kpis, get_catalog_filter_ids
+from backend.application.commands.product_commands import CreateProductCommand, UpdateProductCommand
+from backend.application.queries.product_query_service import ProductQueryService
+from backend.application.services.product_catalog_service import ProductCatalogService
+from backend.application.use_cases.create_product_use_case import CreateProductUseCase
+from backend.application.use_cases.update_product_use_case import UpdateProductUseCase
+from backend.domain.services.product_type_policy import ProductTypePolicy
+from backend.infrastructure.db.repositories.product_repository import ProductRepository
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +55,12 @@ class DialogoProducto(QDialog):
         self.container = container
         self.producto_id = producto_id
         self.ruta_imagen_actual = None
+        self.db = container.db if hasattr(container, 'db') else container
+        self.product_query_service = ProductQueryService.from_connection(self.db)
+        product_repository = ProductRepository(self.db)
+        product_service = ProductCatalogService(repository=product_repository)
+        self.create_product_use_case = CreateProductUseCase(app_service=product_service)
+        self.update_product_use_case = UpdateProductUseCase(app_service=product_service)
         
         self.setWindowTitle("Nuevo Producto" if not producto_id else f"Editar Producto #{producto_id}")
         self.setMinimumSize(650, 500)
@@ -89,7 +103,8 @@ class DialogoProducto(QDialog):
         # ================= CAMPOS BASE =================
         
         self.cmb_tipo = QComboBox()
-        self.cmb_tipo.addItems(["Simple", "Compuesto", "Procesable", "Subproducto", "Producido", "Insumo", "Servicio"])
+        for label in self.product_query_service.type_labels_es():
+            self.cmb_tipo.addItem(label)
         self.cmb_tipo.currentTextChanged.connect(self.al_cambiar_tipo)
         
         self.txt_nombre = QLineEdit()
@@ -246,25 +261,23 @@ class DialogoProducto(QDialog):
         self._actualizar_hint_tipo(tipo)
 
     def _actualizar_hint_tipo(self, tipo: str):
-        hints = {
-            "Simple": "Producto que se compra y vende directamente.",
-            "Compuesto": "Producto vendido como paquete/combo. Puede descontar componentes al venderse.",
-            "Procesable": "Producto que puede transformarse en subproductos. Ejemplo: pollo entero.",
-            "Subproducto": "Producto generado por un despiece o usado como componente de otros productos.",
-            "Producido": "Producto elaborado a partir de insumos o subproductos.",
-            "Insumo": "Producto usado como ingrediente/material.",
-            "Servicio": "No controla inventario físico.",
-        }
         if hasattr(self, "lbl_tipo_help"):
-            self.lbl_tipo_help.setText(hints.get(tipo, ""))
+            self.lbl_tipo_help.setText(self.product_query_service.type_help_es(tipo))
+        if all(hasattr(self, name) for name in ("chk_se_vende", "chk_es_inventariable", "chk_permite_receta", "chk_permite_stock_virtual", "chk_descuenta_componentes")):
+            rules = self.product_query_service.type_rules(tipo)
+            self.chk_se_vende.setChecked(bool(rules["is_sellable"]))
+            self.chk_es_inventariable.setChecked(bool(rules["is_inventory_tracked"]))
+            self.chk_permite_receta.setChecked(bool(rules["allows_recipe"]))
+            self.chk_permite_stock_virtual.setChecked(bool(rules["allows_virtual_stock"]))
+            self.chk_descuenta_componentes.setChecked(bool(rules["deducts_components_on_sale"]))
 
     def cargar_categorias(self):
-        """Carga las categorías únicas existentes."""
+        """Carga las categorías únicas existentes mediante QueryService."""
         try:
-            cursor = self.container.db.cursor()
-            cats = cursor.execute("SELECT DISTINCT categoria FROM productos WHERE categoria IS NOT NULL").fetchall()
-            self.cmb_categoria.addItems([c[0] for c in cats])
-        except: pass
+            for category in self.product_query_service.list_categories():
+                self.cmb_categoria.addItem(category)
+        except Exception:
+            pass
 
     def cargar_imagen(self):
         """Abre el diálogo para seleccionar una imagen."""
@@ -294,215 +307,115 @@ class DialogoProducto(QDialog):
         self.lbl_imagen.setText("Sin Imagen")
 
     def cargar_datos_producto(self):
-        """Si estamos editando, carga los datos actuales del producto."""
+        """Si estamos editando, carga los datos actuales del producto mediante QueryService."""
         try:
-            cursor = self.container.db.cursor()
-            prod = cursor.execute("SELECT * FROM productos WHERE id = ?", (self.producto_id,)).fetchone()
-            if prod:
-                p = dict(prod)
+            p = self.product_query_service.get_product(self.producto_id)
+            if p:
                 self.txt_nombre.setText(p.get('nombre', ''))
                 self.txt_codigo.setText(p.get('codigo', ''))
                 self.txt_codigo_barras.setText(p.get('codigo_barras', ''))
                 self.cmb_categoria.setCurrentText(p.get('categoria', ''))
-                self.txt_precio.setValue(p.get('precio', 0.0))
-                self.txt_costo.setValue(p.get('precio_compra', 0.0) or p.get('costo', 0.0))
+                self.txt_precio.setValue(float(p.get('precio') or 0.0))
+                self.txt_costo.setValue(float(p.get('precio_compra') or p.get('costo') or 0.0))
                 self.cmb_unidad.setCurrentText(p.get('unidad', 'pza'))
                 self.cmb_unidad_venta.setCurrentText(p.get('unidad_venta', p.get('unidad', 'pza')))
                 self.cmb_unidad_compra.setCurrentText(p.get('unidad_compra', p.get('unidad', 'pza')))
                 self.cmb_estado.setCurrentText("Activo" if int(p.get('activo', 1) or 1) == 1 else "Inactivo")
-                self.txt_stock_minimo.setValue(p.get('stock_minimo', 0.0))
-                
-                tipo = p.get('tipo_producto', 'simple')
-                if p.get('es_compuesto'): tipo = "Compuesto"
-                if p.get('es_subproducto'): tipo = "Subproducto"
-                self.cmb_tipo.setCurrentText(tipo.capitalize())
+                self.txt_stock_minimo.setValue(float(p.get('stock_minimo') or 0.0))
+                if hasattr(self, "txt_precio_minimo"):
+                    self.txt_precio_minimo.setValue(float(p.get('precio_minimo_venta') or 0.0))
+
+                rules = ProductTypePolicy.rules_for(p.get('tipo_producto'))
+                self.cmb_tipo.setCurrentText(rules.label_es)
                 self._actualizar_hint_tipo(self.cmb_tipo.currentText())
 
-                existencia = p.get('existencia', 0.0) or 0.0
+                existencia = float(p.get('existencia') or 0.0)
                 self.lbl_stock_fisico.setText(f"Stock físico actual: {existencia:.3f} {self.cmb_unidad.currentText()}")
                 self.lbl_disponible_venta.setText(f"Disponible venta: {existencia:.3f} {self.cmb_unidad.currentText()}")
-                
+
                 self.ruta_imagen_actual = p.get('imagen_path')
                 self.mostrar_imagen_previa(self.ruta_imagen_actual)
         except Exception as e:
             logger.error(f"Error cargando producto {self.producto_id}: {e}")
 
     def _auto_calcular_precio_minimo(self) -> None:
-        """Auto-calcula el precio mínimo como costo × (1 + margen_objetivo%)."""
-        try:
-            costo = self.txt_costo.value()
-            if costo > 0 and hasattr(self, 'txt_precio_minimo'):
-                # Get margen_objetivo from DB or default to 30%
-                margen = 30.0
-                try:
-                    r = self.container.db.execute(
-                        "SELECT COALESCE(AVG(margen_objetivo_pct),30) FROM productos WHERE id=?",
-                        (self.producto_id or 0,)).fetchone()
-                    if r and r[0]: margen = float(r[0])
-                except Exception:
-                    pass
-                precio_min = round(costo * (1 + margen / 100), 2)
-                # Only auto-set if currently empty or lower than cost
-                current = self.txt_precio_minimo.value()
-                if current < costo:
-                    self.txt_precio_minimo.setValue(precio_min)
-        except Exception:
-            pass
+        """Reservado para SystemSettingsService; no aplica defaults numéricos arbitrarios."""
+        return
 
     def guardar_producto(self):
         nombre = self.txt_nombre.text().strip()
-        precio = self.txt_precio.value()
-        
         if not nombre:
             QMessageBox.warning(self, "Validación", "El nombre es obligatorio.")
             return
-            
-        tipo = self.cmb_tipo.currentText()
-        tipo_str = (tipo or "Simple").strip().lower()
-        es_compuesto = 1 if tipo_str == "compuesto" else 0
-        es_subproducto = 1 if tipo_str == "subproducto" else 0
 
-        # codigo_val must be defined before the if/else so both branches can use it
-        codigo_val = self.txt_codigo.text().strip() or None
+        duplicate = self.product_query_service.find_duplicate_name(
+            nombre, exclude_product_id=self.producto_id if self.producto_id else None
+        )
+        allow_duplicate_name = False
+        if duplicate:
+            resp = QMessageBox.question(
+                self, "⚠️ Producto similar existe",
+                f"Ya existe un producto activo con el nombre '{nombre}'\n"
+                f"(Código: {duplicate.get('codigo')}, ID: {duplicate.get('id')})\n\n"
+                "¿Deseas guardarlo de todas formas?",
+                QMessageBox.Yes | QMessageBox.No)
+            if resp != QMessageBox.Yes:
+                return
+            allow_duplicate_name = True
 
-        # v13.30: Auto-generar código único si está vacío
-        if not codigo_val:
-            import uuid as _uuid
-            codigo_val = f"P-{_uuid.uuid4().hex[:8].upper()}"
+        command_kwargs = dict(
+            operation_id=f"product-{uuid4()}",
+            branch_id=str(getattr(self.container, 'sucursal_id', 1)),
+            user_name=getattr(self, "usuario_actual", "Sistema") or "Sistema",
+            name=nombre,
+            sku=self.txt_codigo.text().strip() or None,
+            barcode=self.txt_codigo_barras.text().strip(),
+            category=self.cmb_categoria.currentText().strip(),
+            sale_price=self.txt_precio.value(),
+            purchase_price=self.txt_costo.value(),
+            minimum_sale_price=getattr(self, "txt_precio_minimo", type("x", (), {"value": lambda s: 0.0})()).value(),
+            unit=self.cmb_unidad.currentText(),
+            sale_unit=self.cmb_unidad_venta.currentText(),
+            purchase_unit=self.cmb_unidad_compra.currentText(),
+            minimum_stock=self.txt_stock_minimo.value(),
+            product_type=ProductTypePolicy.normalize(self.cmb_tipo.currentText()),
+            image_path=self.ruta_imagen_actual,
+            active=(self.cmb_estado.currentText() == "Activo"),
+            allow_duplicate_name=allow_duplicate_name,
+        )
+        command = (
+            UpdateProductCommand(product_id=self.producto_id, **command_kwargs)
+            if self.producto_id
+            else CreateProductCommand(**command_kwargs)
+        )
+        result = (
+            self.update_product_use_case.execute(command)
+            if self.producto_id
+            else self.create_product_use_case.execute(command)
+        )
+        if not result.success:
+            if result.message == "PRODUCT_SKU_DUPLICATE":
+                QMessageBox.warning(self, "Código duplicado", "El código capturado ya está en uso por otro producto.")
+                return
+            QMessageBox.critical(self, "No se pudo guardar", "No fue posible guardar el producto. Revise la información e intente nuevamente.")
+            return
 
-        try:
-            cursor = self.container.db.cursor()
-            if self.producto_id:
-                # UPDATE — check for duplicate codigo (excluding self)
-                if codigo_val:
-                    existing = cursor.execute(
-                        "SELECT id FROM productos WHERE codigo=? AND id!=?",
-                        (codigo_val, self.producto_id)
-                    ).fetchone()
-                    if existing:
-        # [spj-dedup removed local QMessageBox import]
-                        QMessageBox.warning(self, "Código duplicado",
-                            f"El código '{codigo_val}' ya está en uso por otro producto.")
-                        return
-                query = """
-                    UPDATE productos SET 
-                        nombre=?, codigo=?, codigo_barras=?, categoria=?, precio=?, precio_compra=?, precio_minimo_venta=?, 
-                        unidad=?, stock_minimo=?, tipo_producto=?, es_compuesto=?, es_subproducto=?, activo=?,
-                        imagen_path=?, ultima_actualizacion=datetime('now')
-                    WHERE id=?
-                """
-                cursor.execute(query, (
-                    nombre, codigo_val, self.txt_codigo_barras.text(), self.cmb_categoria.currentText(),
-                    precio, self.txt_costo.value(), getattr(self, "txt_precio_minimo", type("x", (), {"value": lambda s: 0})()).value(), self.cmb_unidad.currentText(), self.txt_stock_minimo.value(),
-                    tipo_str, es_compuesto, es_subproducto, (1 if self.cmb_estado.currentText() == "Activo" else 0), self.ruta_imagen_actual, self.producto_id
-                ))
-            else:
-                # INSERT
-                # v13.30: Verificar duplicado por código
-                existing = cursor.execute(
-                    "SELECT id, nombre FROM productos WHERE codigo=?", (codigo_val,)
-                ).fetchone()
-                if existing:
-                    QMessageBox.warning(
-                        self, "Código duplicado",
-                        f"El código '{codigo_val}' ya existe (Producto: {existing[1]}).\n"
-                        "Usa un código diferente o deja el campo vacío para autogenerar."
-                    )
-                    return
+        if result.data.get("recipe_pending"):
+            QMessageBox.information(
+                self, "Receta pendiente",
+                "El producto fue guardado con receta permitida.\n\n"
+                "⚠️  Aún no tiene una receta activa.\n"
+                "Administra la receta desde Productos > Receta antes de procesarlo en ventas o producción.")
 
-                # v13.30: Verificar duplicado por nombre (evitar productos repetidos)
-                dup_nombre = cursor.execute(
-                    "SELECT id, codigo FROM productos WHERE LOWER(TRIM(nombre))=LOWER(TRIM(?)) AND activo=1",
-                    (nombre,)
-                ).fetchone()
-                if dup_nombre:
-                    resp = QMessageBox.question(
-                        self, "⚠️ Producto similar existe",
-                        f"Ya existe un producto activo con el nombre '{nombre}'\n"
-                        f"(Código: {dup_nombre[1]}, ID: {dup_nombre[0]})\n\n"
-                        "¿Deseas guardarlo de todas formas?",
-                        QMessageBox.Yes | QMessageBox.No)
-                    if resp != QMessageBox.Yes:
-                        return
-
-                query = """
-                    INSERT INTO productos (
-                        nombre, codigo, codigo_barras, categoria, precio, precio_compra, 
-                        unidad, stock_minimo, tipo_producto, es_compuesto, es_subproducto, 
-                        imagen_path, existencia, oculto, activo
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
-                """
-                cursor.execute(query, (
-                    nombre, codigo_val, self.txt_codigo_barras.text().strip(), self.cmb_categoria.currentText(),
-                    precio, self.txt_costo.value(), self.cmb_unidad.currentText(), self.txt_stock_minimo.value(),
-                    tipo_str, es_compuesto, es_subproducto, self.ruta_imagen_actual
-                ))
-                
-            # ── Validate composite product has a recipe ──────────────────────────
-            if es_compuesto:
-                nuevo_id = self.producto_id
-                if not nuevo_id:
-                    row_id = cursor.execute("SELECT last_insert_rowid()").fetchone()
-                    nuevo_id = row_id[0] if row_id else None
-                if nuevo_id:
-                    rec = self.container.db.execute(
-                        "SELECT id FROM product_recipes WHERE base_product_id=? AND is_active=1",
-                        (nuevo_id,)).fetchone()
-                    if not rec:
-                        from PyQt5.QtWidgets import QMessageBox as _QMB
-                        _QMB.information(
-                            self, "Receta pendiente",
-                            "El producto fue guardado como compuesto.\n\n"
-                            "⚠️  Aún no tiene una receta activa.\n"
-                            "Administra la receta desde Productos > Receta "
-                            "antes de procesarlo en ventas o producción.")
-
-            self.container.db.commit()
-
-            # Registrar en Auditoría
-            if hasattr(self.container, 'audit_service'):
-                accion = "ACTUALIZAR_PRODUCTO" if self.producto_id else "CREAR_PRODUCTO"
-                self.container.audit_service.log_change(
-                    usuario="Sistema", accion=accion, modulo="PRODUCTOS",
-                    entidad="productos", entidad_id=str(self.producto_id)
-                )
-
-            # Publicar al EventBus — actualiza dashboard y sugerencias de forma reactiva
-            try:
-                from core.events.event_bus import get_bus
-                get_bus().publish(
-                    "PRODUCTO_MODIFICADO",
-                    {
-                        "producto_id": self.producto_id,
-                        "nombre": nombre,
-                        "precio": precio,
-                        "sucursal_id": getattr(self.container, 'sucursal_id', 1),
-                        "accion": "actualizar" if self.producto_id else "crear",
-                    }
-                )
-            except Exception:
-                pass  # EventBus opcional — no bloquea el guardado
-
-            # EventBus: notificar cambio de producto
-            try:
-                from core.events.event_bus import get_bus, PRODUCTO_ACTUALIZADO, PRODUCTO_CREADO
-                evento = PRODUCTO_ACTUALIZADO if self.producto_id else PRODUCTO_CREADO
-                get_bus().publish(evento, {
-                    "producto_id": self.producto_id,
-                    "nombre":      nombre,
-                    "precio":      precio,
-                }, async_=True)
-            except Exception: pass
-
-            self.accept()
-    
-        except Exception as e:
-            self.container.db.rollback()
-            logger.exception("productos.guardar")
-            QMessageBox.critical(
-                self, "No se pudo guardar",
-                "No fue posible guardar el producto. Revise la información e intente nuevamente."
+        if hasattr(self.container, 'audit_service'):
+            accion = "ACTUALIZAR_PRODUCTO" if self.producto_id else "CREAR_PRODUCTO"
+            self.container.audit_service.log_change(
+                usuario="Sistema", accion=accion, modulo="PRODUCTOS",
+                entidad="productos", entidad_id=str(result.entity_id)
             )
+
+        self.producto_id = int(result.entity_id) if result.entity_id and str(result.entity_id).isdigit() else self.producto_id
+        self.accept()
 
 # ==============================================================================
 # MODULO PRINCIPAL (Centro de Productos y Producción)
@@ -520,6 +433,7 @@ class ModuloProductos(QWidget, RefreshMixin):
         self.container = container # 🧠 Recibimos el Cerebro
         # Extraemos la db para mantener compatibilidad si algo lo requiere
         self.conexion = container.db if hasattr(container, 'db') else container
+        self.product_query_service = ProductQueryService.from_connection(self.conexion)
         self.sucursal_id = 1
         self.usuario_actual = ""
 
@@ -653,12 +567,8 @@ class ModuloProductos(QWidget, RefreshMixin):
         self.cmb_filtro_cat.setMinimumWidth(140)
         self.cmb_filtro_cat.currentIndexChanged.connect(self.cargar_catalogo)
         try:
-            db = self.container.db if hasattr(self.container, 'db') else self.conexion
-            cats = db.execute(
-                "SELECT DISTINCT categoria FROM productos WHERE categoria IS NOT NULL AND categoria!='' ORDER BY categoria"
-            ).fetchall()
-            for r in cats:
-                self.cmb_filtro_cat.addItem(r[0])
+            for category in self.product_query_service.list_categories():
+                self.cmb_filtro_cat.addItem(category)
         except Exception:
             pass
 
@@ -771,9 +681,10 @@ class ModuloProductos(QWidget, RefreshMixin):
             return None
         try:
             pid = int(self.tabla_productos.item(row, 0).text())
-            db = self.container.db if hasattr(self.container, 'db') else self.conexion
-            r = db.execute("SELECT id,nombre,tipo_producto FROM productos WHERE id=?", (pid,)).fetchone()
-            return dict(r) if r else None
+            p = self.product_query_service.get_product(pid)
+            if not p:
+                return None
+            return {"id": p.get("id"), "nombre": p.get("nombre"), "tipo_producto": p.get("tipo_producto")}
         except Exception:
             return None
 
@@ -932,54 +843,26 @@ class ModuloProductos(QWidget, RefreshMixin):
     def cargar_catalogo(self):
         if hasattr(self, "_loading_catalogo"):
             self._loading_catalogo.show()
-        # Ensure codigo_barras column exists on any existing DB
-        try:
-            db = self.container.db if hasattr(self.container, 'db') else self.conexion
-            db.execute("ALTER TABLE productos ADD COLUMN codigo_barras TEXT DEFAULT ''")
-            try: db.commit()
-            except Exception: pass
-        except Exception: pass
 
         busqueda = self.txt_buscar_prod.text().strip()
 
-        # v13.30: Leer filtros
         filtro_cat = ""
         if hasattr(self, 'cmb_filtro_cat'):
             cat_text = self.cmb_filtro_cat.currentText()
             if not cat_text.startswith("📁"):
                 filtro_cat = cat_text
 
-        filtro_estado = 0  # 0=activos, 1=eliminados, 2=todos
+        filtro_estado = "active"
         if hasattr(self, 'cmb_filtro_estado'):
-            filtro_estado = self.cmb_filtro_estado.currentIndex()
+            filtro_estado = {0: "active", 1: "deleted", 2: "all"}.get(self.cmb_filtro_estado.currentIndex(), "active")
 
         try:
-            query = ("SELECT id, codigo, COALESCE(codigo_barras,'') as codigo_barras, "
-                     "nombre, categoria, precio, existencia, COALESCE(activo,1) as activo "
-                     "FROM productos WHERE 1=1")
-            params = []
-
-            # Filtro estado
-            if filtro_estado == 0:
-                query += " AND COALESCE(activo,1)=1"
-            elif filtro_estado == 1:
-                query += " AND COALESCE(activo,1)=0"
-            # else: todos
-
-            # Filtro categoría
-            if filtro_cat:
-                query += " AND categoria=?"
-                params.append(filtro_cat)
-
-            # Búsqueda texto
-            if busqueda:
-                query += " AND (nombre LIKE ? OR codigo LIKE ? OR COALESCE(codigo_barras,'') LIKE ?)"
-                params.extend([f'%{busqueda}%', f'%{busqueda}%', f'%{busqueda}%'])
-
-            query += " ORDER BY activo DESC, nombre ASC LIMIT 1000"
-
-            cursor = self.container.db.cursor() if hasattr(self.container, 'db') else self.conexion.cursor()
-            rows = cursor.execute(query, params).fetchall()
+            table_rows = self.product_query_service.list_for_table({
+                "query": busqueda,
+                "category": filtro_cat,
+                "state": filtro_estado,
+            })
+            rows = [row.values for row in table_rows]
             db = self.container.db if hasattr(self.container, 'db') else self.conexion
             kpi_mode = getattr(self, "_kpi_filter_mode", "all")
             if kpi_mode in {"sin_tipo", "receta_pendiente", "sin_costo"}:
@@ -993,31 +876,24 @@ class ModuloProductos(QWidget, RefreshMixin):
             for row_idx, row_data in enumerate(rows):
                 self.tabla_productos.insertRow(row_idx)
                 prod_id = row_data['id']
-                activo = int(row_data['activo']) if 'activo' in row_data.keys() else 1
+                activo = int(row_data.get('activo', 1) or 1)
                 is_deleted = not activo
 
-                # Color de fondo para productos eliminados
                 bg_color = _QC(Colors.DANGER.BG_SOFT) if is_deleted else None
 
                 self.tabla_productos.setItem(row_idx, 0, QTableWidgetItem(str(prod_id)))
-                self.tabla_productos.setItem(row_idx, 1, QTableWidgetItem(str(row_data['codigo'] or '')))
-                self.tabla_productos.setItem(row_idx, 2, QTableWidgetItem(
-                    str(row_data['codigo_barras'] if 'codigo_barras' in row_data.keys() else '')))
-                self.tabla_productos.setItem(row_idx, 3, QTableWidgetItem(str(row_data['nombre'])))
-                self.tabla_productos.setItem(row_idx, 4, QTableWidgetItem(str(row_data['categoria'] or '')))
-                self.tabla_productos.setItem(row_idx, 5, QTableWidgetItem(f"${row_data['precio']:.2f}"))
-                self.tabla_productos.setItem(row_idx, 6, QTableWidgetItem(f"{row_data['existencia']:.3f}"))
+                self.tabla_productos.setItem(row_idx, 1, QTableWidgetItem(str(row_data.get('codigo') or '')))
+                self.tabla_productos.setItem(row_idx, 2, QTableWidgetItem(str(row_data.get('codigo_barras') or '')))
+                self.tabla_productos.setItem(row_idx, 3, QTableWidgetItem(str(row_data.get('nombre') or '')))
+                self.tabla_productos.setItem(row_idx, 4, QTableWidgetItem(str(row_data.get('categoria') or '')))
+                self.tabla_productos.setItem(row_idx, 5, QTableWidgetItem(f"${float(row_data.get('precio') or 0):.2f}"))
+                self.tabla_productos.setItem(row_idx, 6, QTableWidgetItem(f"{float(row_data.get('existencia') or 0):.3f}"))
 
-                # v13.30: Estado con color y texto claro
                 estado_txt = "✅ Activo" if activo else "❌ Eliminado"
                 estado_item = QTableWidgetItem(estado_txt)
-                if is_deleted:
-                    estado_item.setForeground(_QC(Colors.DANGER_HOVER))
-                else:
-                    estado_item.setForeground(_QC(Colors.SUCCESS_BASE))
+                estado_item.setForeground(_QC(Colors.SUCCESS_BASE if activo else Colors.DANGER_HOVER))
                 self.tabla_productos.setItem(row_idx, 7, estado_item)
 
-                # v13.30: Colorear toda la fila si está eliminado
                 if bg_color:
                     for ci in range(8):
                         it = self.tabla_productos.item(row_idx, ci)
@@ -1025,7 +901,6 @@ class ModuloProductos(QWidget, RefreshMixin):
                             it.setBackground(bg_color)
                             it.setForeground(_QC(Colors.NEUTRAL.SLATE_400))
 
-                # ── Acciones ──────────────────────────────────────────────
                 _cell = _QW(); _lay = _HL(_cell)
                 _lay.setContentsMargins(2, 2, 2, 2); _lay.setSpacing(2)
 
@@ -1035,33 +910,27 @@ class ModuloProductos(QWidget, RefreshMixin):
                 _lay.addWidget(btn_editar)
 
                 if activo:
-                    # Producto activo: ocultar + eliminar
                     btn_toggle = create_table_button(self, "🙈", "Ocultar del POS", "warning")
                     btn_toggle.setFixedSize(28, 26)
-                    btn_toggle.clicked.connect(
-                        lambda _, pid=prod_id, a=activo: self._toggle_activo(pid, a))
+                    btn_toggle.clicked.connect(lambda _, pid=prod_id, a=activo: self._toggle_activo(pid, a))
                     _lay.addWidget(btn_toggle)
 
                     btn_del = create_table_button(self, "🗑️", "Eliminar (soft delete)", "danger")
                     btn_del.setFixedSize(28, 26)
-                    btn_del.clicked.connect(
-                        lambda _, pid=prod_id, nom=row_data['nombre']: self.eliminar_producto(pid, nom))
+                    btn_del.clicked.connect(lambda _, pid=prod_id, nom=row_data.get('nombre', ''): self.eliminar_producto(pid, nom))
                     _lay.addWidget(btn_del)
                 else:
                     btn_restaurar = create_table_button(self, "♻️", "Restaurar producto", "success")
                     btn_restaurar.setFixedSize(28, 26)
-                    btn_restaurar.clicked.connect(
-                        lambda _, pid=prod_id, nom=row_data['nombre']: self._restaurar_producto(pid, nom))
+                    btn_restaurar.clicked.connect(lambda _, pid=prod_id, nom=row_data.get('nombre', ''): self._restaurar_producto(pid, nom))
                     _lay.addWidget(btn_restaurar)
 
                 self.tabla_productos.setCellWidget(row_idx, 8, _cell)
 
-            # v13.30: Actualizar conteo
             if hasattr(self, 'lbl_conteo'):
                 total = len(rows)
-                activos = sum(1 for r in rows if int(r['activo'] if 'activo' in r.keys() else 1))
-                self.lbl_conteo.setText(
-                    f"Mostrando {total} productos ({activos} activos, {total - activos} eliminados)")
+                activos = sum(1 for r in rows if int(r.get('activo', 1) or 1))
+                self.lbl_conteo.setText(f"Mostrando {total} productos ({activos} activos, {total - activos} eliminados)")
             if hasattr(self, "_empty_catalogo"):
                 self._empty_catalogo.setVisible(len(rows) == 0)
             self._refresh_kpi_productos()

--- a/pos_spj_v13.4/tests/unit/test_product_catalog_refactor.py
+++ b/pos_spj_v13.4/tests/unit/test_product_catalog_refactor.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import sqlite3
+
+from backend.application.commands.product_commands import CreateProductCommand, UpdateProductCommand
+from backend.application.queries.product_query_service import ProductQueryService
+from backend.application.services.product_catalog_service import ProductCatalogService
+from backend.application.use_cases.create_product_use_case import CreateProductUseCase
+from backend.application.use_cases.update_product_use_case import UpdateProductUseCase
+from backend.domain.services.product_type_policy import ProductTypePolicy
+from backend.infrastructure.db.repositories.product_repository import ProductRepository
+from backend.shared.events.event_bus import InMemoryEventBus
+from backend.shared.events.event_names import EventName
+
+
+def _db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE productos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            nombre TEXT NOT NULL,
+            codigo TEXT,
+            codigo_barras TEXT,
+            categoria TEXT,
+            precio REAL DEFAULT 0,
+            precio_compra REAL DEFAULT 0,
+            precio_minimo_venta REAL DEFAULT 0,
+            unidad TEXT,
+            stock_minimo REAL DEFAULT 0,
+            tipo_producto TEXT,
+            es_compuesto INTEGER DEFAULT 0,
+            es_subproducto INTEGER DEFAULT 0,
+            imagen_path TEXT,
+            existencia REAL DEFAULT 0,
+            oculto INTEGER DEFAULT 0,
+            activo INTEGER DEFAULT 1,
+            ultima_actualizacion TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE product_recipes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            base_product_id INTEGER,
+            is_active INTEGER DEFAULT 1
+        )
+        """
+    )
+    return conn
+
+
+def _service(conn: sqlite3.Connection, bus: InMemoryEventBus | None = None) -> ProductCatalogService:
+    return ProductCatalogService(repository=ProductRepository(conn), event_bus=bus or InMemoryEventBus())
+
+
+def _create_command(**overrides):
+    data = dict(
+        operation_id="op-product-1",
+        branch_id="1",
+        user_name="ana",
+        name="Combo familiar",
+        sku="P-COMBO",
+        barcode="750000000001",
+        category="Paquetes",
+        sale_price=120.5,
+        purchase_price=80.0,
+        minimum_sale_price=90.0,
+        unit="pza",
+        minimum_stock=0.0,
+        product_type="Compuesto",
+    )
+    data.update(overrides)
+    return CreateProductCommand(**data)
+
+
+def test_product_type_policy_extracts_rules_for_required_types() -> None:
+    assert ProductTypePolicy.spanish_labels() == (
+        "Simple",
+        "Compuesto",
+        "Procesable",
+        "Subproducto",
+        "Producido",
+        "Insumo",
+        "Servicio",
+    )
+    assert ProductTypePolicy.rules_for("Compuesto").allows_recipe is True
+    assert ProductTypePolicy.rules_for("Compuesto").deducts_components_on_sale is True
+    assert ProductTypePolicy.rules_for("Servicio").is_inventory_tracked is False
+    assert ProductTypePolicy.rules_for("Subproducto").is_byproduct is True
+
+
+def test_create_product_use_case_persists_zero_inventory_and_emits_event() -> None:
+    conn = _db()
+    bus = InMemoryEventBus()
+    events = []
+    bus.subscribe(EventName.PRODUCT_CREATED, events.append)
+
+    result = CreateProductUseCase(app_service=_service(conn, bus)).execute(_create_command())
+
+    assert result.success is True
+    assert result.message == "PRODUCT_CREATED"
+    assert result.data["recipe_pending"] is True
+    row = conn.execute("SELECT * FROM productos WHERE id=?", (result.entity_id,)).fetchone()
+    assert row["nombre"] == "Combo familiar"
+    assert row["tipo_producto"] == "compuesto"
+    assert row["es_compuesto"] == 1
+    assert row["existencia"] == 0
+    assert len(events) == 1
+    assert events[0].operation_id == "op-product-1"
+    assert events[0].payload["recipe_pending"] is True
+
+
+def test_update_product_use_case_keeps_inventory_untouched() -> None:
+    conn = _db()
+    conn.execute(
+        """
+        INSERT INTO productos(nombre, codigo, categoria, precio, precio_compra, unidad, stock_minimo, tipo_producto, existencia, activo)
+        VALUES ('Harina', 'HAR', 'Insumos', 10, 4, 'kg', 0, 'insumo', 25, 1)
+        """
+    )
+    conn.commit()
+
+    command = UpdateProductCommand(
+        operation_id="op-update-product",
+        branch_id="1",
+        user_name="ana",
+        product_id=1,
+        name="Harina premium",
+        sku="HAR",
+        category="Insumos",
+        sale_price=11,
+        purchase_price=5,
+        unit="kg",
+        product_type="Insumo",
+    )
+    result = UpdateProductUseCase(app_service=_service(conn)).execute(command)
+
+    assert result.success is True
+    row = conn.execute("SELECT nombre, existencia, tipo_producto FROM productos WHERE id=1").fetchone()
+    assert row["nombre"] == "Harina premium"
+    assert row["existencia"] == 25
+    assert row["tipo_producto"] == "insumo"
+
+
+def test_product_query_service_supplies_search_and_categories_for_ui() -> None:
+    conn = _db()
+    conn.execute(
+        "INSERT INTO productos(nombre, codigo, categoria, precio, unidad, tipo_producto, activo) VALUES ('Arrachera', 'ARR', 'Carnes', 150, 'kg', 'simple', 1)"
+    )
+    conn.commit()
+
+    service = ProductQueryService.from_connection(conn)
+
+    assert service.list_categories() == ["Carnes"]
+    result = service.search_products("arr")
+    assert result[0].label == "Arrachera"
+    assert result[0].metadata["unit"] == "kg"


### PR DESCRIPTION
### Motivation
- Implement a canonical, English backend flow for Products while preserving Spanish UI and existing recipe logic. 
- Centralize product-type rules and product catalog mutations behind application services and use cases to avoid SQL and business mutations in the PyQt UI. 
- Provide QueryService-backed reads for UI autocompletes/search and replace long QComboBox mass-loading with `SearchSelector` for related-product selection. 

### Description
- Added `ProductCatalogService` with helpers for pricing, barcode/image normalization, duplicate checks, recipe-pending detection and event emission (`PRODUCT_CREATED` / `PRODUCT_UPDATED`). 
- Added `ProductTypePolicy` to centralize rules for types: Simple, Compuesto, Procesable, Subproducto, Producido, Insumo and Servicio, and exposed Spanish labels/help for the UI. 
- Added `ProductQueryService` (SQLite adapter) to serve product searches, table rows, categories and type metadata for the UI. 
- Introduced `CreateProductCommand` / `UpdateProductCommand`, `CreateProductUseCase` and `UpdateProductUseCase`, and a `ProductRepository` to own persistence (new files under `backend/...`). 
- Updated the Products UI (`modulos/productos.py`) to keep Spanish labels but read via `ProductQueryService` and perform create/update via the new use cases, and replaced recipe base/component combo boxes with `SearchSelector`-based selectors in `modulos/dialogs/receta_dialog.py`. 

### Testing
- Ran product-focused unit tests: `pytest pos_spj_v13.4/tests/unit/test_product_catalog_refactor.py` and related unit suites, which passed (product catalog unit tests passed). 
- Ran integration tests in `pos_spj_v13.4/tests/integration`, which passed for the product paths exercised. 
- Compiled modified modules with `python -m py_compile` to ensure syntax correctness. 
- Ran full architecture tests; the suite largely passed but a pre-existing architecture guard (SQL-in-UI allowlist) reported one increased violation in `modulos/ventas.py` (allowlist growth by 1), which appears unrelated to the product refactor. 
- Noted two failing unit tests in an unrelated inventory area that expect an older `InventoryApplicationService(db=...)` signature (existing integration/compatibility debt), and a local PyQt import smoke is blocked by missing system library `libGL.so.1` in the container; these are documented as known environment / pre-existing issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27131c43b08328aced80fcedc11ea2)