### PR TITLE
Bootstrap canonical refactor control files and architecture tests

### DIFF
--- a/pos_spj_v13.4/docs/refactor/CURRENT_MODULE.md
+++ b/pos_spj_v13.4/docs/refactor/CURRENT_MODULE.md
@@ -1,0 +1,54 @@
+# Módulo actual
+
+## Código
+
+```text
+UUIDV7_CUTOVER
+```
+
+## Nombre
+
+Corte global de identidad UUIDv7.
+
+## Estado
+
+```text
+PENDING
+```
+
+## Iteración
+
+```text
+0
+```
+
+## Objetivo
+
+Eliminar por completo:
+
+* IDs enteros funcionales;
+* PK y FK enteras;
+* `AUTOINCREMENT`;
+* `lastrowid`;
+* casts `int(..._id)`;
+* `legacy_id`;
+* escritura dual;
+* lectura dual;
+* fallback de identidad;
+* tablas paralelas.
+
+## Hallazgos abiertos
+
+Pendientes de auditoría inicial.
+
+## Tests requeridos
+
+Pendientes de auditoría inicial.
+
+## Bloqueos
+
+Ninguno registrado.
+
+## Próxima acción
+
+Ejecutar auditoría completa del esquema y contratos de identidad.

--- a/pos_spj_v13.4/docs/refactor/GLOBAL_VIOLATIONS.md
+++ b/pos_spj_v13.4/docs/refactor/GLOBAL_VIOLATIONS.md
@@ -1,0 +1,76 @@
+# Violaciones globales del refactor
+
+## Estado
+
+Pendiente de primera auditoría global.
+
+## Categorías obligatorias
+
+### Identidad UUIDv7
+
+- Pendiente.
+
+### SQL en UI
+
+- Pendiente.
+
+### Commit o rollback en UI
+
+- Pendiente.
+
+### Schema fuera de migrations
+
+- Pendiente.
+
+### Rutas duplicadas
+
+- Pendiente.
+
+### Fuentes duplicadas de verdad
+
+- Pendiente.
+
+### Defaults numéricos hardcodeados
+
+- Pendiente.
+
+### Estilos hardcodeados
+
+- Pendiente.
+
+### Excepciones silenciosas
+
+- Pendiente.
+
+### Código legacy
+
+- Pendiente.
+
+### Tests
+
+- Pendiente.
+
+## Formato de hallazgo
+
+Cada hallazgo debe registrar:
+
+```text
+ID:
+Severidad:
+Categoría:
+Módulo:
+Archivo:
+Línea:
+Descripción:
+Causa raíz:
+Test de protección:
+Estado:
+Iteración detectada:
+Iteración corregida:
+```
+
+## Regla
+
+No borrar hallazgos corregidos.
+
+Cambiar su estado a `RESOLVED` para conservar trazabilidad.

--- a/pos_spj_v13.4/docs/refactor/MASTER_REFACTOR_STATE.md
+++ b/pos_spj_v13.4/docs/refactor/MASTER_REFACTOR_STATE.md
@@ -1,0 +1,39 @@
+# Estado maestro del refactor SPJ
+
+## Estado global
+
+```text
+IN_PROGRESS
+```
+
+## Regla de cierre
+
+El proyecto solo puede pasar a `DONE` cuando:
+
+* todos los módulos estén en `DONE`;
+* no existan violaciones abiertas;
+* todos los tests pasen;
+* UUIDv7 sea la única identidad;
+* no exista código legacy funcional;
+* no existan rutas duplicadas;
+* la validación global esté completa.
+
+## Módulo actual
+
+```text
+UUIDV7_CUTOVER
+```
+
+## Última actualización
+
+Pendiente de primera ejecución.
+
+## Resumen
+
+| Módulo         | Estado  | Iteración | Violaciones | Tests fallidos |
+| -------------- | ------- | --------: | ----------: | -------------: |
+| UUIDV7_CUTOVER | PENDING |         0 |   Pendiente |      Pendiente |
+
+## Historial
+
+El historial debe agregarse de forma acumulativa. No borrar entradas anteriores.

--- a/pos_spj_v13.4/docs/refactor/MODULE_QUEUE.md
+++ b/pos_spj_v13.4/docs/refactor/MODULE_QUEUE.md
@@ -1,0 +1,65 @@
+# Cola maestra de módulos
+
+## Estados permitidos
+
+```text
+PENDING
+AUDIT
+PROTECTION
+IMPLEMENTATION
+LEGACY_REMOVAL
+INTEGRATION
+VALIDATION
+BLOCKED
+DONE
+```
+
+## Cola
+
+| Orden | Código                | Módulo                   | Estado  |
+| ----: | --------------------- | ------------------------ | ------- |
+|     0 | UUIDV7_CUTOVER        | Corte global UUIDv7      | PENDING |
+|     1 | CONFIGURACION         | Configuración            | PENDING |
+|     2 | MERMA                 | Merma                    | PENDING |
+|     3 | PRODUCTOS             | Productos                | PENDING |
+|     4 | INVENTARIO            | Inventario               | PENDING |
+|     5 | VENTAS                | Ventas                   | PENDING |
+|     6 | PROCESAMIENTO_CARNICO | Procesamiento cárnico    | PENDING |
+|     7 | RECETAS               | Recetas                  | PENDING |
+|     8 | PRODUCCION            | Producción               | PENDING |
+|     9 | TRANSFERENCIAS        | Transferencias           | PENDING |
+|    10 | COMPRAS               | Compras                  | PENDING |
+|    11 | RECEPCION             | Recepción                | PENDING |
+|    12 | PLANEACION_COMPRAS    | Planeación de compras    | PENDING |
+|    13 | COTIZACIONES          | Cotizaciones             | PENDING |
+|    14 | PEDIDOS               | Pedidos                  | PENDING |
+|    15 | DELIVERY              | Delivery                 | PENDING |
+|    16 | WHATSAPP              | WhatsApp                 | PENDING |
+|    17 | CLIENTES              | Clientes                 | PENDING |
+|    18 | PROVEEDORES           | Proveedores              | PENDING |
+|    19 | CAJA                  | Caja                     | PENDING |
+|    20 | FINANZAS              | Finanzas                 | PENDING |
+|    21 | CUENTAS_COBRAR        | Cuentas por cobrar       | PENDING |
+|    22 | CUENTAS_PAGAR         | Cuentas por pagar        | PENDING |
+|    23 | ACTIVOS               | Activos                  | PENDING |
+|    24 | MANTENIMIENTO         | Mantenimiento            | PENDING |
+|    25 | RRHH                  | Recursos humanos         | PENDING |
+|    26 | FIDELIDAD             | Fidelidad                | PENDING |
+|    27 | TARJETAS_FIDELIDAD    | Tarjetas de fidelidad    | PENDING |
+|    28 | PROMOCIONES           | Promociones              | PENDING |
+|    29 | TICKETS               | Tickets                  | PENDING |
+|    30 | ETIQUETAS             | Etiquetas                | PENDING |
+|    31 | HARDWARE              | Hardware                 | PENDING |
+|    32 | NOTIFICACIONES        | Notificaciones           | PENDING |
+|    33 | DASHBOARD             | Dashboard                | PENDING |
+|    34 | BI                    | Inteligencia de negocios | PENDING |
+|    35 | REPORTES              | Reportes                 | PENDING |
+|    36 | API                   | API FastAPI              | PENDING |
+|    37 | SINCRONIZACION        | Sincronización           | PENDING |
+|    38 | INSTALADOR            | Instalador               | PENDING |
+|    39 | ACTUALIZADOR          | Actualizador             | PENDING |
+|    40 | CIERRE_GLOBAL         | Cierre global            | PENDING |
+
+## Regla
+
+Codex selecciona siempre el primer módulo que no esté en `DONE`, salvo que una dependencia documentada obligue a reordenar temporalmente la cola.

--- a/pos_spj_v13.4/docs/refactor/UUIDV7_CUTOVER_REPORT.md
+++ b/pos_spj_v13.4/docs/refactor/UUIDV7_CUTOVER_REPORT.md
@@ -1,0 +1,73 @@
+# Reporte de corte global UUIDv7
+
+## Estado
+
+```text
+PENDING
+```
+
+## Alcance
+
+* Tablas.
+* PK.
+* FK.
+* Commands.
+* DTO.
+* Use Cases.
+* Application Services.
+* Query Services.
+* Repositories.
+* Eventos.
+* Outbox.
+* API.
+* PyQt.
+* Tests.
+* Fixtures.
+* Seeds.
+* Scripts.
+* Sincronización.
+
+## Inventario inicial
+
+Pendiente.
+
+## Grafo PK/FK
+
+Pendiente.
+
+## Tablas migradas
+
+Pendiente.
+
+## Contratos migrados
+
+Pendiente.
+
+## Violaciones eliminadas
+
+Pendiente.
+
+## Validaciones
+
+```text
+[ ] Backup verificado.
+[ ] Migración atómica ejecutada.
+[ ] Conteos pre/post coinciden.
+[ ] PRAGMA foreign_key_check sin errores.
+[ ] PRAGMA integrity_check = ok.
+[ ] Cero PK funcionales enteras.
+[ ] Cero FK funcionales enteras.
+[ ] Cero AUTOINCREMENT funcional.
+[ ] Cero lastrowid funcional.
+[ ] Cero casts int(..._id).
+[ ] Cero legacy_id.
+[ ] Cero escritura dual.
+[ ] Cero fallback.
+[ ] Tests UUIDv7 aprobados.
+```
+
+## Resultado
+
+```text
+NOT DONE
+```

--- a/pos_spj_v13.4/docs/refactor/modules/README.md
+++ b/pos_spj_v13.4/docs/refactor/modules/README.md
@@ -1,0 +1,38 @@
+# Reportes por módulo
+
+Cada módulo debe tener un reporte acumulativo:
+
+```text
+modules/<codigo_modulo>.md
+```
+
+Ejemplos:
+
+```text
+modules/productos.md
+modules/inventario.md
+modules/ventas.md
+```
+
+No crear un reporte diferente para cada iteración.
+
+Cada iteración se agrega al mismo archivo para conservar historial.
+
+## Formato mínimo
+
+```text
+Módulo
+Estado
+Iteración
+Hallazgos
+Causas raíz
+Tests agregados
+Archivos creados
+Archivos modificados
+Archivos eliminados
+Migraciones
+Validación manual
+Regresiones
+Violaciones restantes
+Siguiente estado
+```

--- a/pos_spj_v13.4/docs/refactor/refactor_state.json
+++ b/pos_spj_v13.4/docs/refactor/refactor_state.json
@@ -1,0 +1,338 @@
+{
+  "schema_version": 1,
+  "skill_version": "uuidv7-strict",
+  "global_status": "IN_PROGRESS",
+  "current_module": "UUIDV7_CUTOVER",
+  "global_iteration": 0,
+  "last_completed_module": null,
+  "modules": {
+    "UUIDV7_CUTOVER": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/UUIDV7_CUTOVER_REPORT.md"
+    },
+    "CONFIGURACION": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/configuracion.md"
+    },
+    "MERMA": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/merma.md"
+    },
+    "PRODUCTOS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/productos.md"
+    },
+    "INVENTARIO": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/inventario.md"
+    },
+    "VENTAS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/ventas.md"
+    },
+    "PROCESAMIENTO_CARNICO": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/procesamiento_carnico.md"
+    },
+    "RECETAS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/recetas.md"
+    },
+    "PRODUCCION": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/produccion.md"
+    },
+    "TRANSFERENCIAS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/transferencias.md"
+    },
+    "COMPRAS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/compras.md"
+    },
+    "RECEPCION": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/recepcion.md"
+    },
+    "PLANEACION_COMPRAS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/planeacion_compras.md"
+    },
+    "COTIZACIONES": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/cotizaciones.md"
+    },
+    "PEDIDOS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/pedidos.md"
+    },
+    "DELIVERY": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/delivery.md"
+    },
+    "WHATSAPP": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/whatsapp.md"
+    },
+    "CLIENTES": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/clientes.md"
+    },
+    "PROVEEDORES": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/proveedores.md"
+    },
+    "CAJA": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/caja.md"
+    },
+    "FINANZAS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/finanzas.md"
+    },
+    "CUENTAS_COBRAR": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/cuentas_cobrar.md"
+    },
+    "CUENTAS_PAGAR": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/cuentas_pagar.md"
+    },
+    "ACTIVOS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/activos.md"
+    },
+    "MANTENIMIENTO": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/mantenimiento.md"
+    },
+    "RRHH": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/rrhh.md"
+    },
+    "FIDELIDAD": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/fidelidad.md"
+    },
+    "TARJETAS_FIDELIDAD": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/tarjetas_fidelidad.md"
+    },
+    "PROMOCIONES": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/promociones.md"
+    },
+    "TICKETS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/tickets.md"
+    },
+    "ETIQUETAS": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/etiquetas.md"
+    },
+    "HARDWARE": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/hardware.md"
+    },
+    "NOTIFICACIONES": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/notificaciones.md"
+    },
+    "DASHBOARD": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/dashboard.md"
+    },
+    "BI": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/bi.md"
+    },
+    "REPORTES": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/reportes.md"
+    },
+    "API": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/api.md"
+    },
+    "SINCRONIZACION": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/sincronizacion.md"
+    },
+    "INSTALADOR": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/instalador.md"
+    },
+    "ACTUALIZADOR": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/actualizador.md"
+    },
+    "CIERRE_GLOBAL": {
+      "status": "PENDING",
+      "iteration": 0,
+      "score": 0,
+      "open_violations": null,
+      "tests_failed": null,
+      "report": "docs/refactor/modules/cierre_global.md"
+    }
+  }
+}

--- a/pos_spj_v13.4/tests/architecture/refactor_control_helpers.py
+++ b/pos_spj_v13.4/tests/architecture/refactor_control_helpers.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = PACKAGE_ROOT.parent
+REFACTOR_DIR = PACKAGE_ROOT / "docs" / "refactor"
+MODULES_DIR = REFACTOR_DIR / "modules"
+CONTROL_FILE_NAMES = {
+    "MASTER_REFACTOR_STATE.md",
+    "MODULE_QUEUE.md",
+    "CURRENT_MODULE.md",
+    "GLOBAL_VIOLATIONS.md",
+    "UUIDV7_CUTOVER_REPORT.md",
+    "refactor_state.json",
+}
+REQUIRED_CONTROL_PATHS = [
+    REFACTOR_DIR / "MASTER_REFACTOR_STATE.md",
+    REFACTOR_DIR / "MODULE_QUEUE.md",
+    REFACTOR_DIR / "CURRENT_MODULE.md",
+    REFACTOR_DIR / "GLOBAL_VIOLATIONS.md",
+    REFACTOR_DIR / "UUIDV7_CUTOVER_REPORT.md",
+    REFACTOR_DIR / "refactor_state.json",
+    MODULES_DIR / "README.md",
+]
+ALLOWED_STATES = {
+    "PENDING",
+    "AUDIT",
+    "PROTECTION",
+    "IMPLEMENTATION",
+    "LEGACY_REMOVAL",
+    "INTEGRATION",
+    "VALIDATION",
+    "BLOCKED",
+    "DONE",
+}
+
+
+def load_refactor_state() -> dict:
+    return json.loads((REFACTOR_DIR / "refactor_state.json").read_text(encoding="utf-8"))
+
+
+def parse_queue_modules() -> dict[str, str]:
+    content = (REFACTOR_DIR / "MODULE_QUEUE.md").read_text(encoding="utf-8")
+    rows: dict[str, str] = {}
+    for line in content.splitlines():
+        match = re.match(r"^\|\s*\d+\s*\|\s*([A-Z0-9_]+)\s*\|.*\|\s*([A-Z_]+)\s*\|$", line)
+        if match:
+            rows[match.group(1)] = match.group(2)
+    return rows
+
+
+def parse_current_module_code() -> str:
+    content = (REFACTOR_DIR / "CURRENT_MODULE.md").read_text(encoding="utf-8")
+    match = re.search(r"## Código\s*\n\s*```text\s*\n([^\n]+)\n```", content)
+    assert match, "CURRENT_MODULE.md must include a Código fenced text block"
+    return match.group(1).strip()

--- a/pos_spj_v13.4/tests/architecture/test_current_module_matches_state.py
+++ b/pos_spj_v13.4/tests/architecture/test_current_module_matches_state.py
@@ -1,0 +1,15 @@
+from .refactor_control_helpers import load_refactor_state, parse_current_module_code, parse_queue_modules
+
+
+def test_current_module_matches_json_state_and_queue():
+    state = load_refactor_state()
+    current_from_markdown = parse_current_module_code()
+    assert current_from_markdown == state["current_module"]
+    assert current_from_markdown in parse_queue_modules()
+
+
+def test_exactly_one_current_module_is_defined():
+    state = load_refactor_state()
+    current = state.get("current_module")
+    assert isinstance(current, str) and current
+    assert list(state["modules"]).count(current) == 1

--- a/pos_spj_v13.4/tests/architecture/test_module_queue_is_complete.py
+++ b/pos_spj_v13.4/tests/architecture/test_module_queue_is_complete.py
@@ -1,0 +1,15 @@
+from .refactor_control_helpers import ALLOWED_STATES, load_refactor_state, parse_queue_modules
+
+
+def test_module_queue_is_complete_in_refactor_state():
+    queue_modules = parse_queue_modules()
+    state_modules = load_refactor_state()["modules"]
+    missing = sorted(set(queue_modules) - set(state_modules))
+    extra = sorted(set(state_modules) - set(queue_modules))
+    assert not missing
+    assert not extra
+
+
+def test_module_queue_uses_only_allowed_states():
+    invalid = {code: status for code, status in parse_queue_modules().items() if status not in ALLOWED_STATES}
+    assert not invalid

--- a/pos_spj_v13.4/tests/architecture/test_refactor_control_files_exist.py
+++ b/pos_spj_v13.4/tests/architecture/test_refactor_control_files_exist.py
@@ -1,0 +1,8 @@
+from .refactor_control_helpers import MODULES_DIR, REQUIRED_CONTROL_PATHS, REFACTOR_DIR
+
+
+def test_refactor_control_files_exist_in_canonical_tree():
+    missing = [str(path) for path in REQUIRED_CONTROL_PATHS if not path.is_file()]
+    assert not missing
+    assert REFACTOR_DIR.is_dir()
+    assert MODULES_DIR.is_dir()

--- a/pos_spj_v13.4/tests/architecture/test_refactor_files_inside_package.py
+++ b/pos_spj_v13.4/tests/architecture/test_refactor_files_inside_package.py
@@ -1,0 +1,14 @@
+from .refactor_control_helpers import CONTROL_FILE_NAMES, PACKAGE_ROOT, REFACTOR_DIR, REPO_ROOT, REQUIRED_CONTROL_PATHS
+
+
+def test_refactor_control_files_are_inside_package_refactor_dir():
+    for path in REQUIRED_CONTROL_PATHS:
+        resolved = path.resolve()
+        assert resolved.is_relative_to(REFACTOR_DIR.resolve())
+        assert resolved.is_relative_to(PACKAGE_ROOT.resolve())
+
+
+def test_no_refactor_control_file_copies_exist_in_external_repo_root():
+    forbidden = [REPO_ROOT / name for name in CONTROL_FILE_NAMES]
+    existing = [str(path) for path in forbidden if path.exists()]
+    assert not existing

--- a/pos_spj_v13.4/tests/architecture/test_refactor_state_json_is_valid.py
+++ b/pos_spj_v13.4/tests/architecture/test_refactor_state_json_is_valid.py
@@ -1,0 +1,30 @@
+from .refactor_control_helpers import ALLOWED_STATES, REFACTOR_DIR, load_refactor_state
+
+
+def test_refactor_state_json_is_valid_and_uses_allowed_states():
+    state = load_refactor_state()
+    assert state["global_status"] in {"IN_PROGRESS", "DONE", "BLOCKED"}
+    assert state["current_module"] in state["modules"]
+    invalid = {
+        code: module.get("status")
+        for code, module in state["modules"].items()
+        if module.get("status") not in ALLOWED_STATES
+    }
+    assert not invalid
+
+
+def test_done_modules_are_complete():
+    state = load_refactor_state()
+    incomplete_done = {}
+    for code, module in state["modules"].items():
+        if module.get("status") != "DONE":
+            continue
+        report_path = REFACTOR_DIR.parent.parent / module["report"]
+        if not (
+            module.get("score") == 100
+            and module.get("open_violations") == 0
+            and module.get("tests_failed") == 0
+            and report_path.is_file()
+        ):
+            incomplete_done[code] = module
+    assert not incomplete_done


### PR DESCRIPTION
### Motivation
- Provide the mandatory refactor control state and templates so the master refactor loop can start automatically inside the real package tree. 
- Ensure the repo follows the refactor protection rules that require control files to live under `pos_spj_v13.4/pos_spj_v13.4/docs/refactor/` and avoid external-root duplicates. 

### Description
- Add canonical refactor control documents `MASTER_REFACTOR_STATE.md`, `MODULE_QUEUE.md`, `CURRENT_MODULE.md`, `GLOBAL_VIOLATIONS.md`, and `UUIDV7_CUTOVER_REPORT.md` under `pos_spj_v13.4/docs/refactor/`. 
- Add `refactor_state.json` seeded with the full module queue entries and `current_module` set to `UUIDV7_CUTOVER`. 
- Add `pos_spj_v13.4/docs/refactor/modules/README.md` as the per-module reports index. 
- Add architecture test helpers and tests under `pos_spj_v13.4/tests/architecture/` to validate placement, JSON validity, queue completeness, current-module consistency, allowed states, DONE-module completeness, and absence of control-file copies at the repository root (`refactor_control_helpers.py` and five `test_*` files). 

### Testing
- Run `python -m pytest pos_spj_v13.4/tests/architecture/test_refactor_control_files_exist.py pos_spj_v13.4/tests/architecture/test_refactor_state_json_is_valid.py pos_spj_v13.4/tests/architecture/test_module_queue_is_complete.py pos_spj_v13.4/tests/architecture/test_current_module_matches_state.py pos_spj_v13.4/tests/architecture/test_refactor_files_inside_package.py` and all tests passed. 
- Test summary: `9 passed` (architecture protection tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ebf8f26c88328b95783d227e4ce53)