### PR TITLE
FASE 7.31 SINCRONIZACION — born-clean UUIDv7 en el motor offline-firs…

### DIFF
--- a/pos_spj_v13.4/core/services/sync_service.py
+++ b/pos_spj_v13.4/core/services/sync_service.py
@@ -68,14 +68,15 @@ class SyncService:
         """
         _sucursal = sucursal_id or getattr(self, 'sucursal_id', 1)
         try:
+            from backend.shared.ids import new_uuid
             payload_json = json.dumps(payload, ensure_ascii=False, default=str)
             _cur = cursor if cursor is not None else self._cursor()
             _cur.execute("""
                 INSERT INTO sync_outbox
-                    (tabla, operacion, registro_id, payload, sucursal_id,
+                    (id, tabla, operacion, registro_id, payload, sucursal_id,
                      enviado, intentos, fecha)
-                VALUES (?, ?, ?, ?, ?, 0, 0, datetime('now'))
-            """, (tabla, operacion, registro_id, payload_json, _sucursal))
+                VALUES (?, ?, ?, ?, ?, ?, 0, 0, datetime('now'))
+            """, (new_uuid(), tabla, operacion, registro_id, payload_json, _sucursal))
 
             # Increment Lamport clock (best-effort, never blocks the sale)
             try:
@@ -107,9 +108,10 @@ class SyncService:
         cursor = self._cursor()
         
         # Tomamos hasta 50 eventos pendientes por lote
+        # id es la identidad UUIDv7 (time-ordered); se expone como uuid del evento.
         pendientes = cursor.execute("""
-            SELECT id, uuid, tabla, operacion, registro_id, payload 
-            FROM sync_outbox 
+            SELECT id, id AS uuid, tabla, operacion, registro_id, payload
+            FROM sync_outbox
             WHERE enviado = 0 AND intentos < 10
             ORDER BY id ASC LIMIT 50
         """).fetchall()

--- a/pos_spj_v13.4/docs/refactor/MODULE_QUEUE.md
+++ b/pos_spj_v13.4/docs/refactor/MODULE_QUEUE.md
@@ -49,7 +49,7 @@ DONE
 |    28 | RRHH                  | Recursos humanos         | DONE |
 |    29 | REPORTES              | Reportes                 | DONE |
 |    30 | API                   | API FastAPI              | DONE |
-|    31 | SINCRONIZACION        | Sincronización           | PENDING |
+|    31 | SINCRONIZACION        | Sincronización           | DONE |
 |    32 | INSTALADOR            | Instalador               | PENDING |
 |    33 | ACTUALIZADOR          | Actualizador             | PENDING |
 |    34 | CIERRE_GLOBAL         | Cierre global            | PENDING |

--- a/pos_spj_v13.4/docs/refactor/refactor_state.json
+++ b/pos_spj_v13.4/docs/refactor/refactor_state.json
@@ -255,8 +255,8 @@
       "report": "docs/refactor/modules/api.md"
     },
     "SINCRONIZACION": {
-      "status": "PENDING",
-      "iteration": 0,
+      "status": "DONE",
+      "iteration": 1,
       "score": 0,
       "open_violations": null,
       "tests_failed": null,

--- a/pos_spj_v13.4/migrations/m000_base_schema.py
+++ b/pos_spj_v13.4/migrations/m000_base_schema.py
@@ -2236,13 +2236,12 @@ def _create_mermas_ajustes(conn):
 def _create_sync(conn):
     conn.execute("""
         CREATE TABLE IF NOT EXISTS sync_outbox (
-            id          INTEGER PRIMARY KEY AUTOINCREMENT,
-            uuid        TEXT UNIQUE DEFAULT (lower(hex(randomblob(16)))),
+            id          TEXT PRIMARY KEY,
             tabla       TEXT NOT NULL,
             operacion   TEXT NOT NULL,
-            registro_id INTEGER,
+            registro_id TEXT,
             payload     TEXT,
-            sucursal_id INTEGER,
+            sucursal_id TEXT,
             lamport_ts  INTEGER DEFAULT 0,
             enviado     INTEGER DEFAULT 0,
             intentos    INTEGER DEFAULT 0,
@@ -2252,13 +2251,12 @@ def _create_sync(conn):
     """)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS sync_inbox (
-            id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            uuid            TEXT UNIQUE,
+            id              TEXT PRIMARY KEY,
             tabla           TEXT NOT NULL,
             operacion       TEXT NOT NULL,
-            registro_id     INTEGER,
+            registro_id     TEXT,
             payload         TEXT,
-            sucursal_origen INTEGER,
+            sucursal_origen TEXT,
             lamport_ts      INTEGER DEFAULT 0,
             integrado       INTEGER DEFAULT 0,
             fecha_recibido  REAL DEFAULT (unixepoch())
@@ -2272,8 +2270,7 @@ def _create_sync(conn):
     """)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS sync_batch_log (
-            id            INTEGER PRIMARY KEY AUTOINCREMENT,
-            batch_id      TEXT NOT NULL UNIQUE,
+            batch_id      TEXT PRIMARY KEY,
             device_id     TEXT NOT NULL,
             event_count   INTEGER NOT NULL,
             compressed_size INTEGER,
@@ -2299,24 +2296,22 @@ def _create_sync(conn):
     """)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS sync_version_history (
-            id          INTEGER PRIMARY KEY AUTOINCREMENT,
             event_id    TEXT NOT NULL,
             version     INTEGER NOT NULL,
             hash        TEXT NOT NULL,
             device_id   TEXT NOT NULL,
             recorded_at DATETIME NOT NULL DEFAULT (datetime('now')),
-            UNIQUE(event_id, version)
+            PRIMARY KEY(event_id, version)
         )
     """)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS event_log (
-            id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            uuid            TEXT    NOT NULL UNIQUE,
+            id              TEXT    PRIMARY KEY,
             tipo            TEXT    NOT NULL,
             entidad         TEXT    NOT NULL,
-            entidad_id      INTEGER,
+            entidad_id      TEXT,
             payload         TEXT    NOT NULL,
-            sucursal_id     INTEGER NOT NULL DEFAULT 1,
+            sucursal_id     TEXT    NOT NULL,
             usuario         TEXT    NOT NULL DEFAULT 'Sistema',
             synced          INTEGER DEFAULT 0,
             sync_intentos   INTEGER DEFAULT 0,

--- a/pos_spj_v13.4/migrations/standalone/048_sync_improvements.py
+++ b/pos_spj_v13.4/migrations/standalone/048_sync_improvements.py
@@ -32,14 +32,8 @@ def up(conn):
     add_col("event_log",   "operation_id TEXT")
     add_col("sync_outbox", "operation_id TEXT")
 
-    # Asegurar uuid en sync_outbox para idempotencia
-    add_col("sync_outbox", "uuid TEXT")
-    try:
-        conn.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS idx_outbox_uuid "
-            "ON sync_outbox(uuid) WHERE uuid IS NOT NULL"
-        )
-    except Exception: pass
+    # Identidad UUIDv7 TEXT (REGLA CERO): sync_outbox.id ES la identidad
+    # (born-clean, sin columna uuid dual). Ya no se añade uuid.
 
     # Índices de performance para sync
     for idx in [

--- a/pos_spj_v13.4/migrations/standalone/054_sync_improvements_orphan.py
+++ b/pos_spj_v13.4/migrations/standalone/054_sync_improvements_orphan.py
@@ -32,15 +32,8 @@ def run(conn) -> None:
     add_col("event_log",   "operation_id TEXT")
     add_col("sync_outbox", "operation_id TEXT")
 
-    # Asegurar uuid en sync_outbox para idempotencia
-    add_col("sync_outbox", "uuid TEXT")
-    try:
-        conn.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS idx_outbox_uuid "
-            "ON sync_outbox(uuid) WHERE uuid IS NOT NULL"
-        )
-    except Exception:
-        pass
+    # Identidad UUIDv7 TEXT (REGLA CERO): sync_outbox.id ES la identidad de
+    # sincronización (born-clean, sin columna uuid dual). Ya no se añade uuid.
 
     # Índices de performance para sync
     for idx in [

--- a/pos_spj_v13.4/sync/event_logger.py
+++ b/pos_spj_v13.4/sync/event_logger.py
@@ -68,16 +68,18 @@ class EventLogger:
         self._ensure_table()
 
     def _ensure_table(self) -> None:
+        # Identidad UUIDv7 TEXT (REGLA CERO): id es la identidad del evento (sin
+        # columna uuid dual). Esquema canónico en m000_base_schema; creación
+        # defensiva born-clean para conexiones aisladas.
         self.conn.execute("""
             CREATE TABLE IF NOT EXISTS event_log (
-                id               INTEGER PRIMARY KEY AUTOINCREMENT,
-                uuid             TEXT    NOT NULL UNIQUE,
+                id               TEXT    PRIMARY KEY,
                 tipo             TEXT    NOT NULL,
                 entidad          TEXT    NOT NULL,
-                entidad_id       INTEGER,
+                entidad_id       TEXT,
                 payload          TEXT    NOT NULL,
                 payload_hash     TEXT,
-                sucursal_id      INTEGER NOT NULL DEFAULT 1,
+                sucursal_id      TEXT    NOT NULL,
                 usuario          TEXT    NOT NULL,
                 origin_device_id TEXT    DEFAULT '',
                 device_version   INTEGER DEFAULT 0,
@@ -122,7 +124,8 @@ class EventLogger:
         operation_id:  str   = None,
     ) -> int:
         try:
-            event_uuid   = str(uuid.uuid4())
+            from backend.shared.ids import new_uuid
+            event_uuid   = new_uuid()  # identidad UUIDv7 (REGLA CERO)
             payload_str  = json.dumps(payload or {}, ensure_ascii=False)
             payload_hash = _sha256_payload(payload_str)
 
@@ -141,10 +144,11 @@ class EventLogger:
             device_ver   = self._next_device_version(tipo)
             from utils.operation_context import get_operation_id
             op_id = operation_id or get_operation_id() or ""
-            cur = self.conn.execute(
+            # id es la identidad UUIDv7 del evento (antes columna uuid dual).
+            self.conn.execute(
                 """
                 INSERT INTO event_log
-                    (uuid, tipo, entidad, entidad_id, payload, payload_hash,
+                    (id, tipo, entidad, entidad_id, payload, payload_hash,
                      sucursal_id, usuario, origin_device_id, device_version,
                      event_version, operation_id)
                 VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
@@ -170,22 +174,24 @@ class EventLogger:
                 lamport_ts = int(lp_row[0]) + 1 if lp_row else 1
                 self.conn.execute(
                     "INSERT OR IGNORE INTO sync_outbox"
-                    "(uuid,tabla,operacion,registro_id,payload,sucursal_id,lamport_ts)"
+                    "(id,tabla,operacion,registro_id,payload,sucursal_id,lamport_ts)"
                     " VALUES(?,?,?,?,?,?,?)",
                     (event_uuid, f"event:{entidad}", "EVENT",
                      entidad_id, payload_str, sucursal_id, lamport_ts)
                 )
             except Exception as _be:
                 logger.debug("EventLogger→outbox bridge: %s", _be)
-            return cur.lastrowid
+            return event_uuid
         except Exception as exc:
             logger.warning("EventLogger.registrar falló silenciosamente: %s", exc)
             return -1
 
     def pendientes(self, limit: int = 100) -> list:
+        # id es la identidad UUIDv7; se expone también como uuid para los
+        # consumidores del protocolo de sincronización.
         return self.conn.execute(
             """
-            SELECT id, uuid, tipo, entidad, entidad_id, payload,
+            SELECT id, id AS uuid, tipo, entidad, entidad_id, payload,
                    payload_hash, sucursal_id, usuario,
                    origin_device_id, device_version, event_version, fecha
             FROM event_log

--- a/pos_spj_v13.4/sync/sync_engine.py
+++ b/pos_spj_v13.4/sync/sync_engine.py
@@ -40,15 +40,17 @@ class SyncEngine:
         self._init_tables()
 
     def _init_tables(self):
+        # Identidad UUIDv7 TEXT (REGLA CERO): id es la identidad de sincronización
+        # (sin columna uuid dual). El esquema canónico vive en m000_base_schema;
+        # esta creación defensiva lo replica born-clean para conexiones aisladas.
         self.conn.executescript("""
             CREATE TABLE IF NOT EXISTS sync_outbox (
-                id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                uuid        TEXT UNIQUE DEFAULT (lower(hex(randomblob(16)))),
+                id          TEXT PRIMARY KEY,
                 tabla       TEXT NOT NULL,
                 operacion   TEXT NOT NULL,   -- INSERT / UPDATE / DELETE
-                registro_id INTEGER,
+                registro_id TEXT,
                 payload     TEXT,            -- JSON del registro
-                sucursal_id INTEGER,
+                sucursal_id TEXT,
                 lamport_ts  INTEGER DEFAULT 0,
                 enviado     INTEGER DEFAULT 0,
                 intentos    INTEGER DEFAULT 0,
@@ -56,13 +58,12 @@ class SyncEngine:
                 fecha       REAL DEFAULT (unixepoch())
             );
             CREATE TABLE IF NOT EXISTS sync_inbox (
-                id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                uuid        TEXT UNIQUE,
+                id          TEXT PRIMARY KEY,
                 tabla       TEXT NOT NULL,
                 operacion   TEXT NOT NULL,
-                registro_id INTEGER,
+                registro_id TEXT,
                 payload     TEXT,
-                sucursal_origen INTEGER,
+                sucursal_origen TEXT,
                 lamport_ts  INTEGER DEFAULT 0,
                 integrado   INTEGER DEFAULT 0,
                 fecha_recibido REAL DEFAULT (unixepoch())
@@ -111,11 +112,12 @@ class SyncEngine:
         if tabla not in TABLAS_SINCRONIZABLES:
             return
         ts = self._tick_lamport()
+        from backend.shared.ids import new_uuid
         self.conn.execute(
             """INSERT INTO sync_outbox
-               (tabla, operacion, registro_id, payload, sucursal_id, lamport_ts)
-               VALUES(?,?,?,?,?,?)""",
-            (tabla, operacion, registro_id,
+               (id, tabla, operacion, registro_id, payload, sucursal_id, lamport_ts)
+               VALUES(?,?,?,?,?,?,?)""",
+            (new_uuid(), tabla, operacion, registro_id,
              json.dumps(payload, default=str),
              self.sucursal_id, ts))
         try: self.conn.commit()
@@ -123,8 +125,10 @@ class SyncEngine:
 
     # ── Obtener pendientes para enviar ────────────────────────────────────
     def get_pending(self, limit: int = 100) -> list:
+        # id ES la identidad de sincronización (UUIDv7): se propaga como uuid del
+        # evento hacia el receptor para la deduplicación idempotente.
         rows = self.conn.execute(
-            """SELECT id, uuid, tabla, operacion, registro_id, payload, lamport_ts
+            """SELECT id, id AS uuid, tabla, operacion, registro_id, payload, lamport_ts
                FROM sync_outbox WHERE enviado=0
                ORDER BY lamport_ts ASC LIMIT ?""",
             (limit,)).fetchall()
@@ -151,10 +155,11 @@ class SyncEngine:
         v13.2: Idempotencia por uuid — skip si ya fue aplicado.
         Resolución de conflictos: last-write-wins por lamport_ts.
         """
-        uuid_val = item.get("uuid", "")
+        # Identidad del evento remoto (UUIDv7): es el id del outbox emisor.
+        uuid_val = item.get("id") or item.get("uuid", "")
         if uuid_val:
             already = self.conn.execute(
-                "SELECT 1 FROM sync_inbox WHERE uuid=? AND integrado=1",
+                "SELECT 1 FROM sync_inbox WHERE id=? AND integrado=1",
                 (uuid_val,)
             ).fetchone()
             if already:
@@ -216,7 +221,7 @@ class SyncEngine:
                 try:
                     self.conn.execute(
                         "INSERT OR IGNORE INTO sync_inbox"
-                        "(uuid,tabla,operacion,registro_id,integrado,fecha_recibido)"
+                        "(id,tabla,operacion,registro_id,integrado,fecha_recibido)"
                         " VALUES(?,?,?,?,1,unixepoch())",
                         (uuid_val, tabla, operacion, reg_id))
                 except Exception:

--- a/pos_spj_v13.4/sync/sync_worker.py
+++ b/pos_spj_v13.4/sync/sync_worker.py
@@ -400,7 +400,7 @@ class SyncWorker(_SyncWorkerBase):
         Previously only read event_log → sales events (in sync_outbox) were never sent.
         """
         rows_el = conn.execute("""
-            SELECT id, uuid, tipo, entidad, entidad_id, payload,
+            SELECT id, id AS uuid, tipo, entidad, entidad_id, payload,
                    usuario, fecha,
                    COALESCE(payload_hash,   '')  AS payload_hash,
                    COALESCE(event_version,  1)   AS event_version,
@@ -415,7 +415,7 @@ class SyncWorker(_SyncWorkerBase):
 
         rows_ob = conn.execute("""
             SELECT id,
-                   COALESCE(uuid, lower(hex(randomblob(16)))) AS uuid,
+                   id             AS uuid,
                    tabla          AS tipo,
                    tabla          AS entidad,
                    registro_id    AS entidad_id,
@@ -460,7 +460,7 @@ class SyncWorker(_SyncWorkerBase):
         try:
             conn.execute(
                 f"UPDATE event_log SET synced=1, fecha_sync=datetime('now') "
-                f"WHERE uuid IN ({placeholders})",
+                f"WHERE id IN ({placeholders})",
                 uuids,
             )
         except Exception:
@@ -469,7 +469,7 @@ class SyncWorker(_SyncWorkerBase):
         try:
             conn.execute(
                 f"UPDATE sync_outbox SET enviado=1 "
-                f"WHERE uuid IN ({placeholders})",
+                f"WHERE id IN ({placeholders})",
                 uuids,
             )
         except Exception:
@@ -497,7 +497,7 @@ class SyncWorker(_SyncWorkerBase):
             razon   = c.get("razon", "conflicto")
             conn.execute(
                 "UPDATE event_log SET sync_error=?, sync_intentos=sync_intentos+1 "
-                "WHERE uuid=?",
+                "WHERE id=?",
                 (f"CONFLICTO: {razon}", uuid_ev),
             )
             logger.warning("Conflicto evento %s: %s", uuid_ev, razon)
@@ -527,7 +527,7 @@ class SyncWorker(_SyncWorkerBase):
 
             if policy == "LAST_WRITE_WINS":
                 row = conn.execute(
-                    "SELECT device_version FROM event_log WHERE uuid=?",
+                    "SELECT device_version FROM event_log WHERE id=?",
                     (uuid_ev,),
                 ).fetchone()
                 local_ver = int(row[0]) if row else 0
@@ -538,7 +538,7 @@ class SyncWorker(_SyncWorkerBase):
                         "UPDATE event_log SET synced=0, sync_error=NULL, "
                         "event_version=event_version+1, "
                         "sync_intentos=CASE WHEN sync_intentos>0 THEN sync_intentos-1 ELSE 0 END "
-                        "WHERE uuid=?",
+                        "WHERE id=?",
                         (uuid_ev,),
                     )
                     logger.info(
@@ -550,7 +550,7 @@ class SyncWorker(_SyncWorkerBase):
             # SERVER_AUTHORITATIVE o LWW donde servidor gana
             conn.execute(
                 "UPDATE event_log SET sync_error=?, sync_intentos=sync_intentos+1 "
-                "WHERE uuid=?",
+                "WHERE id=?",
                 (f"CONFLICTO[{policy}]: {razon}", uuid_ev),
             )
             logger.warning(

--- a/pos_spj_v13.4/tests/architecture/test_clean_birth_guardrails.py
+++ b/pos_spj_v13.4/tests/architecture/test_clean_birth_guardrails.py
@@ -168,6 +168,67 @@ def test_api_webapp_treats_identity_as_uuid_no_int_casts():
     assert "producto_id: str" in uc_src
 
 
+def test_sincronizacion_tables_are_born_clean_single_uuid_identity():
+    """SINCRONIZACION born-clean (REGLA CERO): las tablas del motor offline-first
+    llevan identidad UUIDv7 TEXT única — sin columna uuid dual, sin surrogate
+    entero, sin DEFAULT 1:
+      - sync_outbox / sync_inbox / event_log: id TEXT PRIMARY KEY (sin uuid dual),
+        registro_id/entidad_id/sucursal_id/sucursal_origen TEXT.
+      - sync_batch_log: identidad natural batch_id TEXT (sin surrogate id).
+      - sync_version_history: PK compuesta (event_id, version) (sin surrogate id).
+    Los writers acuñan new_uuid() y NO usan lastrowid como identidad; el protocolo
+    de sync expone id AS uuid (compatibilidad de wire sin columna dual).
+    """
+    import migrations.m000_base_schema as base
+    from migrations import engine as migrator
+
+    conn = sqlite3.connect(":memory:")
+    base.up(conn)
+    conn.commit()
+    migrator.up(conn)
+    conn.commit()
+
+    # Tablas con id TEXT PK único (sin columna uuid dual).
+    for table, fk_cols in (
+        ("sync_outbox", ("registro_id", "sucursal_id")),
+        ("sync_inbox", ("registro_id", "sucursal_origen")),
+        ("event_log", ("entidad_id", "sucursal_id")),
+    ):
+        cols = {r[1]: (r[2].upper(), r[4], r[5]) for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+        assert cols["id"][0] == "TEXT", f"{table}.id debe ser TEXT"
+        assert cols["id"][2] == 1, f"{table}.id debe ser PRIMARY KEY"
+        assert "uuid" not in cols, f"{table} no debe tener columna uuid dual"
+        for fk in fk_cols:
+            assert cols[fk][0] == "TEXT", f"{table}.{fk} debe ser TEXT"
+        # sucursal_id no debe traer DEFAULT 1.
+        if "sucursal_id" in cols:
+            assert cols["sucursal_id"][1] not in (1, "1"), f"{table}.sucursal_id no debe tener DEFAULT 1"
+
+    # sync_batch_log: identidad natural batch_id TEXT, sin surrogate id.
+    sbl = {r[1]: (r[2].upper(), r[5]) for r in conn.execute("PRAGMA table_info(sync_batch_log)").fetchall()}
+    assert "id" not in sbl, "sync_batch_log no debe tener surrogate id entero"
+    assert sbl["batch_id"] == ("TEXT", 1), "sync_batch_log.batch_id debe ser TEXT PRIMARY KEY"
+
+    # sync_version_history: PK natural compuesta (event_id, version), sin surrogate.
+    svh = {r[1]: (r[2].upper(), r[5]) for r in conn.execute("PRAGMA table_info(sync_version_history)").fetchall()}
+    assert "id" not in svh, "sync_version_history no debe tener surrogate id entero"
+    assert svh["event_id"][1] >= 1 and svh["version"][1] >= 1, "PK compuesta (event_id, version)"
+
+    # Writers acuñan UUIDv7 y no usan lastrowid como identidad.
+    se_src = (REPO / "sync/sync_engine.py").read_text(encoding="utf-8")
+    assert "from backend.shared.ids import new_uuid" in se_src
+    assert "AUTOINCREMENT" not in se_src
+    el_src = (REPO / "sync/event_logger.py").read_text(encoding="utf-8")
+    assert "event_uuid   = new_uuid()" in el_src
+    assert "cur.lastrowid" not in el_src
+    ss_src = (REPO / "core/services/sync_service.py").read_text(encoding="utf-8")
+    assert "new_uuid()" in ss_src
+    # El protocolo de sync preserva el wire alias id AS uuid (sin columna dual).
+    assert "id AS uuid" in se_src
+    sw_src = (REPO / "sync/sync_worker.py").read_text(encoding="utf-8")
+    assert "id AS uuid" in sw_src
+
+
 def test_loyalty_ledger_born_clean_and_dead_points_tables_removed():
     """The canonical loyalty_ledger carries a TEXT UUIDv7 id (minted by the repo,
     not autoincrement) with TEXT cliente_id/sucursal_id, and the dead points

--- a/pos_spj_v13.4/tests/test_sync_service_cursor_compat.py
+++ b/pos_spj_v13.4/tests/test_sync_service_cursor_compat.py
@@ -15,7 +15,7 @@ def test_sync_service_cursor_usa_conn_si_no_hay_cursor_directo():
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE configuraciones(clave TEXT, valor TEXT)")
     conn.execute(
-        "CREATE TABLE sync_outbox(id INTEGER PRIMARY KEY, tabla TEXT, operacion TEXT, registro_id INTEGER, payload TEXT, sucursal_id INTEGER, enviado INTEGER, intentos INTEGER, fecha TEXT)"
+        "CREATE TABLE sync_outbox(id TEXT PRIMARY KEY, tabla TEXT, operacion TEXT, registro_id TEXT, payload TEXT, sucursal_id TEXT, enviado INTEGER, intentos INTEGER, fecha TEXT)"
     )
     conn.execute("CREATE TABLE sync_state(key TEXT PRIMARY KEY, value TEXT)")
     conn.commit()


### PR DESCRIPTION
…t · SINCRONIZACION DONE

Identidad UUIDv7 TEXT única (REGLA CERO) en todo el subsistema de sincronización, eliminando la identidad dual uuid+id, los surrogates enteros y los DEFAULT 1.

Esquema (m000_base_schema):
- sync_outbox / sync_inbox / event_log: id TEXT PRIMARY KEY (sin columna uuid dual), registro_id / entidad_id / sucursal_id / sucursal_origen TEXT; event_log sin DEFAULT 1.
- sync_batch_log: identidad natural batch_id TEXT (sin surrogate id).
- sync_version_history: PK compuesta (event_id, version) (sin surrogate id).

Writers born-clean:
- sync_engine (record_change / _init_tables / get_pending / integrate_remote): acuña new_uuid() para id; dedup y updates por id; SELECT id AS uuid para preservar el protocolo de wire sin columna dual.
- event_logger: event_uuid = new_uuid() (antes uuid4); INSERT (id, ...); bridge a sync_outbox por id; retorna event_uuid (antes lastrowid).
- sync_service.registrar_evento: INSERT con new_uuid() id; lector dispatch id AS uuid.
- sync_worker: SELECT id AS uuid en event_log y sync_outbox; marca/consulta por id.

Migraciones 048/054: eliminado el re-add de sync_outbox.uuid + idx_outbox_uuid (re-introducía identidad dual); reemplazado por comentario born-clean.

Tests: guardrail test_sincronizacion_tables_are_born_clean_single_uuid_identity; fixture de test_sync_service_cursor_compat flipeada a id TEXT PK. Regresión stash-diff full-suite: cero fallos nuevos vs baseline.


Claude-Session: https://claude.ai/code/session_01FjvtLMufyoqmwefhCoNGnf