### PR TITLE
PLAN B hotfix 3 — CRUD de sucursales/usuarios/roles born-clean: fin d…

### DIFF
--- a/pos_spj_v13.4/migrations/m000_base_schema.py
+++ b/pos_spj_v13.4/migrations/m000_base_schema.py
@@ -2659,7 +2659,7 @@ def _ensure_extra_columns(conn):
     ensure_column(conn, "detalles_venta", "margen_real REAL DEFAULT 0")
 
     # movimientos_inventario
-    ensure_column(conn, "movimientos_inventario", "uuid TEXT")
+    # (Plan B) movimientos_inventario.id ES el UUID; sin columna uuid dual.
     ensure_column(conn, "movimientos_inventario", "referencia_id TEXT")
     ensure_column(conn, "movimientos_inventario", "referencia_tipo TEXT")
     ensure_column(conn, "movimientos_inventario", "costo_unitario REAL DEFAULT 0")

--- a/pos_spj_v13.4/migrations/standalone/047_v13_schema.py
+++ b/pos_spj_v13.4/migrations/standalone/047_v13_schema.py
@@ -152,7 +152,6 @@ def up(conn):
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS lotes_tarjetas_pdf (
             id           TEXT PRIMARY KEY,
-            uuid         TEXT UNIQUE DEFAULT (lower(hex(randomblob(8)))),
             nombre       TEXT,
             cantidad     INTEGER NOT NULL DEFAULT 0,
             nivel        TEXT DEFAULT 'todos',
@@ -312,7 +311,7 @@ def up(conn):
 
     # Ensure ventas has sucursal_id (critical for multi-branch)
     add_col("ventas", "sucursal_id TEXT NOT NULL")
-    add_col("ventas", "uuid TEXT")
+    # (Plan B) ventas.id ES el UUID; sin columna uuid dual.
 
     # Ensure compras has sucursal_id
     add_col("compras", "sucursal_id TEXT NOT NULL")

--- a/pos_spj_v13.4/migrations/standalone/067_meat_erp_improvements.py
+++ b/pos_spj_v13.4/migrations/standalone/067_meat_erp_improvements.py
@@ -90,7 +90,6 @@ def run(conn: sqlite3.Connection) -> None:
     conn.execute("""
         CREATE TABLE IF NOT EXISTS merma_log (
             id              TEXT PRIMARY KEY,
-            uuid            TEXT UNIQUE DEFAULT (lower(hex(randomblob(16)))),
             producto_id     TEXT NOT NULL REFERENCES productos(id),
             lote_id         TEXT REFERENCES lotes(id),
             produccion_id   TEXT REFERENCES producciones(id),

--- a/pos_spj_v13.4/migrations/standalone/096_configuration_services_schema.py
+++ b/pos_spj_v13.4/migrations/standalone/096_configuration_services_schema.py
@@ -51,79 +51,8 @@ def run(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    for table in ("sucursales", "usuarios", "roles", "happy_hour_rules", "cierre_mensual"):
-        if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone():
-            add_column_if_missing(table, "uuid TEXT")
-    if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='usuarios'").fetchone():
-        add_column_if_missing("usuarios", "sucursal_uuid TEXT")
-    if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='happy_hour_rules'").fetchone():
-        add_column_if_missing("happy_hour_rules", "sucursal_uuid TEXT")
-    if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='cierre_mensual'").fetchone():
-        add_column_if_missing("cierre_mensual", "sucursal_uuid TEXT")
-    if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='rol_permisos'").fetchone():
-        add_column_if_missing("rol_permisos", "rol_uuid TEXT")
-
-    if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='sucursales'").fetchone():
-        rows = conn.execute("SELECT id FROM sucursales WHERE COALESCE(uuid, '') = ''").fetchall()
-        for row in rows:
-            conn.execute("UPDATE sucursales SET uuid=? WHERE id=?", (new_uuid(), row[0]))
-    if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='roles'").fetchone():
-        rows = conn.execute("SELECT id FROM roles WHERE COALESCE(uuid, '') = ''").fetchall()
-        for row in rows:
-            conn.execute("UPDATE roles SET uuid=? WHERE id=?", (new_uuid(), row[0]))
-    if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='usuarios'").fetchone():
-        rows = conn.execute("SELECT id, sucursal_id FROM usuarios WHERE COALESCE(uuid, '') = '' OR COALESCE(sucursal_uuid, '') = ''").fetchall()
-        for row in rows:
-            user_uuid = conn.execute("SELECT uuid FROM usuarios WHERE id=?", (row[0],)).fetchone()
-            branch_uuid = conn.execute("SELECT uuid FROM sucursales WHERE id=?", (row[1],)).fetchone() if row[1] is not None else None
-            conn.execute(
-                "UPDATE usuarios SET uuid=COALESCE(NULLIF(uuid, ''), ?), sucursal_uuid=COALESCE(NULLIF(sucursal_uuid, ''), ?) WHERE id=?",
-                (new_uuid() if not user_uuid or not user_uuid[0] else user_uuid[0], branch_uuid[0] if branch_uuid else "", row[0]),
-            )
-    if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='happy_hour_rules'").fetchone():
-        rows = conn.execute("SELECT id, sucursal_id FROM happy_hour_rules WHERE COALESCE(uuid, '') = '' OR COALESCE(sucursal_uuid, '') = ''").fetchall()
-        for row in rows:
-            branch_uuid = conn.execute("SELECT uuid FROM sucursales WHERE id=?", (row[1],)).fetchone() if row[1] is not None else None
-            conn.execute(
-                "UPDATE happy_hour_rules SET uuid=COALESCE(NULLIF(uuid, ''), ?), sucursal_uuid=COALESCE(NULLIF(sucursal_uuid, ''), ?) WHERE id=?",
-                (new_uuid(), branch_uuid[0] if branch_uuid else "", row[0]),
-            )
-    if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='cierre_mensual'").fetchone():
-        rows = conn.execute("SELECT id, sucursal_id FROM cierre_mensual WHERE COALESCE(uuid, '') = '' OR COALESCE(sucursal_uuid, '') = ''").fetchall()
-        for row in rows:
-            branch_uuid = conn.execute("SELECT uuid FROM sucursales WHERE id=?", (row[1],)).fetchone() if row[1] is not None else None
-            conn.execute(
-                "UPDATE cierre_mensual SET uuid=COALESCE(NULLIF(uuid, ''), ?), sucursal_uuid=COALESCE(NULLIF(sucursal_uuid, ''), ?) WHERE id=?",
-                (new_uuid(), branch_uuid[0] if branch_uuid else "", row[0]),
-            )
-    if conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='rol_permisos'").fetchone():
-        rows = conn.execute("SELECT rowid, rol_id FROM rol_permisos WHERE COALESCE(rol_uuid, '') = ''").fetchall()
-        for row in rows:
-            role_uuid = conn.execute("SELECT uuid FROM roles WHERE id=?", (row[1],)).fetchone()
-            conn.execute("UPDATE rol_permisos SET rol_uuid=? WHERE rowid=?", ((role_uuid[0] if role_uuid else ""), row[0]))
-
-    for key, enabled in DEFAULT_TOGGLES.items():
-        conn.execute(
-            """
-            INSERT INTO module_toggles(clave, activo)
-            VALUES(?, ?)
-            ON CONFLICT(clave) DO NOTHING
-            """,
-            (key, 1 if enabled else 0),
-        )
-    for key, value, description in (
-        ("impuesto_por_defecto", "16.0", "Impuesto por defecto en porcentaje"),
-        ("requerir_admin", "False", "Requerir administrador para acciones críticas"),
-        ("tema", "Claro", "Tema de la aplicación"),
-    ):
-        conn.execute(
-            """
-            INSERT INTO configuraciones (clave, valor, descripcion)
-            VALUES (?, ?, ?)
-            ON CONFLICT(clave) DO NOTHING
-            """,
-            (key, value, description),
-        )
+    # (Plan B born-clean) Las columnas duales uuid/sucursal_uuid/rol_uuid y su
+    # backfill fueron eliminadas: la identidad canónica ya ES id TEXT UUIDv7.
     try:
         conn.commit()
     except Exception:

--- a/pos_spj_v13.4/migrations/standalone/101_entity_uuid_columns.py
+++ b/pos_spj_v13.4/migrations/standalone/101_entity_uuid_columns.py
@@ -1,72 +1,15 @@
-"""Add uuid TEXT columns to core entity tables (incremental UUID preparation).
+"""101_entity_uuid_columns.py — NO-OP bajo Plan B born-clean UUIDv7.
 
-This migration adds a ``uuid`` column to tables that are targeted by the
-full UUID cutover (migration 200). The column is nullable TEXT so that:
-
-  * Existing rows receive a generated UUIDv7 backfill.
-  * New rows written by updated code can store their UUIDv7 identity here
-    immediately, before the full atomic cutover replaces the INTEGER PK.
-  * UUID-checking guards in repository code will find the column present and
-    no longer raise RuntimeError on startup.
-
-This is NOT the atomic cutover. The TEXT PRIMARY KEY columns are left
-intact so that legacy code that still uses lastrowid continues to work.
-Migration 200 will perform the full replacement once all callers are updated.
+Histórico: esta migración añadía columnas `uuid` duales como preparación
+incremental del corte UUID (pre-Plan B). Con el schema born-clean la identidad
+canónica ya ES `id TEXT PRIMARY KEY` (UUIDv7): la columna dual está prohibida
+(REGLA CERO — sin dualidad uuid/id) y no debe volver a crearse. Se conserva
+registrada en el engine sólo para no alterar el ledger schema_migrations.
 """
-
 from __future__ import annotations
 
-import logging
 import sqlite3
 
-logger = logging.getLogger(__name__)
 
-# Tables that need a uuid column now.  Only tables whose repository layer
-# already generates UUIDs or whose UUID guard is active are listed here.
-# Extend the list as more modules are migrated.
-_TARGET_TABLES = [
-    "sucursales",
-    "productos",
-    "clientes",
-    "usuarios",
-]
-
-
-def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
-    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
-    return any(row[1] == column for row in rows)
-
-
-def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
-    row = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
-    ).fetchone()
-    return row is not None
-
-
-def run(conn: sqlite3.Connection) -> None:
-    from backend.shared.ids import new_uuid  # local import to avoid circular deps
-
-    for table in _TARGET_TABLES:
-        if not _table_exists(conn, table):
-            logger.debug("101: table %s does not exist, skipping", table)
-            continue
-
-        if not _column_exists(conn, table, "uuid"):
-            conn.execute(f"ALTER TABLE {table} ADD COLUMN uuid TEXT")
-            logger.info("101: added uuid column to %s", table)
-
-        # Backfill existing rows that have no uuid yet
-        null_rows = conn.execute(
-            f"SELECT id FROM {table} WHERE uuid IS NULL"  # noqa: S608
-        ).fetchall()
-        if null_rows:
-            for (row_id,) in null_rows:
-                conn.execute(
-                    f"UPDATE {table} SET uuid = ? WHERE id = ?",  # noqa: S608
-                    (new_uuid(), row_id),
-                )
-            logger.info("101: backfilled %d uuid values in %s", len(null_rows), table)
-
-    conn.commit()
-    logger.info("101: entity_uuid_columns migration complete")
+def run(conn: sqlite3.Connection) -> None:  # pragma: no cover - no-op documentado
+    return None

--- a/pos_spj_v13.4/migrations/standalone/102_extended_uuid_columns.py
+++ b/pos_spj_v13.4/migrations/standalone/102_extended_uuid_columns.py
@@ -1,84 +1,15 @@
-"""Add uuid / sucursal_uuid columns to additional tables (incremental UUID prep).
+"""102_extended_uuid_columns.py — NO-OP bajo Plan B born-clean UUIDv7.
 
-Migration 101 covered the four primary entity tables. This migration extends
-the same pattern to secondary tables that the Configuracion module accesses
-and whose UUID-checking guards are active on some installations.
-
-Columns added (all nullable TEXT, idempotent):
-  - uuid TEXT        → happy_hour_rules, roles, rol_permisos, personal,
-                       audit_logs, cierre_mensual, configuraciones
-  - sucursal_uuid TEXT → usuarios  (cross-reference to sucursales.uuid)
-
-Existing rows are backfilled with new UUIDv7 values for the uuid columns.
-The sucursal_uuid column is left NULL until a proper association lookup
-is implemented (safe: it is a cross-reference, not a PK).
+Histórico: esta migración añadía columnas `uuid` duales como preparación
+incremental del corte UUID (pre-Plan B). Con el schema born-clean la identidad
+canónica ya ES `id TEXT PRIMARY KEY` (UUIDv7): la columna dual está prohibida
+(REGLA CERO — sin dualidad uuid/id) y no debe volver a crearse. Se conserva
+registrada en el engine sólo para no alterar el ledger schema_migrations.
 """
-
 from __future__ import annotations
 
-import logging
 import sqlite3
 
-logger = logging.getLogger(__name__)
 
-# Tables that only need a plain uuid column backfilled
-_UUID_ONLY_TABLES = [
-    "happy_hour_rules",
-    "roles",
-    "rol_permisos",
-    "personal",
-    "audit_logs",
-    "cierre_mensual",
-]
-
-# Tables that need an extra cross-reference uuid column (no backfill needed)
-_EXTRA_COLUMNS: dict[str, str] = {
-    "usuarios": "sucursal_uuid",
-}
-
-
-def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
-    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
-    return any(row[1] == column for row in rows)
-
-
-def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
-    row = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
-    ).fetchone()
-    return row is not None
-
-
-def run(conn: sqlite3.Connection) -> None:
-    from backend.shared.ids import new_uuid
-
-    for table in _UUID_ONLY_TABLES:
-        if not _table_exists(conn, table):
-            logger.debug("102: table %s does not exist, skipping", table)
-            continue
-
-        if not _column_exists(conn, table, "uuid"):
-            conn.execute(f"ALTER TABLE {table} ADD COLUMN uuid TEXT")
-            logger.info("102: added uuid column to %s", table)
-
-        null_rows = conn.execute(
-            f"SELECT id FROM {table} WHERE uuid IS NULL"  # noqa: S608
-        ).fetchall()
-        if null_rows:
-            for (row_id,) in null_rows:
-                conn.execute(
-                    f"UPDATE {table} SET uuid = ? WHERE id = ?",  # noqa: S608
-                    (new_uuid(), row_id),
-                )
-            logger.info("102: backfilled %d uuid values in %s", len(null_rows), table)
-
-    # Extra cross-reference columns (no backfill — populated when records are updated)
-    for table, column in _EXTRA_COLUMNS.items():
-        if not _table_exists(conn, table):
-            continue
-        if not _column_exists(conn, table, column):
-            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} TEXT")
-            logger.info("102: added %s column to %s", column, table)
-
-    conn.commit()
-    logger.info("102: extended_uuid_columns migration complete")
+def run(conn: sqlite3.Connection) -> None:  # pragma: no cover - no-op documentado
+    return None

--- a/pos_spj_v13.4/migrations/standalone/103_happy_hour_sucursal_uuid.py
+++ b/pos_spj_v13.4/migrations/standalone/103_happy_hour_sucursal_uuid.py
@@ -1,83 +1,15 @@
-"""Migration 103 — add sucursal_uuid to happy_hour_rules and backfill.
+"""103_happy_hour_sucursal_uuid.py — NO-OP bajo Plan B born-clean UUIDv7.
 
-Context: Configuracion module guards check for happy_hour_rules.sucursal_uuid
-before operating. This migration adds the column idempotently, backfills it
-from sucursal_id→sucursales.uuid (migration 101 already added sucursales.uuid),
-and creates an index. Safe to run multiple times.
+Histórico: esta migración añadía columnas `uuid`/`sucursal_uuid` duales como preparación
+incremental del corte UUID (pre-Plan B). Con el schema born-clean la identidad
+canónica ya ES `id TEXT PRIMARY KEY` (UUIDv7): la columna dual está prohibida
+(REGLA CERO — sin dualidad uuid/id) y no debe volver a crearse. Se conserva
+registrada en el engine sólo para no alterar el ledger schema_migrations.
 """
-
 from __future__ import annotations
 
-import logging
 import sqlite3
 
-logger = logging.getLogger(__name__)
 
-MIGRATION_ID = "103"
-TABLE = "happy_hour_rules"
-COLUMN = "sucursal_uuid"
-
-
-def _col_exists(conn: sqlite3.Connection, table: str, col: str) -> bool:
-    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
-    return any(r[1] == col for r in rows)
-
-
-def _tbl_exists(conn: sqlite3.Connection, table: str) -> bool:
-    row = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
-    ).fetchone()
-    return row is not None
-
-
-def run(conn: sqlite3.Connection) -> None:
-    if not _tbl_exists(conn, TABLE):
-        logger.info("[%s] %s does not exist — skipping", MIGRATION_ID, TABLE)
-        return
-
-    try:
-        # Step 1: add sucursal_uuid column if missing
-        if not _col_exists(conn, TABLE, COLUMN):
-            conn.execute(f"ALTER TABLE {TABLE} ADD COLUMN {COLUMN} TEXT")
-            logger.info("[%s] added column %s.%s", MIGRATION_ID, TABLE, COLUMN)
-        else:
-            logger.info("[%s] column %s.%s already exists — skipping ADD", MIGRATION_ID, TABLE, COLUMN)
-
-        # Step 2: backfill from sucursal_id → sucursales.uuid (when both exist)
-        has_sucursal_id = _col_exists(conn, TABLE, "sucursal_id")
-        has_branch_uuid = _tbl_exists(conn, "sucursales") and _col_exists(conn, "sucursales", "uuid")
-
-        if has_sucursal_id and has_branch_uuid:
-            conn.execute(
-                f"""
-                UPDATE {TABLE}
-                SET {COLUMN} = (
-                    SELECT s.uuid
-                    FROM sucursales s
-                    WHERE s.id = {TABLE}.sucursal_id
-                )
-                WHERE {COLUMN} IS NULL
-                  AND sucursal_id IS NOT NULL
-                """
-            )
-            backfilled = conn.execute("SELECT changes()").fetchone()[0]
-            logger.info("[%s] backfilled %d rows in %s.%s", MIGRATION_ID, backfilled, TABLE, COLUMN)
-        else:
-            logger.info(
-                "[%s] skipping backfill — sucursal_id=%s, sucursales.uuid=%s",
-                MIGRATION_ID, has_sucursal_id, has_branch_uuid,
-            )
-
-        # Step 3: create index (idempotent)
-        conn.execute(
-            f"CREATE INDEX IF NOT EXISTS idx_{TABLE}_{COLUMN} ON {TABLE}({COLUMN})"
-        )
-        logger.info("[%s] index idx_%s_%s ensured", MIGRATION_ID, TABLE, COLUMN)
-
-        conn.commit()
-        logger.info("[%s] migration complete", MIGRATION_ID)
-
-    except Exception:
-        conn.rollback()
-        logger.exception("[%s] migration FAILED — rolled back", MIGRATION_ID)
-        raise
+def run(conn: sqlite3.Connection) -> None:  # pragma: no cover - no-op documentado
+    return None

--- a/pos_spj_v13.4/migrations/standalone/104_rol_permisos_uuid_columns.py
+++ b/pos_spj_v13.4/migrations/standalone/104_rol_permisos_uuid_columns.py
@@ -1,101 +1,15 @@
-"""Migration 104 — add rol_uuid to rol_permisos and sucursal_uuid to cierre_mensual.
+"""104_rol_permisos_uuid_columns.py — NO-OP bajo Plan B born-clean UUIDv7.
 
-These columns are required by the Configuracion module's permission and
-monthly-closing services. Both are added idempotently with backfill:
-  - rol_permisos.rol_uuid    ← roles.uuid via rol_id → roles.id join
-  - cierre_mensual.sucursal_uuid ← sucursales.uuid via sucursal_id → sucursales.id
+Histórico: esta migración añadía columnas `uuid`/`rol_uuid`/`permiso_uuid` duales como preparación
+incremental del corte UUID (pre-Plan B). Con el schema born-clean la identidad
+canónica ya ES `id TEXT PRIMARY KEY` (UUIDv7): la columna dual está prohibida
+(REGLA CERO — sin dualidad uuid/id) y no debe volver a crearse. Se conserva
+registrada en el engine sólo para no alterar el ledger schema_migrations.
 """
-
 from __future__ import annotations
 
-import logging
 import sqlite3
 
-logger = logging.getLogger(__name__)
 
-MIGRATION_ID = "104"
-
-
-def _col_exists(conn: sqlite3.Connection, table: str, col: str) -> bool:
-    return any(r[1] == col for r in conn.execute(f"PRAGMA table_info({table})").fetchall())
-
-
-def _tbl_exists(conn: sqlite3.Connection, table: str) -> bool:
-    return bool(conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
-    ).fetchone())
-
-
-def _add_and_backfill(
-    conn: sqlite3.Connection,
-    table: str,
-    new_col: str,
-    src_col: str,
-    ref_table: str,
-    ref_src: str,
-    ref_dst: str,
-) -> None:
-    """Add new_col to table and backfill via a lookup join."""
-    if not _tbl_exists(conn, table):
-        logger.info("[%s] %s does not exist — skipping", MIGRATION_ID, table)
-        return
-
-    if not _col_exists(conn, table, new_col):
-        conn.execute(f"ALTER TABLE {table} ADD COLUMN {new_col} TEXT")
-        logger.info("[%s] added column %s.%s", MIGRATION_ID, table, new_col)
-
-    has_src_col = _col_exists(conn, table, src_col)
-    has_ref_uuid = _tbl_exists(conn, ref_table) and _col_exists(conn, ref_table, ref_dst)
-
-    if has_src_col and has_ref_uuid:
-        conn.execute(
-            f"""
-            UPDATE {table}
-            SET {new_col} = (
-                SELECT r.{ref_dst}
-                FROM {ref_table} r
-                WHERE r.{ref_src} = {table}.{src_col}
-            )
-            WHERE {new_col} IS NULL
-              AND {src_col} IS NOT NULL
-            """
-        )
-        updated = conn.execute("SELECT changes()").fetchone()[0]
-        logger.info("[%s] backfilled %d rows in %s.%s", MIGRATION_ID, updated, table, new_col)
-
-    conn.execute(
-        f"CREATE INDEX IF NOT EXISTS idx_{table}_{new_col} ON {table}({new_col})"
-    )
-
-
-def run(conn: sqlite3.Connection) -> None:
-    try:
-        # rol_permisos.rol_uuid ← roles.uuid via rol_id → roles.id
-        _add_and_backfill(
-            conn,
-            table="rol_permisos",
-            new_col="rol_uuid",
-            src_col="rol_id",
-            ref_table="roles",
-            ref_src="id",
-            ref_dst="uuid",
-        )
-
-        # cierre_mensual.sucursal_uuid ← sucursales.uuid via sucursal_id → sucursales.id
-        _add_and_backfill(
-            conn,
-            table="cierre_mensual",
-            new_col="sucursal_uuid",
-            src_col="sucursal_id",
-            ref_table="sucursales",
-            ref_src="id",
-            ref_dst="uuid",
-        )
-
-        conn.commit()
-        logger.info("[%s] migration complete", MIGRATION_ID)
-
-    except Exception:
-        conn.rollback()
-        logger.exception("[%s] migration FAILED — rolled back", MIGRATION_ID)
-        raise
+def run(conn: sqlite3.Connection) -> None:  # pragma: no cover - no-op documentado
+    return None

--- a/pos_spj_v13.4/migrations/standalone/105_movimientos_inventario.py
+++ b/pos_spj_v13.4/migrations/standalone/105_movimientos_inventario.py
@@ -81,7 +81,7 @@ def run(conn: sqlite3.Connection) -> None:
         # Table exists — ensure optional columns added by later migrations are present
         _add_col(conn, "movimientos_inventario", "lote_id",      "TEXT")
         _add_col(conn, "movimientos_inventario", "merma_motivo",  "TEXT")
-        _add_col(conn, "movimientos_inventario", "uuid",          "TEXT")
+        # (Plan B) movimientos_inventario.id ES el UUID; sin columna uuid dual.
         _add_col(conn, "movimientos_inventario", "referencia_id", "INTEGER")
         _add_col(conn, "movimientos_inventario", "operation_id",  "TEXT")
         logger.info("105: movimientos_inventario already exists — columns verified")

--- a/pos_spj_v13.4/migrations/standalone/107_productos_costo_column.py
+++ b/pos_spj_v13.4/migrations/standalone/107_productos_costo_column.py
@@ -45,7 +45,7 @@ def run(conn: sqlite3.Connection) -> None:
         _add_col(conn, "productos", "es_compuesto",    "INTEGER DEFAULT 0")
         _add_col(conn, "productos", "es_subproducto",  "INTEGER DEFAULT 0")
         _add_col(conn, "productos", "precio_minimo",   "REAL DEFAULT 0")
-        _add_col(conn, "productos", "uuid",            "TEXT")
+        # (Plan B) productos.id ES el UUID; sin columna uuid dual.
     else:
         logger.warning("107: productos table does not exist — skipping (run m000 first)")
 

--- a/pos_spj_v13.4/repositories/config_repository.py
+++ b/pos_spj_v13.4/repositories/config_repository.py
@@ -34,18 +34,12 @@ class ConfigRepository:
             return False
         return any(str(row[1]) == column_name for row in rows)
 
-    def _uuid_column(self, table_name: str) -> str | None:
-        return "uuid" if self._column_exists(table_name, "uuid") else None
+    def _uuid_column(self, table_name: str) -> str:
+        # Born-clean: id ES el UUID canónico; no existe columna uuid dual.
+        return "id"
 
     def _require_uuid_column(self, table_name: str) -> str:
-        uuid_column = self._uuid_column(table_name)
-        if not uuid_column:
-            logger.warning(
-                "%s: uuid column not found — falling back to integer id (run migrations 101-103)",
-                table_name,
-            )
-            return "id"
-        return uuid_column
+        return "id"
 
     def _require_uuidv7(self, value: str, field_name: str) -> str:
         normalized = str(value or "").strip().lower()
@@ -62,51 +56,40 @@ class ConfigRepository:
         qualified = f"{table_alias}.{uuid_column}" if table_alias else uuid_column
         return f"{qualified} AS {alias}"
 
-    def _row_id_from_uuid(self, table_name: str, entity_id: str | None) -> int | None:
+    def _row_id_from_uuid(self, table_name: str, entity_id: str | None) -> str | None:
+        """Born-clean: id ES el UUID; devuelve el id si la fila existe."""
         if not entity_id:
             return None
-        uuid_column = self._require_uuid_column(table_name)
-        row = self.db.execute(f"SELECT id FROM {table_name} WHERE {uuid_column}=?", (entity_id,)).fetchone()
-        return int(row[0]) if row else None
+        row = self.db.execute(f"SELECT id FROM {table_name} WHERE id=?", (entity_id,)).fetchone()
+        return str(row[0]) if row else None
 
-    def _to_int(self, value: object) -> int | None:
-        """Coacciona el rowid entero (identidad pre-cutover) para el puente
-        integer→uuid; None si el valor no es un entero válido."""
-        try:
-            return int(value)  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            return None
-
-    def _uuid_from_row_id(self, table_name: str, row_id: int | None) -> str | None:
+    def _uuid_from_row_id(self, table_name: str, row_id) -> str | None:
         if row_id is None:
             return None
-        uuid_column = self._require_uuid_column(table_name)
-        row = self.db.execute(f"SELECT {uuid_column} FROM {table_name} WHERE id=?", (row_id,)).fetchone()
-        return str(row[0]) if row and row[0] else None
+        row = self.db.execute(f"SELECT id FROM {table_name} WHERE id=?", (row_id,)).fetchone()
+        return str(row[0]) if row else None
 
     def _resolve_db_identifier(self, table_name: str, entity_id: str) -> tuple[str, object]:
         uuid_column = self._require_uuid_column(table_name)
         return uuid_column, self._require_uuidv7(entity_id, f"{table_name}.id")
 
-    def _resolve_branch_row(self, branch_id: str | None) -> tuple[int | None, str | None]:
+    def _resolve_branch_row(self, branch_id: str | None) -> tuple[str | None, str | None]:
         if not branch_id:
             return None, None
         branch_uuid = self._require_uuidv7(branch_id, "branch_id")
-        row_id = self._row_id_from_uuid("sucursales", branch_uuid)
-        if row_id is None:
+        if self._row_id_from_uuid("sucursales", branch_uuid) is None:
             raise ValueError("branch_id must reference an existing branch UUID")
-        return row_id, branch_uuid
+        return branch_uuid, branch_uuid
 
     def _resolve_role_row(self, role_id: str) -> tuple[int | None, str | None]:
         role_uuid = self._require_uuidv7(role_id, "role_id")
-        row_id = self._row_id_from_uuid("roles", role_uuid)
-        if row_id is None:
+        if self._row_id_from_uuid("roles", role_uuid) is None:
             raise ValueError("role_id must reference an existing role UUID")
-        return row_id, role_uuid
+        return role_uuid, role_uuid
 
     def _resolve_user_row(self, user_id: str) -> tuple[int | None, str | None]:
         user_uuid = self._require_uuidv7(user_id, "user_id")
-        row_id = self._row_id_from_uuid("usuarios", user_uuid)
+        row_id = self._row_id_from_uuid("usuarios", user_uuid)  # id == uuid
         if row_id is None:
             raise ValueError("user_id must reference an existing user UUID")
         return row_id, user_uuid
@@ -267,22 +250,17 @@ class ConfigRepository:
         active: bool,
         branch_id: str | None = None,
     ) -> str:
-        branch_row_id, branch_uuid = self._resolve_branch_row(branch_id)
+        _, branch_uuid = self._resolve_branch_row(branch_id)
         if branch_id is not None:
-            assignments = ["nombre=?", "direccion=?", "telefono=?", "activa=?"]
-            params: list[object] = [name, address, phone, 1 if active else 0]
-            assignments.insert(0, "uuid=?")
-            params.insert(0, branch_uuid)
-            params.append(branch_uuid)
-            self.db.execute(f"UPDATE sucursales SET {', '.join(assignments)} WHERE uuid=?", tuple(params))
+            self.db.execute(
+                "UPDATE sucursales SET nombre=?, direccion=?, telefono=?, activa=? WHERE id=?",
+                (name, address, phone, 1 if active else 0, branch_uuid),
+            )
             return str(branch_uuid)
 
         new_branch_uuid = new_uuid()
-        fields = ["nombre", "direccion", "telefono", "activa"]
-        values: list[object] = [name, address, phone, 1 if active else 0]
-        self._require_uuid_column("sucursales")
-        fields.insert(0, "uuid")
-        values.insert(0, new_branch_uuid)
+        fields = ["id", "nombre", "direccion", "telefono", "activa"]
+        values: list[object] = [new_branch_uuid, name, address, phone, 1 if active else 0]
         placeholders = ",".join("?" for _ in fields)
         self.db.execute(
             f"INSERT INTO sucursales ({','.join(fields)}) VALUES ({placeholders})",
@@ -316,30 +294,23 @@ class ConfigRepository:
         after_hours_message: str,
         branch_id: str | None = None,
     ) -> str:
-        branch_row_id, branch_uuid = self._resolve_branch_row(branch_id)
+        _, branch_uuid = self._resolve_branch_row(branch_id)
         if branch_id is not None:
-            params: list[object] = [
-                name,
-                address,
-                phone,
-                opening_time,
-                closing_time,
-                operation_days,
-                1 if accepts_after_hours_orders else 0,
-                after_hours_message,
-            ]
-            sql = """
+            self.db.execute(
+                """
                 UPDATE sucursales SET nombre=?, direccion=?, telefono=?,
                     hora_apertura=?, hora_cierre=?, dias_operacion=?,
                     acepta_pedidos_fuera_horario=?, mensaje_fuera_horario=?
-            """
-            sql += ", uuid=? WHERE uuid=?"
-            params.extend([branch_uuid, branch_uuid])
-            self.db.execute(sql, tuple(params))
+                WHERE id=?
+                """,
+                (name, address, phone, opening_time, closing_time, operation_days,
+                 1 if accepts_after_hours_orders else 0, after_hours_message, branch_uuid),
+            )
             return str(branch_uuid)
 
         new_branch_uuid = new_uuid()
         fields = [
+            "id",
             "nombre",
             "direccion",
             "telefono",
@@ -351,6 +322,7 @@ class ConfigRepository:
             "activa",
         ]
         values: list[object] = [
+            new_branch_uuid,
             name,
             address,
             phone,
@@ -361,9 +333,6 @@ class ConfigRepository:
             after_hours_message,
             1,
         ]
-        self._require_uuid_column("sucursales")
-        fields.insert(0, "uuid")
-        values.insert(0, new_branch_uuid)
         placeholders = ",".join("?" for _ in fields)
         self.db.execute(
             f"INSERT INTO sucursales ({','.join(fields)}) VALUES ({placeholders})",
@@ -391,32 +360,13 @@ class ConfigRepository:
         return {key: row[index] for index, key in enumerate(keys) if index < len(row)}
 
     def _hhr_select_parts(self) -> tuple[str, str, str]:
-        """Return (id_expr, branch_expr, join_sql) for happy_hour_rules queries.
-
-        All column references use table aliases to avoid ambiguous column name errors
-        when sucursales also has a uuid column.
-        """
-        has_hhr_uuid = self._column_exists("happy_hour_rules", "uuid")
-        has_sucursal_uuid = self._column_exists("happy_hour_rules", "sucursal_uuid")
-        has_s_uuid = self._column_exists("sucursales", "uuid")
-
-        id_expr = "h.uuid AS id" if has_hhr_uuid else "h.id AS id"
-
-        if has_sucursal_uuid and has_s_uuid:
-            branch_expr = "COALESCE(h.sucursal_uuid, s.uuid) AS sucursal_id"
-            join_sql = "LEFT JOIN sucursales AS s ON s.uuid = h.sucursal_uuid"
-        elif has_sucursal_uuid:
-            branch_expr = "h.sucursal_uuid AS sucursal_id"
-            join_sql = ""
-        else:
-            logger.warning(
-                "happy_hour_rules.sucursal_uuid not found — run migration 103; "
-                "sucursal_id will be integer"
-            )
-            branch_expr = "CAST(h.sucursal_id AS TEXT) AS sucursal_id"
-            join_sql = "LEFT JOIN sucursales AS s ON s.id = h.sucursal_id"
-
-        return id_expr, branch_expr, join_sql
+        """(id_expr, branch_expr, join_sql) para happy_hour_rules — born-clean:
+        h.id es la identidad y h.sucursal_id es el UUID de la sucursal."""
+        return (
+            "h.id AS id",
+            "h.sucursal_id AS sucursal_id",
+            "LEFT JOIN sucursales AS s ON s.id = h.sucursal_id",
+        )
 
     def list_happy_hour_rules(self) -> list[dict]:
         id_expr, branch_expr, join_sql = self._hhr_select_parts()
@@ -448,9 +398,15 @@ class ConfigRepository:
         return self._happy_hour_row_to_dict(row) if row else None
 
     def save_happy_hour_rule(self, rule: dict) -> str:
-        branch_row_id, branch_uuid = self._resolve_branch_row(str(rule.get("sucursal_id") or "").strip() or None)
+        _, branch_uuid = self._resolve_branch_row(str(rule.get("sucursal_id") or "").strip() or None)
         rule_uuid = str(rule.get("id") or "").strip() or new_uuid()
+        columns = [
+            "id", "nombre", "hora_inicio", "hora_fin", "dias_semana",
+            "tipo_descuento", "valor", "aplica_a", "aplica_valor",
+            "mensaje_wa", "activo", "sucursal_id",
+        ]
         values: list[object] = [
+            rule_uuid,
             rule["nombre"],
             rule["hora_inicio"],
             rule["hora_fin"],
@@ -461,24 +417,8 @@ class ConfigRepository:
             rule.get("aplica_valor") or "",
             rule.get("mensaje_wa") or "",
             1 if rule.get("activo") else 0,
+            branch_uuid,
         ]
-        has_sucursal_uuid_col = self._column_exists("happy_hour_rules", "sucursal_uuid")
-        if has_sucursal_uuid_col:
-            values.append(branch_uuid or "")
-        columns = [
-            "nombre", "hora_inicio", "hora_fin", "dias_semana",
-            "tipo_descuento", "valor", "aplica_a", "aplica_valor",
-            "mensaje_wa", "activo",
-        ]
-        if has_sucursal_uuid_col:
-            columns.append("sucursal_uuid")
-        elif self._column_exists("happy_hour_rules", "sucursal_id") and branch_row_id is not None:
-            columns.append("sucursal_id")
-            values.append(branch_row_id)
-        has_hhr_uuid = self._column_exists("happy_hour_rules", "uuid")
-        if has_hhr_uuid:
-            columns.insert(0, "uuid")
-            values.insert(0, rule_uuid)
 
         existing_column, existing_value = self._resolve_db_identifier("happy_hour_rules", rule_uuid)
         existing = None
@@ -534,18 +474,11 @@ class ConfigRepository:
         }
 
     def save_monthly_close(self, *, period: str, closed_by: str, totals: dict[str, float], branch_id: str) -> None:
-        branch_row_id, branch_uuid = self._resolve_branch_row(branch_id)
-        fields = ["periodo", "cerrado_por", "total_ventas", "total_compras", "total_merma"]
-        values: list[object] = [period, closed_by, totals["sales"], totals["purchases"], totals["waste"]]
-        if self._column_exists("cierre_mensual", "uuid"):
-            fields.insert(0, "uuid")
-            values.insert(0, new_uuid())
-        if self._column_exists("cierre_mensual", "sucursal_uuid"):
-            fields.append("sucursal_uuid")
-            values.append(branch_uuid or "")
-        elif self._column_exists("cierre_mensual", "sucursal_id") and branch_row_id is not None:
-            fields.append("sucursal_id")
-            values.append(branch_row_id)
+        _, branch_uuid = self._resolve_branch_row(branch_id)
+        fields = ["id", "periodo", "cerrado_por", "total_ventas", "total_compras",
+                  "total_merma", "sucursal_id"]
+        values: list[object] = [new_uuid(), period, closed_by, totals["sales"],
+                                totals["purchases"], totals["waste"], branch_uuid]
         placeholders = ",".join("?" for _ in fields)
         self.db.execute(
             f"INSERT INTO cierre_mensual ({','.join(fields)}) VALUES ({placeholders})",
@@ -583,34 +516,16 @@ class ConfigRepository:
         return [tuple(row) for row in rows]
 
     def list_users_v13(self) -> list[tuple]:
-        has_user_uuid = self._column_exists("usuarios", "uuid")
-        has_sucursal_uuid = (
-            self._column_exists("usuarios", "sucursal_uuid")
-            and self._column_exists("sucursales", "uuid")
-        )
-        user_id_expr = "u.uuid AS id" if has_user_uuid else "u.id AS id"
-        user_uuid_expr = "u.uuid AS usuario_uuid" if has_user_uuid else "NULL AS usuario_uuid"
-        branch_uuid_expr = (
-            "s.uuid AS sucursal_uuid_val"
-            if self._column_exists("sucursales", "uuid")
-            else "NULL AS sucursal_uuid_val"
-        )
-        if not has_sucursal_uuid:
-            logger.warning("usuarios.sucursal_uuid not found — run migration 102; using integer join")
-        branch_join = (
-            "LEFT JOIN sucursales s ON s.uuid = u.sucursal_uuid"
-            if has_sucursal_uuid
-            else "LEFT JOIN sucursales s ON s.id = u.sucursal_id"
-        )
+        # Born-clean: usuarios.id y sucursales.id son la identidad UUIDv7 única.
         return self.db.execute(
-            f"""
-            SELECT {user_id_expr}, u.usuario, u.nombre,
+            """
+            SELECT u.id AS id, u.usuario, u.nombre,
                    COALESCE(r.nombre,'cajero') AS rol,
                    COALESCE(s.nombre,'Principal') AS sucursal,
-                   u.activo, {user_uuid_expr}, {branch_uuid_expr}
+                   u.activo, u.id AS usuario_uuid, s.id AS sucursal_uuid_val
             FROM usuarios u
             LEFT JOIN roles r ON r.nombre = u.rol
-            {branch_join}
+            LEFT JOIN sucursales s ON s.id = u.sucursal_id
             ORDER BY u.nombre LIMIT 200
             """
         ).fetchall()
@@ -627,9 +542,7 @@ class ConfigRepository:
 
     def get_user_form_data(self, user_id: str) -> tuple | None:
         column, value = self._resolve_db_identifier("usuarios", user_id)
-        branch_column = (
-            "sucursal_uuid" if self._column_exists("usuarios", "sucursal_uuid") else "sucursal_id"
-        )
+        branch_column = "sucursal_id"  # born-clean: UUID de la sucursal
         return self.db.execute(
             f"SELECT usuario,nombre,email,rol,{branch_column},activo,empleado_id FROM usuarios WHERE {column}=?",
             (value,),
@@ -658,12 +571,6 @@ class ConfigRepository:
         """
         if entity_id is None or entity_id == "":
             return None
-        if self._column_exists(table, "uuid") and self._looks_like_uuid(entity_id):
-            row = self.db.execute(
-                f"SELECT {label_column} FROM {table} WHERE uuid=?", (str(entity_id),)
-            ).fetchone()
-            if row:
-                return str(row[0])
         row = self.db.execute(
             f"SELECT {label_column} FROM {table} WHERE id=?", (entity_id,)
         ).fetchone()
@@ -686,53 +593,37 @@ class ConfigRepository:
         employee_id: int | None,
         password_hash: str | None,
     ) -> str:
-        branch_row_id, branch_uuid = self._resolve_branch_row(branch_id)
-        has_user_uuid = self._column_exists("usuarios", "uuid")
-        has_sucursal_uuid = self._column_exists("usuarios", "sucursal_uuid")
+        # Born-clean: usuarios.id ES el UUID; sucursal_id es el UUID de la sucursal.
+        _, branch_uuid = self._resolve_branch_row(branch_id)
         persisted_user_id = user_id or new_uuid()
-        role_fields = ["usuario", "nombre", "email", "rol", "activo", "empleado_id"]
-        role_values: list[object] = [username, name, email, role, 1 if active else 0, employee_id]
-        if has_user_uuid:
-            role_fields.insert(0, "uuid")
-            role_values.insert(0, persisted_user_id)
-        else:
-            logger.warning("usuarios: uuid column not found — saving without uuid (run migrations 101-103)")
+        fields = ["usuario", "nombre", "email", "rol", "activo", "empleado_id", "sucursal_id"]
+        values: list[object] = [username, name, email, role, 1 if active else 0,
+                                employee_id, branch_uuid or ""]
         if password_hash is not None:
-            role_fields.append("password_hash")
-            role_values.append(password_hash)
-        if has_sucursal_uuid:
-            role_fields.append("sucursal_uuid")
-            role_values.append(branch_uuid or "")
-        else:
-            logger.warning("usuarios.sucursal_uuid not found — run migration 102; field skipped")
-            # Fall back to integer sucursal_id
-            if self._column_exists("usuarios", "sucursal_id") and branch_row_id is not None:
-                role_fields.append("sucursal_id")
-                role_values.append(branch_row_id)
+            fields.append("password_hash")
+            values.append(password_hash)
 
         existing = None
         if user_id:
-            column, value = self._resolve_db_identifier("usuarios", user_id)
-            existing = self.db.execute(f"SELECT id FROM usuarios WHERE {column}=?", (value,)).fetchone()
+            _, value = self._resolve_db_identifier("usuarios", user_id)
+            existing = self.db.execute("SELECT id FROM usuarios WHERE id=?", (value,)).fetchone()
         if existing:
-            assignments = ",".join(f"{field}=?" for field in role_fields)
-            where_col = "uuid" if has_user_uuid else "id"
-            update_id = persisted_user_id if has_user_uuid else existing[0]
-            params = list(role_values) + [update_id]
-            self.db.execute(f"UPDATE usuarios SET {assignments} WHERE {where_col}=?", tuple(params))
-            user_row_id = int(existing[0])
-        else:
-            placeholders = ",".join("?" for _ in role_fields)
-            cursor = self.db.execute(
-                f"INSERT INTO usuarios({','.join(role_fields)}) VALUES({placeholders})",
-                tuple(role_values),
+            assignments = ",".join(f"{field}=?" for field in fields)
+            self.db.execute(
+                f"UPDATE usuarios SET {assignments} WHERE id=?",
+                tuple(values) + (persisted_user_id,),
             )
-            # Born-clean: usuarios.id ES el UUID persistido; sin fallback rowid.
-            user_row_id = persisted_user_id
-        if employee_id and user_row_id is not None:
-            self.db.execute("UPDATE personal SET usuario_id=? WHERE id=?", (user_row_id, employee_id))
-        if not has_user_uuid and user_row_id is not None:
-            return str(user_row_id)
+        else:
+            fields.insert(0, "id")
+            values.insert(0, persisted_user_id)
+            placeholders = ",".join("?" for _ in fields)
+            self.db.execute(
+                f"INSERT INTO usuarios({','.join(fields)}) VALUES({placeholders})",
+                tuple(values),
+            )
+        if employee_id:
+            self.db.execute("UPDATE personal SET usuario_id=? WHERE id=?",
+                            (persisted_user_id, employee_id))
         return persisted_user_id
 
     def set_user_active(self, user_id: str, active: bool) -> None:
@@ -761,19 +652,13 @@ class ConfigRepository:
         if not row:
             logger.warning("Role not found while resolving permissions: %s", role_name)
             return set()
-        role_row_id = self._to_int(row[0])
-        # Ruta UUID canónica cuando la columna existe; en esquema entero pre-cutover
-        # (sin columna uuid en roles) se resuelve por rol_id entero directamente.
-        if self._column_exists("roles", "uuid"):
-            role_uuid = self._uuid_from_row_id("roles", role_row_id)
-            if role_uuid:
-                return self.permission_codes_for_role_id(role_uuid)
-        return self._role_permissions_by_row_id(role_row_id)
+        # Born-clean: roles.id ES el UUID y rol_permisos referencia rol_id (UUID).
+        return self._role_permissions_by_row_id(str(row[0]))
 
-    def _role_permissions_by_row_id(self, role_row_id: int | None) -> set[str]:
-        """Resuelve permisos por rol_id entero (esquema pre-cutover sin rol_uuid)."""
-        if role_row_id is None or not self._column_exists("rol_permisos", "rol_id"):
-            logger.warning("rol_permisos: no usable integer identity — returning empty")
+    def _role_permissions_by_row_id(self, role_row_id: str | None) -> set[str]:
+        """Resuelve permisos por rol_id (UUID de roles.id)."""
+        if not role_row_id:
+            logger.warning("rol_permisos: rol sin identidad — returning empty")
             return set()
         rows = self.db.execute(
             "SELECT modulo, accion FROM rol_permisos WHERE rol_id=? AND permitido=1",
@@ -782,14 +667,8 @@ class ConfigRepository:
         return {normalize_permission(f"{row[0]}.{row[1]}") for row in rows}
 
     def permission_codes_for_role_id(self, role_id: str) -> set[str]:
-        role_row_id, role_uuid = self._resolve_role_row(role_id)
-        if self._column_exists("rol_permisos", "rol_uuid") and role_uuid:
-            rows = self.db.execute(
-                "SELECT modulo, accion FROM rol_permisos WHERE rol_uuid=? AND permitido=1",
-                (role_uuid,),
-            ).fetchall()
-            return {normalize_permission(f"{row[0]}.{row[1]}") for row in rows}
-        return self._role_permissions_by_row_id(role_row_id)
+        role_uuid, _ = self._resolve_role_row(role_id)
+        return self._role_permissions_by_row_id(role_uuid)
 
     def permission_codes_for_user(self, user_id: str, branch_id: str | None = None) -> set[str]:
         # usuarios.id es la identidad canónica del usuario (entero pre-cutover,
@@ -863,37 +742,19 @@ class ConfigRepository:
         return self._resolve_label("roles", "nombre", role_id)
 
     def role_permissions(self, role_id: str) -> dict[tuple[str, str], bool]:
-        role_row_id, role_uuid = self._resolve_role_row(role_id)
-        if self._column_exists("rol_permisos", "rol_uuid") and role_uuid:
-            rows = self.db.execute(
-                "SELECT modulo, accion, permitido FROM rol_permisos WHERE rol_uuid=?",
-                (role_uuid,),
-            ).fetchall()
-        elif role_row_id is not None and self._column_exists("rol_permisos", "rol_id"):
-            rows = self.db.execute(
-                "SELECT modulo, accion, permitido FROM rol_permisos WHERE rol_id=?",
-                (role_row_id,),
-            ).fetchall()
-        else:
-            logger.warning("rol_permisos: no usable identity column found — run migrations; returning empty")
-            return {}
+        role_uuid, _ = self._resolve_role_row(role_id)
+        rows = self.db.execute(
+            "SELECT modulo, accion, permitido FROM rol_permisos WHERE rol_id=?",
+            (role_uuid,),
+        ).fetchall()
         return {(row[0], row[1]): bool(row[2]) for row in rows}
 
     def save_role_permissions(self, role_id: str, permissions: dict[tuple[str, str], bool]) -> None:
-        role_row_id, role_uuid = self._resolve_role_row(role_id)
-        if self._column_exists("rol_permisos", "rol_uuid") and role_uuid:
-            self.db.execute("DELETE FROM rol_permisos WHERE rol_uuid=?", (role_uuid,))
-            insert_sql = "INSERT INTO rol_permisos(rol_uuid,modulo,accion,permitido) VALUES(?,?,?,?)"
-            for (module, action), allowed in permissions.items():
-                self.db.execute(insert_sql, (role_uuid, module, action, 1 if allowed else 0))
-        elif role_row_id is not None and self._column_exists("rol_permisos", "rol_id"):
-            self.db.execute("DELETE FROM rol_permisos WHERE rol_id=?", (role_row_id,))
-            insert_sql = "INSERT INTO rol_permisos(rol_id,modulo,accion,permitido) VALUES(?,?,?,?)"
-            for (module, action), allowed in permissions.items():
-                self.db.execute(insert_sql, (role_row_id, module, action, 1 if allowed else 0))
-        else:
-            logger.warning("rol_permisos: no usable identity column found — run migrations; permissions not saved")
-            return
+        role_uuid, _ = self._resolve_role_row(role_id)
+        self.db.execute("DELETE FROM rol_permisos WHERE rol_id=?", (role_uuid,))
+        insert_sql = "INSERT INTO rol_permisos(id,rol_id,modulo,accion,permitido) VALUES(?,?,?,?,?)"
+        for (module, action), allowed in permissions.items():
+            self.db.execute(insert_sql, (new_uuid(), role_uuid, module, action, 1 if allowed else 0))
 
     def audit_log_rows(self, limit: int = 200) -> list[tuple]:
         return self.db.execute(
@@ -903,23 +764,14 @@ class ConfigRepository:
 
     def save_role(self, *, role_id: str | None, name: str, description: str) -> str:
         persisted_role_id = role_id or new_uuid()
-        role_fields = ["nombre", "descripcion"]
-        role_values: list[object] = [name, description]
-        self._require_uuid_column("roles")
-        role_fields.insert(0, "uuid")
-        role_values.insert(0, persisted_role_id)
         existing = None
         if role_id:
-            column, value = self._resolve_db_identifier("roles", role_id)
-            existing = self.db.execute(f"SELECT id FROM roles WHERE {column}=?", (value,)).fetchone()
+            _, value = self._resolve_db_identifier("roles", role_id)
+            existing = self.db.execute("SELECT id FROM roles WHERE id=?", (value,)).fetchone()
         if existing:
-            assignments = ",".join(f"{field}=?" for field in role_fields)
-            params = list(role_values) + [persisted_role_id]
-            self.db.execute(f"UPDATE roles SET {assignments} WHERE uuid=?", tuple(params))
+            self.db.execute("UPDATE roles SET nombre=?, descripcion=? WHERE id=?",
+                            (name, description, persisted_role_id))
         else:
-            placeholders = ",".join("?" for _ in role_fields)
-            self.db.execute(
-                f"INSERT INTO roles({','.join(role_fields)}) VALUES({placeholders})",
-                tuple(role_values),
-            )
+            self.db.execute("INSERT INTO roles(id, nombre, descripcion) VALUES(?,?,?)",
+                            (persisted_role_id, name, description))
         return persisted_role_id

--- a/pos_spj_v13.4/tests/architecture/test_configuracion_guardrails.py
+++ b/pos_spj_v13.4/tests/architecture/test_configuracion_guardrails.py
@@ -136,18 +136,20 @@ BASELINE: dict[str, dict[str, int]] = {
         # FASE 2 added tolerant label resolvers (username_for_id/role_name_for_id
         # via _resolve_label) so events carry names, not integer ids: +1 select,
         # +1 execute vs the FASE 0 baseline.
-        "sql_select": 43,
-        "sql_insert": 11,
+        # Plan B: reescritura born-clean del repo eliminó todo el SQL dual
+        # uuid/id (ratchet DOWN: select 43→40, insert 11→10, delete 2→1,
+        # execute 65→60, cast_as_text 1→0).
+        "sql_select": 40,
+        "sql_insert": 10,
         "sql_update": 11,
-        "sql_delete": 2,
+        "sql_delete": 1,
         # FASE 3 removed _commit() (and its except: pass) — the repository no
         # longer commits/rolls back; services own the UnitOfWork boundary.
-        "cursor_execute": 65,
+        "cursor_execute": 60,
         # Plan B: el fallback rowid del alta de usuarios fue eliminado (lastrowid 1->0).
         # CONFIGURACION permisos slice: permission_codes_for_user dropped the
         # int(user_id) cast and the "Accept legacy integer IDs" comment
         # (int_id_cast 1->0, legacy_lower 1->0).
-        "cast_as_text": 1,    # CAST(h.sucursal_id AS TEXT) pre-103 fallback
         "principal_fallback": 1,
     },
     "core/repositories/hardware_config_repository.py": {


### PR DESCRIPTION
…e la identidad dual

Corrige los 3 bugs reportados en Configuración:
1) Nueva sucursal invisible hasta reiniciar: el INSERT escribía la columna dual
   `uuid` y NO `id` → fila con id NULL, invisible para los lectores por id.
2) Editar sucursal pre-existente → int() base 10: _row_id_from_uuid hacía
   int(row[0]) sobre el UUID.
3) Nueva sucursal ausente en selectores: misma fila id-NULL.

Causa raíz doble:
a) Las migraciones 101/102/103/104 (y restos en 047/067/096/105/107) RE-AÑADÍAN
   las columnas duales uuid/sucursal_uuid/rol_uuid en BDs nuevas (escaparon del
   barrido F3 porque no crean PK enteras). Todas convertidas a no-op documentado
   o limpiadas: una BD nueva tiene CERO columnas duales (verificado tabla por
   tabla), cero PK enteras y foreign_key_check OK.
b) ConfigRepository seguía operando en modo dual. Reescritura born-clean total
   (130 menciones uuid → 0 residuo funcional):
   - Helpers: identidad única id (passthrough validado UUIDv7, sin int()); _to_int eliminado.
   - save_branch / save_branch_delivery_profile: INSERT con id=new_uuid(); UPDATE WHERE id (sin tocar uuid).
   - save_user_v13: INSERT/UPDATE con id y sucursal_id=UUID (antes insertaba SIN id → usuarios fantasma); vincula personal por UUID.
   - save_role / save_role_permissions / role_permissions / permission_codes_*: rol_permisos por rol_id UUID con id propio acuñado; sin ramas rol_uuid.
   - save_happy_hour_rule / _hhr_select_parts / save_monthly_close / list_users_v13 / _resolve_label / get_user_*: directos por id/sucursal_id.

Smoke integral sobre BD born-clean: crear sucursal → visible INMEDIATAMENTE con id real · editar la pre-existente (UUID instalación) sin int() · selectores (repo + ModuleSettingsQueryService) muestran la nueva · alta de usuario con id y branch UUID · roles+permisos round-trip. Guardrails 41/41 + config/permission tests verdes (snapshot CONFIGURACION ratchet DOWN: select 43→40, insert 11→10, delete 2→1, execute 65→60, cast_as_text→0). compileall limpio.


Claude-Session: https://claude.ai/code/session_01FjvtLMufyoqmwefhCoNGnf